### PR TITLE
Use Next.js Link in homepage navigation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function Page() {
+  return (
+    <main className="space-y-4">
+      <Link href="/dashboard">Dashboard</Link>
+      <Link href="/auth">Sign in</Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Add homepage with Next.js `Link` for internal navigation

## Testing
- `npm test`
- `npm run lint` *(fails: Failed to install required TypeScript dependencies, please install them manually to continue: yarn add --exact --cwd /workspace/ToolTimePro-Ai --dev @types/react)*

------
https://chatgpt.com/codex/tasks/task_e_689d1fa035a88326b1cd120c97c0bc35