### PR TITLE
feat: add homepage and /api/health endpoint

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,4 @@
+import { NextResponse } from 'next/server';
+export async function GET() {
+  return NextResponse.json({ ok: true, ts: Date.now() });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,13 @@
+export default function Home() {
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'ui-sans-serif, system-ui' }}>
+      <h1>ToolTime Pro</h1>
+      <p>Welcome! Deployed on Netlify with Next.js.</p>
+      <ul style={{ marginTop: 16, lineHeight: 1.8 }}>
+        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/dashboard">Dashboard</a></li>
+        <li><a href="/dashboard/shield/calculator">Shield Calculator</a></li>
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple homepage with links
- add `/api/health` endpoint returning JSON

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c3dcab3bc8326a7922aaeaaa57db8