### PR TITLE
Add fallback Crisp website ID to prevent initialization failures

### DIFF
--- a/src/components/help/CrispChat.tsx
+++ b/src/components/help/CrispChat.tsx
@@ -29,7 +29,7 @@ export default function CrispChat() {
   const { user, dbUser, company } = useAuth();
 
   useEffect(() => {
-    const websiteId = process.env.NEXT_PUBLIC_CRISP_WEBSITE_ID;
+    const websiteId = process.env.NEXT_PUBLIC_CRISP_WEBSITE_ID || '6baf2f53-e868-4a02-a9c7-eef3e5549db6';
     if (!websiteId) return;
 
     // Initialize Crisp


### PR DESCRIPTION
## Summary
Added a fallback Crisp website ID to ensure the chat widget initializes even when the environment variable is not set.

## Key Changes
- Modified `CrispChat.tsx` to provide a default website ID (`6baf2f53-e868-4a02-a9c7-eef3e5549db6`) when `NEXT_PUBLIC_CRISP_WEBSITE_ID` environment variable is undefined
- This prevents the Crisp chat initialization from silently failing due to missing environment configuration

## Implementation Details
- Used the nullish coalescing operator (`||`) to supply the fallback ID
- The existing null check (`if (!websiteId) return;`) remains in place as a safety guard
- This ensures the chat widget has a valid configuration in development or when the environment variable is not explicitly set

https://claude.ai/code/session_01VPkeqJqPDk12YDVH64LxQG