### PR TITLE
Add SMS consent flow for 2FA verification messages

### DIFF
--- a/src/app/api/auth/2fa/send-code/route.ts
+++ b/src/app/api/auth/2fa/send-code/route.ts
@@ -65,12 +65,13 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Failed to generate code' }, { status: 500 })
     }
 
-    // Send SMS via Twilio directly (bypass customer consent checks)
+    // Send SMS via Twilio (2FA verification - user consented during setup)
     const accountSid = process.env.TWILIO_ACCOUNT_SID
     const authToken2 = process.env.TWILIO_AUTH_TOKEN
     const fromNumber = process.env.TWILIO_PHONE_NUMBER
+    const messagingServiceSid = process.env.TWILIO_2FA_MESSAGING_SERVICE_SID
 
-    if (!accountSid || !authToken2 || !fromNumber) {
+    if (!accountSid || !authToken2 || (!fromNumber && !messagingServiceSid)) {
       return NextResponse.json({ error: 'SMS service not configured' }, { status: 500 })
     }
 
@@ -83,11 +84,22 @@ export async function POST(request: Request) {
       digits.length === 11 && digits.startsWith('1') ? `+${digits}` :
       userData.two_fa_phone.startsWith('+') ? userData.two_fa_phone : `+${digits}`
 
-    await twilioClient.messages.create({
-      body: `Your ToolTime Pro verification code is: ${code}. It expires in 10 minutes.`,
-      to: toPhone,
-      from: fromNumber,
-    })
+    const smsBody = `Your ToolTime Pro verification code is: ${code}. It expires in 10 minutes. Reply STOP to opt out, HELP for help. Msg&Data rates may apply.`
+
+    // Prefer messaging service SID (linked to 2FA A2P campaign) over raw phone number
+    if (messagingServiceSid) {
+      await twilioClient.messages.create({
+        body: smsBody,
+        to: toPhone,
+        messagingServiceSid,
+      })
+    } else {
+      await twilioClient.messages.create({
+        body: smsBody,
+        to: toPhone,
+        from: fromNumber!,
+      })
+    }
 
     // Return masked phone for UI
     const phoneLast4 = userData.two_fa_phone.slice(-4)

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -688,6 +688,7 @@ function TwoFactorCard() {
   const [phone, setPhone] = useState('')
   const [editPhone, setEditPhone] = useState('')
   const [showSetup, setShowSetup] = useState(false)
+  const [smsConsent, setSmsConsent] = useState(false)
   const [saving, setSaving] = useState(false)
   const [disabling, setDisabling] = useState(false)
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
@@ -723,6 +724,11 @@ function TwoFactorCard() {
     const digits = editPhone.replace(/\D/g, '')
     if (digits.length < 10) {
       setMessage({ type: 'error', text: 'Please enter a valid 10-digit phone number.' })
+      return
+    }
+
+    if (!smsConsent) {
+      setMessage({ type: 'error', text: 'You must agree to receive SMS verification codes to enable 2FA.' })
       return
     }
 
@@ -849,6 +855,24 @@ function TwoFactorCard() {
               required
             />
             <p className="text-xs text-gray-500 mt-1">We&apos;ll send a 6-digit code to this number when you log in from an unrecognized device.</p>
+          </div>
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={smsConsent}
+                onChange={(e) => setSmsConsent(e.target.checked)}
+                className="mt-1 w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 cursor-pointer"
+              />
+              <span className="text-sm text-gray-700">
+                I agree to receive SMS text messages containing verification codes for two-factor authentication at the phone number provided above.
+                Msg &amp; data rates may apply. Frequency varies based on login activity. Reply <strong>STOP</strong> to opt out or <strong>HELP</strong> for help at any time.
+                View our{' '}
+                <a href="/sms" target="_blank" className="text-blue-600 underline">SMS Terms</a>
+                {' '}and{' '}
+                <a href="/privacy" target="_blank" className="text-blue-600 underline">Privacy Policy</a>.
+              </span>
+            </label>
           </div>
           <div className="flex gap-3">
             <button

--- a/src/app/sms/page.tsx
+++ b/src/app/sms/page.tsx
@@ -90,6 +90,43 @@ export default function SmsPage() {
           </section>
 
           <section>
+            <h2 className="text-xl font-bold mb-3">Two-Factor Authentication (2FA) SMS</h2>
+            <p className="mb-4">
+              If you enable two-factor authentication (2FA) in your ToolTime Pro account settings,
+              you will receive SMS messages containing one-time verification codes when logging in
+              from unrecognized devices. By enabling 2FA and providing your phone number, you
+              explicitly consent to receive these security-related text messages.
+            </p>
+
+            {/* Visual representation of the 2FA opt-in CTA */}
+            <div className="border-2 border-dashed border-[#f5a623] rounded-xl p-6 bg-[#fef3d6]/50">
+              <p className="text-sm font-bold text-[#5c5c70] mb-3 uppercase tracking-wide">2FA Opt-In Example (shown in Account Settings)</p>
+              <div className="bg-[#fef3d6] rounded-xl p-4">
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked
+                    readOnly
+                    className="mt-1 w-5 h-5 rounded border-gray-300 text-[#f5a623] focus:ring-[#f5a623] cursor-pointer"
+                  />
+                  <span className="text-sm text-[#1a1a2e]">
+                    I agree to receive SMS text messages containing verification codes for
+                    two-factor authentication at the phone number provided above.
+                    Msg &amp; data rates may apply. Frequency varies based on login activity.
+                    Reply <strong>STOP</strong> to opt out or <strong>HELP</strong> for help at any time.
+                  </span>
+                </label>
+              </div>
+            </div>
+
+            <p className="mt-4">
+              2FA messages contain only a one-time verification code and standard compliance
+              language. You can disable 2FA at any time from your account settings to stop
+              receiving these messages.
+            </p>
+          </section>
+
+          <section>
             <h2 className="text-xl font-bold mb-3">{t('messageFrequency')}</h2>
             <p>
               Message frequency varies based on your service activity. You will typically receive


### PR DESCRIPTION
## Summary
This PR implements an explicit SMS consent mechanism for two-factor authentication (2FA) messages in ToolTime Pro. Users must now actively agree to receive SMS verification codes before enabling 2FA, ensuring compliance with messaging regulations and improving transparency around SMS usage.

## Key Changes

- **SMS Terms Page Enhancement** (`src/app/sms/page.tsx`)
  - Added new "Two-Factor Authentication (2FA) SMS" section explaining 2FA SMS messages
  - Included visual example of the 2FA opt-in checkbox as it appears in account settings
  - Documented message content, opt-out instructions (STOP/HELP), and user control options

- **2FA Setup Consent Requirement** (`src/app/dashboard/settings/page.tsx`)
  - Added `smsConsent` state to track user agreement
  - Implemented consent checkbox in the 2FA setup form with compliance language
  - Added validation to prevent 2FA enablement without explicit consent
  - Included links to SMS Terms and Privacy Policy for user reference
  - Styled consent box with blue background for visual prominence

- **SMS Sending Improvements** (`src/app/api/auth/2fa/send-code/route.ts`)
  - Updated comment to clarify that SMS is sent for consented 2FA users (not bypassing checks)
  - Added support for Twilio Messaging Service SID (preferred for A2P 2FA campaigns)
  - Enhanced SMS body with compliance language (STOP/HELP instructions, rates disclaimer)
  - Implemented fallback logic: uses Messaging Service SID if available, otherwise uses phone number
  - Improved configuration validation to support both messaging methods

## Implementation Details

- The consent checkbox is required before 2FA can be enabled, with clear error messaging if skipped
- SMS messages now include standard compliance language about message rates and opt-out instructions
- The implementation supports both traditional Twilio phone numbers and dedicated Messaging Service SIDs for better 2FA deliverability
- User-facing documentation on the SMS Terms page mirrors the consent language shown during setup

https://claude.ai/code/session_01D2fmG9S2NwGHgm9tgddagX