### PR TITLE
Add online booking setup to getting started checklist

### DIFF
--- a/src/components/dashboard/GettingStartedChecklist.tsx
+++ b/src/components/dashboard/GettingStartedChecklist.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
-import { CheckCircle2, Circle, Globe, Users, Briefcase, X, ChevronDown, ChevronUp } from 'lucide-react'
+import { CheckCircle2, Circle, Globe, Users, Briefcase, CalendarCheck, X, ChevronDown, ChevronUp } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { supabase } from '@/lib/supabase'
 
@@ -23,6 +23,7 @@ export default function GettingStartedChecklist() {
   const [hasJobs, setHasJobs] = useState(false)
   const [hasWebsite, setHasWebsite] = useState(false)
   const [hasTeam, setHasTeam] = useState(false)
+  const [hasBooking, setHasBooking] = useState(false)
   const [loaded, setLoaded] = useState(false)
 
   useEffect(() => {
@@ -38,7 +39,7 @@ export default function GettingStartedChecklist() {
     const checkProgress = async () => {
       const companyId = dbUser.company_id
 
-      const [customersRes, jobsRes, teamRes, websiteRes] = await Promise.all([
+      const [customersRes, jobsRes, teamRes, websiteRes, servicesRes] = await Promise.all([
         supabase
           .from('customers')
           .select('id', { count: 'exact', head: true })
@@ -56,12 +57,18 @@ export default function GettingStartedChecklist() {
           .select('id', { count: 'exact', head: true })
           .eq('company_id', companyId)
           .eq('status', 'live'),
+        supabase
+          .from('services')
+          .select('id', { count: 'exact', head: true })
+          .eq('company_id', companyId)
+          .eq('is_active', true),
       ])
 
       setHasCustomers((customersRes.count ?? 0) > 0)
       setHasJobs((jobsRes.count ?? 0) > 0)
       setHasTeam((teamRes.count ?? 0) > 1) // More than the owner
       setHasWebsite(!!company?.website || (websiteRes.count ?? 0) > 0)
+      setHasBooking((servicesRes.count ?? 0) > 0)
       setLoaded(true)
     }
 
@@ -78,6 +85,14 @@ export default function GettingStartedChecklist() {
       href: '/dashboard/website-builder',
       completed: hasWebsite,
       icon: <Globe size={18} />,
+    },
+    {
+      id: 'booking',
+      label: 'Set up online booking',
+      description: 'Add services so customers can book appointments online',
+      href: '/dashboard/services',
+      completed: hasBooking,
+      icon: <CalendarCheck size={18} />,
     },
     {
       id: 'customer',

--- a/src/components/help/HelpButton.tsx
+++ b/src/components/help/HelpButton.tsx
@@ -19,21 +19,70 @@ import {
   HelpCircle as FAQIcon,
   Wrench,
   CalendarCheck,
+  ClipboardList,
+  UserCircle,
+  Brain,
+  Globe,
+  Clock,
+  BarChart3,
+  CreditCard,
+  Settings,
+  Contact,
 } from 'lucide-react';
 
 const WIKI_BASE = 'https://github.com/Missmv09/ToolTimePro-Ai/wiki';
 
-const helpLinks = [
-  { label: 'Getting Started', href: `${WIKI_BASE}/Getting-Started`, icon: BookOpen },
-  { label: 'Adding Services', href: `${WIKI_BASE}/Adding-Services`, icon: Wrench },
-  { label: 'Pricing & Plans', href: `${WIKI_BASE}/Pricing-and-Plans`, icon: FileText },
-  { label: 'Quotes & Estimates', href: `${WIKI_BASE}/Quotes-and-Estimates`, icon: CalendarCheck },
-  { label: 'Team Management', href: `${WIKI_BASE}/Team-Management`, icon: Users },
-  { label: 'Mobile & Worker App', href: `${WIKI_BASE}/Mobile-and-Worker-App`, icon: Smartphone },
-  { label: 'Invoicing & Payments', href: `${WIKI_BASE}/Invoicing-and-Payments`, icon: Receipt },
-  { label: 'ToolTime Shield', href: `${WIKI_BASE}/ToolTime-Shield`, icon: Shield },
-  { label: 'Troubleshooting', href: `${WIKI_BASE}/Troubleshooting`, icon: AlertCircle },
-  { label: 'FAQ', href: `${WIKI_BASE}/FAQ`, icon: FAQIcon },
+interface HelpSection {
+  heading: string;
+  links: { label: string; href: string; icon: typeof HelpCircle }[];
+}
+
+const helpSections: HelpSection[] = [
+  {
+    heading: 'Getting Started',
+    links: [
+      { label: 'Getting Started', href: `${WIKI_BASE}/Getting-Started`, icon: BookOpen },
+      { label: 'Pricing & Plans', href: `${WIKI_BASE}/Pricing-and-Plans`, icon: FileText },
+    ],
+  },
+  {
+    heading: 'Core Features',
+    links: [
+      { label: 'Jobs & Scheduling', href: `${WIKI_BASE}/Jobs-and-Scheduling`, icon: ClipboardList },
+      { label: 'Online Booking', href: `${WIKI_BASE}/Online-Booking`, icon: CalendarCheck },
+      { label: 'Customers & Leads', href: `${WIKI_BASE}/Customers-and-Leads`, icon: UserCircle },
+      { label: 'Quotes & Estimates', href: `${WIKI_BASE}/Quotes-and-Estimates`, icon: CalendarCheck },
+      { label: 'Invoicing & Payments', href: `${WIKI_BASE}/Invoicing-and-Payments`, icon: Receipt },
+      { label: 'Payment Plans', href: `${WIKI_BASE}/Payment-Plans-Guide`, icon: CreditCard },
+      { label: 'Time Tracking', href: `${WIKI_BASE}/Time-Tracking`, icon: Clock },
+    ],
+  },
+  {
+    heading: 'AI & Website',
+    links: [
+      { label: 'Jenny AI', href: `${WIKI_BASE}/Jenny-AI`, icon: Brain },
+      { label: 'Website & Blog', href: `${WIKI_BASE}/Website-and-Blog`, icon: Globe },
+      { label: 'Customer Portal Pro', href: `${WIKI_BASE}/Customer-Portal`, icon: Contact },
+    ],
+  },
+  {
+    heading: 'Team & Compliance',
+    links: [
+      { label: 'Adding Services', href: `${WIKI_BASE}/Adding-Services`, icon: Wrench },
+      { label: 'Team Management', href: `${WIKI_BASE}/Team-Management`, icon: Users },
+      { label: 'Mobile & Worker App', href: `${WIKI_BASE}/Mobile-and-Worker-App`, icon: Smartphone },
+      { label: 'ToolTime Shield', href: `${WIKI_BASE}/ToolTime-Shield`, icon: Shield },
+      { label: 'Reports & Analytics', href: `${WIKI_BASE}/Reports-and-Analytics`, icon: BarChart3 },
+    ],
+  },
+  {
+    heading: 'Settings & Support',
+    links: [
+      { label: 'Settings & Integrations', href: `${WIKI_BASE}/Settings-and-Integrations`, icon: Settings },
+      { label: 'Troubleshooting', href: `${WIKI_BASE}/Troubleshooting`, icon: AlertCircle },
+      { label: 'FAQ', href: `${WIKI_BASE}/FAQ`, icon: FAQIcon },
+    ],
+  },
 ];
 
 export default function HelpButton() {
@@ -106,23 +155,27 @@ export default function HelpButton() {
           </div>
 
           {/* Help articles */}
-          <div className="max-h-[300px] overflow-y-auto">
-            <div className="px-4 py-2">
-              <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">Help Center</p>
-            </div>
-            {helpLinks.map((link) => (
-              <a
-                key={link.href}
-                href={link.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => setIsOpen(false)}
-                className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors group"
-              >
-                <link.icon size={16} className="text-gray-400 group-hover:text-gold-500 flex-shrink-0" />
-                <span className="text-sm text-gray-700 group-hover:text-navy-500 flex-1">{link.label}</span>
-                <ExternalLink size={12} className="text-gray-300 group-hover:text-gray-400 flex-shrink-0" />
-              </a>
+          <div className="max-h-[400px] overflow-y-auto">
+            {helpSections.map((section) => (
+              <div key={section.heading}>
+                <div className="px-4 py-2">
+                  <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">{section.heading}</p>
+                </div>
+                {section.links.map((link) => (
+                  <a
+                    key={link.href}
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => setIsOpen(false)}
+                    className="flex items-center gap-3 px-4 py-2 hover:bg-gray-50 transition-colors group"
+                  >
+                    <link.icon size={16} className="text-gray-400 group-hover:text-gold-500 flex-shrink-0" />
+                    <span className="text-sm text-gray-700 group-hover:text-navy-500 flex-1">{link.label}</span>
+                    <ExternalLink size={12} className="text-gray-300 group-hover:text-gray-400 flex-shrink-0" />
+                  </a>
+                ))}
+              </div>
             ))}
           </div>
 

--- a/wiki/Customer-Portal.md
+++ b/wiki/Customer-Portal.md
@@ -1,0 +1,101 @@
+# Customer Portal Pro
+
+Give your customers a branded self-service portal where they can track jobs, view photos, message your team, and access their service history — all without calling you.
+
+---
+
+## Overview
+
+Customer Portal Pro is a premium add-on that creates a professional customer-facing portal for your business. It's included free with **Elite plans** or available as an add-on for **$24/month**.
+
+---
+
+## Features
+
+### Live Job Tracker
+
+Customers can see the real-time status of their jobs:
+- **Scheduled** — Job is booked, showing date and time
+- **En Route** — Worker is on the way
+- **In Progress** — Work has started
+- **Completed** — Job is done
+
+No more "when is the technician coming?" phone calls.
+
+### Before & After Photos
+
+- Workers upload photos during the job from their mobile app
+- Customers see before and after photos in their portal
+- Great for showcasing quality work (landscaping, painting, cleaning, etc.)
+- Builds trust and justifies pricing
+
+### Messaging
+
+- Customers can send messages to your team through the portal
+- No need to call or text — everything is in one place
+- Message history is preserved for reference
+
+### Document Vault
+
+- Store and share documents with customers:
+  - Quotes and estimates
+  - Invoices and receipts
+  - Warranties and guarantees
+  - Contracts and agreements
+- Customers can download documents anytime
+
+### Service History
+
+- Complete history of all jobs performed for the customer
+- Dates, services, pricing, and worker assignments
+- Helps customers remember what was done and when
+- Useful for recurring maintenance tracking
+
+---
+
+## How It Works
+
+1. **Customer receives an invite** — After their first job, they get an email or text with a link to their portal
+2. **Customer logs in** — Simple login with email or phone verification
+3. **Customer sees their dashboard** — Jobs, photos, messages, documents, and history all in one place
+
+---
+
+## Setup
+
+Customer Portal Pro activates automatically when you:
+
+1. Subscribe to the **Elite plan** (included), or
+2. Add the **Customer Portal Pro add-on** ($24/mo) from Settings → Billing
+
+Once active, your customers will receive portal access automatically after their first job.
+
+---
+
+## Why Offer a Customer Portal?
+
+| Benefit | Impact |
+|---------|--------|
+| **Fewer phone calls** | Customers check status themselves |
+| **Professional image** | Branded portal builds trust |
+| **Better reviews** | Before/after photos wow customers |
+| **Repeat business** | Service history reminds customers to rebook |
+| **Document access** | Customers find their own invoices and receipts |
+
+---
+
+## Pricing
+
+| Plan | Customer Portal Pro |
+|------|:-------------------:|
+| Starter ($49/mo) | Add-on $24/mo |
+| Pro ($79/mo) | Add-on $24/mo |
+| Elite ($129/mo) | Included free |
+
+---
+
+## Need Help?
+
+- **Email:** support@tooltimepro.com
+- **Phone:** 1-888-980-8665
+- **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Customers-and-Leads.md
+++ b/wiki/Customers-and-Leads.md
@@ -1,0 +1,142 @@
+# Customers & Leads
+
+Track every customer relationship from first contact to repeat business. Manage leads through your sales pipeline and convert them into loyal customers.
+
+---
+
+## Customers
+
+### Adding a Customer
+
+1. Go to **Customers** in the sidebar
+2. Click **+ Add Customer**
+3. Fill in their details:
+   - **Name** — Full name or business name
+   - **Email** — For quotes, invoices, and communication
+   - **Phone** — For calls and SMS
+   - **Address** — Street, city, state, zip (for job site locations)
+   - **Notes** — Any special details about this customer
+   - **SMS Consent** — Whether they've opted in to text messages
+4. Click **Save**
+
+### Customer Dashboard
+
+Your customer list shows key stats at the top:
+- **Total Customers** — Your complete customer count
+- **Active Jobs** — Jobs currently scheduled or in progress
+- **Unpaid Invoices** — Outstanding balances
+- **Total Revenue** — Lifetime revenue across all customers
+
+### Searching & Filtering
+
+- Use the **search bar** to find customers by name, email, or phone
+- Customer cards show job count, invoice count, and quick action buttons
+
+### Customer Actions
+
+From any customer card, you can:
+- **View Jobs** — See all jobs linked to this customer
+- **Create Quote** — Start a new quote for them
+- **Edit** — Update their contact information
+- **Delete** — Remove the customer record
+
+### SMS Consent Tracking
+
+ToolTime Pro tracks SMS opt-in status with:
+- Consent toggle (yes/no)
+- Consent date timestamp
+- Required for compliance with TCPA regulations
+
+---
+
+## Leads
+
+Leads are potential customers who haven't booked yet. Track them through your sales pipeline from first contact to closed deal.
+
+### Lead Sources
+
+Leads come into your system from:
+- **Online Booking** — Someone books through your website
+- **Jenny AI Chatbot** — Jenny captures visitor info from your site
+- **Manual Entry** — You add them yourself
+- **Website Form** — Contact form submissions
+
+### Adding a Lead
+
+1. Go to **Leads** in the sidebar
+2. Click **+ Add Lead**
+3. Enter their details:
+   - **Name** — Contact name
+   - **Email** and **Phone**
+   - **Service Requested** — What they're interested in
+   - **Estimated Value** — Potential deal value
+   - **Source** — Where the lead came from
+   - **Notes** — Any context from the conversation
+4. Click **Save**
+
+### Lead Pipeline
+
+Track each lead through your sales funnel:
+
+| Status | Meaning |
+|--------|---------|
+| **New** | Just came in — needs first contact |
+| **Contacted** | You've reached out, awaiting response |
+| **Quoted** | You've sent a quote or estimate |
+| **Booked** | They've committed to a job |
+| **Won** | Deal closed, converted to customer |
+| **Lost** | Didn't convert (track why for improvement) |
+
+### Pipeline Stats
+
+At the top of the Leads page, stat cards show how many leads are in each stage so you can see your pipeline health at a glance.
+
+### Lead Actions
+
+- **Call** — Quick-dial the lead's phone number
+- **Convert to Customer** — One-click conversion that creates a full customer record
+- **Delete** — Remove leads that are no longer relevant
+
+### Converting Leads to Customers
+
+When a lead is ready to become a customer:
+
+1. Click the **Convert** button on their lead card
+2. Their information is automatically copied to a new customer record
+3. The lead status updates to "Won"
+4. You can now create jobs, quotes, and invoices for them
+
+---
+
+## How Customers & Leads Connect to Other Features
+
+```
+Lead → Convert → Customer → Quote → Job → Invoice
+                     ↑
+              Online Booking (auto-creates both)
+              Jenny AI (captures lead info)
+```
+
+- **Quotes** are linked to customers — see all quotes sent to a customer
+- **Jobs** are linked to customers — track service history
+- **Invoices** are linked to customers — track payment history
+- **Online Booking** auto-creates both a lead and a customer record
+- **Jenny AI** captures lead information and can auto-create leads
+
+---
+
+## Tips
+
+1. **Follow up on new leads within 1 hour** — Response time is the #1 factor in conversion
+2. **Use the pipeline view** to identify stale leads that need attention
+3. **Track lead sources** to know which marketing channels work best
+4. **Keep customer notes updated** — Your team will thank you on the next visit
+5. **Enable SMS consent** during the first interaction for future communication
+
+---
+
+## Need Help?
+
+- **Email:** support@tooltimepro.com
+- **Phone:** 1-888-980-8665
+- **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -8,18 +8,56 @@ ToolTime Pro is an AI-powered field service management platform built for contra
 
 ---
 
-## Quick Links
+## Getting Started
 
 | Guide | What You'll Learn |
 |-------|-------------------|
 | [Getting Started](Getting-Started) | Account setup, onboarding checklist, first job |
-| [Adding Services](Adding-Services) | Service catalog, pricing, categories |
 | [Pricing & Plans](Pricing-and-Plans) | Starter, Pro, Elite plans and add-ons |
+
+---
+
+## Core Features
+
+| Guide | What You'll Learn |
+|-------|-------------------|
+| [Jobs & Scheduling](Jobs-and-Scheduling) | Jobs, recurring jobs, schedule, dispatch board, route optimizer |
+| [Online Booking](Online-Booking) | Set up your booking page, share link, manage appointments |
+| [Customers & Leads](Customers-and-Leads) | Customer management, lead pipeline, conversions |
 | [Quotes & Estimates](Quotes-and-Estimates) | Smart quoting, e-signatures, approvals |
+| [Invoicing & Payments](Invoicing-and-Payments) | Invoices, card payments, QuickBooks sync |
+| [Payment Plans](Payment-Plans-Guide) | Split invoices into installments |
+| [Time Tracking](Time-Tracking) | GPS clock-in, break tracking, timesheets |
+
+---
+
+## AI & Website
+
+| Guide | What You'll Learn |
+|-------|-------------------|
+| [Jenny AI](Jenny-AI) | Jenny Lite, Pro, and Exec Admin — chatbot, phone, SMS, compliance |
+| [Website & Blog](Website-and-Blog) | Website builder, blog posts, SEO content |
+| [Customer Portal Pro](Customer-Portal) | Branded customer portal with job tracking, photos, messaging |
+
+---
+
+## Team & Compliance
+
+| Guide | What You'll Learn |
+|-------|-------------------|
+| [Adding Services](Adding-Services) | Service catalog, pricing, categories |
 | [Team Management](Team-Management) | Workers, roles, permissions, blended workforce |
 | [Mobile & Worker App](Mobile-and-Worker-App) | GPS clock-in, job management, photo uploads |
-| [Invoicing & Payments](Invoicing-and-Payments) | Invoices, card payments, QuickBooks sync |
 | [ToolTime Shield](ToolTime-Shield) | Compliance, worker classification, HR toolkit |
+| [Reports & Analytics](Reports-and-Analytics) | Revenue charts, worker hours, lead conversion |
+
+---
+
+## Settings & Advanced
+
+| Guide | What You'll Learn |
+|-------|-------------------|
+| [Settings & Integrations](Settings-and-Integrations) | Company settings, webhooks, QuickBooks, Stripe, Google Calendar |
 | [Troubleshooting](Troubleshooting) | Common issues and how to fix them |
 | [FAQ](FAQ) | Frequently asked questions |
 

--- a/wiki/Jenny-AI.md
+++ b/wiki/Jenny-AI.md
@@ -1,0 +1,157 @@
+# Jenny AI
+
+Jenny is your AI-powered assistant that handles customer communication, phone answering, appointment booking, and business insights — 24/7, in English and Spanish.
+
+---
+
+## Jenny AI Tiers
+
+| Feature | Jenny Lite (Free) | Jenny Pro ($49/mo) | Jenny Exec Admin ($79/mo) |
+|---------|:-----------------:|:------------------:|:-------------------------:|
+| Website chatbot | Yes | Yes | Yes |
+| Lead capture | Yes | Yes | Yes |
+| FAQ answering | Yes | Yes | Yes |
+| Bilingual (EN/ES) | Yes | Yes | Yes |
+| AI phone answering | — | Yes | Yes |
+| SMS messaging | — | Yes | Yes |
+| Direct booking from chat | — | Yes | Yes |
+| Emergency escalation | — | Yes | Yes |
+| Compliance advisor | — | — | Yes |
+| HR law monitoring | — | — | Yes |
+| Workforce analytics | — | — | Yes |
+| Business insights | — | — | Yes |
+
+---
+
+## Jenny Lite (Included Free)
+
+Jenny Lite is a website chatbot included with Pro and Elite plans. She sits on your website and captures leads while you're out in the field.
+
+### Setting Up Jenny Lite
+
+1. Go to **Jenny Lite** in the sidebar
+2. Configure your chatbot:
+   - **Business Name** — Your company name as Jenny introduces herself
+   - **Business Type** — Your industry (landscaping, plumbing, HVAC, etc.)
+   - **Phone Number** — For when customers want to call instead
+   - **Greeting Message** — What Jenny says when visitors open the chat
+3. Add **FAQ Entries** (up to 8):
+   - Common questions and your preferred answers
+   - Jenny uses these to respond to customer inquiries
+   - Example: "What areas do you serve?" → "We serve the greater Austin area..."
+4. Customize appearance:
+   - **Accent Color** — Match your brand
+   - **Position** — Left or right side of the screen
+5. **Preview** your chatbot to see how it looks
+6. Copy the **embed code** to add it to external websites
+
+### What Jenny Lite Does
+
+- Greets website visitors and offers help
+- Answers frequently asked questions using your FAQ entries
+- Captures lead information (name, phone, email, service needed)
+- Works 24/7 — captures leads while you sleep
+- Speaks English and Spanish automatically
+
+---
+
+## Jenny Pro ($49/month)
+
+Jenny Pro adds AI phone answering and SMS, so you never miss a customer call.
+
+### Features
+
+- **AI Phone Answering** — Jenny answers calls when you can't, in a natural voice
+- **SMS Conversations** — Jenny texts back and forth with customers
+- **Direct Booking** — Jenny can book appointments right from the phone call or text
+- **Bilingual Voice** — Speaks English and Spanish fluently
+- **Emergency Escalation** — Urgent calls get routed to you immediately
+- **Lead Capture** — Every conversation creates a lead in your system
+
+### Managing SMS Conversations
+
+1. Go to **Jenny Pro** in the sidebar
+2. View all SMS conversations with stats:
+   - Total conversations
+   - Leads captured
+   - Bookings made
+   - Average response time
+3. Filter by status: Active, Resolved, Needs Response
+4. Click into any conversation to see the full message thread
+5. Link conversations to leads for tracking
+
+### Settings
+
+Configure Jenny Pro's behavior:
+- Business hours for call handling
+- Emergency escalation rules
+- Greeting scripts for phone and SMS
+- Booking preferences
+
+> **Included with Elite:** Jenny Pro comes standard with Elite plans at no additional cost.
+
+---
+
+## Jenny Exec Admin ($79/month)
+
+Jenny Exec Admin is your AI-powered executive assistant, built for business owners managing compliance, HR, and growth.
+
+### Features
+
+#### Compliance Advisor
+- Monitors labor law changes in your state
+- Alerts you to potential violations before they happen
+- Tracks meal breaks, rest breaks, and overtime compliance
+- Provides actionable recommendations
+
+#### HR Law Monitoring
+- Tracks employment law updates relevant to your industry
+- Worker classification guidance (W-2 vs. 1099)
+- State-specific compliance requirements
+- Certification and license renewal reminders
+
+#### Business Insights
+- Monthly performance snapshots:
+  - Revenue trends
+  - Jobs completed
+  - Average job value
+  - Active worker metrics
+- AI-powered recommendations for growing your business
+- Workforce analytics and optimization suggestions
+
+#### Executive AI Chat
+- Ask Jenny questions about your business in plain English
+- Get instant answers about compliance, HR policies, and operations
+- Example questions:
+  - "Am I classifying my workers correctly?"
+  - "What are the overtime rules in California?"
+  - "How is my revenue trending this quarter?"
+
+### Accessing Jenny Exec
+
+1. Go to **Jenny Exec** in the sidebar (visible to account owners only)
+2. Browse three tabs:
+   - **Compliance** — Alerts and compliance status
+   - **HR** — Employment law updates and guidance
+   - **Business Insights** — Performance analytics and AI recommendations
+3. Use the AI chat to ask questions anytime
+
+> **Access:** Jenny Exec Admin is available as an add-on ($79/mo) or included with beta tester accounts. Only account owners can access this feature.
+
+---
+
+## Plan Availability
+
+| Plan | Jenny Lite | Jenny Pro | Jenny Exec Admin |
+|------|:----------:|:---------:|:----------------:|
+| Starter ($49/mo) | — | Add-on $49 | Add-on $79 |
+| Pro ($79/mo) | Included | Add-on $49 | Add-on $79 |
+| Elite ($129/mo) | Included | Included | Add-on $79 |
+
+---
+
+## Need Help?
+
+- **Email:** support@tooltimepro.com
+- **Phone:** 1-888-980-8665
+- **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Jobs-and-Scheduling.md
+++ b/wiki/Jobs-and-Scheduling.md
@@ -1,0 +1,187 @@
+# Jobs & Scheduling
+
+Manage your entire workflow — from creating individual jobs to scheduling recurring work, viewing your calendar, dispatching crews, and optimizing routes.
+
+---
+
+## Jobs
+
+Jobs are the core of ToolTime Pro. Every appointment, service call, or project is tracked as a job.
+
+### Creating a Job
+
+1. Click **Jobs** in the sidebar
+2. Click **+ New Job**
+3. Fill in the details:
+   - **Title** — A short description (e.g., "Lawn Mowing — 123 Oak St")
+   - **Customer** — Select an existing customer or create a new one
+   - **Service** — Choose from your service catalog
+   - **Date & Time** — Set the scheduled date and time window
+   - **Assigned Worker** — Assign a team member (they'll see it on their mobile app)
+   - **Address** — Job site location
+   - **Notes** — Internal notes for your crew
+4. Click **Save**
+
+### Job Statuses
+
+| Status | Meaning |
+|--------|---------|
+| **Scheduled** | Job is booked and upcoming |
+| **In Progress** | Worker has started the job |
+| **Completed** | Job is finished |
+| **Cancelled** | Job was cancelled |
+| **Overdue** | Past the scheduled date without completion |
+
+### Managing Jobs
+
+- **Filter** jobs by status to focus on what needs attention
+- **Edit** any job by clicking on it
+- **Convert from quotes** — When a customer approves a quote, it auto-creates a job with all details pre-filled
+- **Link to invoices** — Generate an invoice directly from a completed job
+
+> **Tip:** Overdue jobs appear as alerts on your dashboard so nothing falls through the cracks.
+
+---
+
+## Recurring Jobs
+
+For regular service appointments (weekly lawn care, monthly HVAC maintenance, etc.), set up recurring jobs so they're automatically created on schedule.
+
+### Setting Up a Recurring Job
+
+1. Click **Recurring Jobs** in the sidebar
+2. Click **+ New Recurring Job**
+3. Configure the recurrence:
+   - **Frequency** — Weekly, bi-weekly, monthly, or custom
+   - **Start Date** — When the first job should be created
+   - **End Date** — Optional end date or "ongoing"
+   - **Customer & Service** — Same as a regular job
+   - **Assigned Worker** — Default worker for each occurrence
+4. Save — jobs will be auto-generated on the schedule
+
+### Tips for Recurring Jobs
+
+- Edit the recurring pattern to change future jobs without affecting past ones
+- Each generated job can be individually modified if needed
+- Great for subscription-based services and maintenance contracts
+
+---
+
+## Schedule
+
+The Schedule page gives you a calendar view of all your jobs across your team.
+
+### Views
+
+- **Day View** — See all jobs for a single day, sorted by time
+- **Week View** — Overview of the entire week at a glance
+- **Today Button** — Jump back to the current date quickly
+
+### What You'll See
+
+Each job card shows:
+- Job title and customer name
+- Scheduled time window
+- Assigned worker
+- Job location
+- Status indicator (color-coded)
+
+### Stats at a Glance
+
+At the top of the schedule, stat cards show:
+- Jobs by status (scheduled, in progress, completed, cancelled)
+
+Click any job to view full details or edit it.
+
+---
+
+## Dispatch Board *(Elite Plan)*
+
+The Dispatch Board is your real-time command center for managing crews in the field.
+
+### Features
+
+- **Live Crew Panel** — See every worker's status:
+  - 🟢 Available — Ready for assignment
+  - 🔵 En Route — Heading to a job
+  - 🟡 On Site — Currently working
+  - ⚫ Offline — Not clocked in
+- **Map View** — See GPS locations of all active workers on a live map
+- **List View** — Jobs grouped by status (unassigned, in progress, scheduled, completed)
+- **Quick Assign** — Drag or click to assign available workers to unassigned jobs
+- **Running Late Alerts** — Get notified when a job is behind schedule
+- **Contact Workers** — Call or message crew directly from the board
+
+### How to Use the Dispatch Board
+
+1. Go to **Dispatch Board** in the sidebar
+2. Review unassigned jobs in the queue
+3. Check worker availability in the crew panel
+4. Assign workers to jobs based on location and availability
+5. Monitor progress throughout the day
+
+> **Pro Tip:** Use the map view to assign the nearest available worker to urgent jobs.
+
+---
+
+## Route Optimizer *(Elite Plan)*
+
+Save gas, reduce drive time, and fit more jobs into every day with automatic route optimization.
+
+### How It Works
+
+1. Go to **Route Optimizer** in the sidebar
+2. Select the jobs you want to optimize (or load a day's schedule)
+3. Click **Optimize Route**
+4. The system calculates the most efficient order based on:
+   - Distance between job sites
+   - Time windows for appointments
+   - Your office/start location
+
+### What You'll See
+
+After optimization:
+- **Optimized job order** — Jobs resequenced for efficiency
+- **Total drive time** — Estimated time on the road
+- **Total distance** — Miles between all stops
+- **Fuel cost estimate** — Based on your configured fuel price
+- **Savings comparison** — See how much time, miles, and fuel you saved vs. the original order
+
+### Settings
+
+Configure your route optimization preferences:
+- **Average Speed** — Adjust for your area (city vs. rural)
+- **Fuel Cost** — Current price per gallon
+- **Road Factor** — Accounts for non-straight-line driving
+- **Office Location** — Your start/end point
+
+### Saving Routes
+
+- Name and save optimized routes for reuse
+- Great for recurring service territories
+
+---
+
+## How It All Connects
+
+```
+Online Booking → Jobs → Schedule → Dispatch → Route Optimizer
+                  ↓
+            Quotes → Jobs (from approved quotes)
+                  ↓
+            Invoices (from completed jobs)
+```
+
+- Bookings from your public page automatically create jobs
+- Approved quotes convert into jobs with details pre-filled
+- Completed jobs can generate invoices with one click
+- The Schedule shows all jobs; the Dispatch Board lets you manage them in real-time
+- Route Optimizer takes your daily schedule and finds the most efficient path
+
+---
+
+## Need Help?
+
+- **Email:** support@tooltimepro.com
+- **Phone:** 1-888-980-8665
+- **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Online-Booking.md
+++ b/wiki/Online-Booking.md
@@ -1,0 +1,132 @@
+# Online Booking
+
+Let customers book appointments directly from your website — 24/7, no phone calls needed. Online booking is included in every ToolTime Pro plan.
+
+---
+
+## Setting Up Online Booking
+
+### Step 1: Add Your Services
+
+Before customers can book, you need a service catalog:
+
+1. Go to **Services** (from Settings or the Getting Started checklist)
+2. Click **+ Add Service**
+3. For each service, enter:
+   - **Name** — e.g., "Lawn Mowing", "AC Tune-Up", "Drain Cleaning"
+   - **Description** — What's included
+   - **Default Price** — Starting price shown to customers
+   - **Duration** — Estimated time (in minutes)
+   - **Active** — Toggle on to make it bookable
+4. Save your services
+
+> **Tip:** Start with your 3–5 most popular services. You can always add more later.
+
+### Step 2: Build Your Website (Recommended)
+
+Your booking page works best when connected to your ToolTime Pro website:
+
+1. Go to **Website Builder** in the sidebar
+2. Follow the wizard to create your site
+3. Once published, your booking page is automatically available at your site URL
+
+### Step 3: Share Your Booking Link
+
+1. Go to **Online Booking** in the sidebar
+2. Your unique booking URL is displayed at the top
+3. Click **Copy Link** to copy it to your clipboard
+4. Share it via:
+   - Text message to customers
+   - Email signature
+   - Social media profiles
+   - Google Business Profile
+   - Printed flyers or business cards
+
+---
+
+## How Customers Book
+
+When a customer visits your booking page, they:
+
+1. **Select a service** from your catalog
+2. **Choose a date and time** from available slots
+3. **Enter their details** — Name, phone, email, address
+4. **Add notes** — Special instructions or access details
+5. **Confirm the booking** — They receive a confirmation
+
+The booking automatically:
+- Creates a **new job** on your schedule
+- Creates a **customer record** (or matches an existing one)
+- Creates a **lead** with source "online_booking"
+- Sends an **SMS notification** (if configured)
+
+---
+
+## Managing Bookings
+
+### Booking Dashboard
+
+Go to **Online Booking** in the sidebar to see:
+
+- **Booking Link Card** — Your shareable URL with copy and preview buttons
+- **Stats** — Upcoming, in progress, and completed appointment counts
+- **Booking List** — All appointments with filters
+
+### Filtering Bookings
+
+Use the filter bar to view:
+- **Upcoming** — Future scheduled appointments
+- **Past** — Completed or cancelled appointments
+- **All** — Every booking in your system
+
+### Booking Details
+
+Click any booking to expand and see:
+- Customer name, email, and phone
+- Scheduled date and time
+- Job site address
+- Notes from the customer
+- Quick links to **View/Edit Job** or **Open Dispatch**
+
+---
+
+## Booking Settings
+
+Customize how your booking page works from your company settings:
+
+| Setting | What It Controls |
+|---------|-----------------|
+| **Days Ahead** | How far in advance customers can book (e.g., 30 days) |
+| **Slot Duration** | Time between available slots (e.g., 30 or 60 minutes) |
+| **Business Hours** | Which days/hours are available for booking |
+
+---
+
+## Jenny AI + Online Booking
+
+If you have **Jenny Lite** (included free with Pro and Elite) or **Jenny Pro**, your AI chatbot can also book appointments:
+
+- Jenny captures customer details through chat
+- She suggests available times
+- She books the job directly — no manual entry needed
+- Works 24/7 in English and Spanish
+
+See [Jenny AI](Jenny-AI) for more on AI-powered booking.
+
+---
+
+## Tips for Getting More Bookings
+
+1. **Add your booking link everywhere** — Email signature, social bios, Google listing
+2. **Keep your service catalog updated** — Accurate pricing builds trust
+3. **Set reasonable time slots** — Don't overbook your team
+4. **Respond quickly** — Even though booking is automated, follow up promptly
+5. **Enable SMS notifications** — So you never miss a new booking
+
+---
+
+## Need Help?
+
+- **Email:** support@tooltimepro.com
+- **Phone:** 1-888-980-8665
+- **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Payment-Plans-Guide.md
+++ b/wiki/Payment-Plans-Guide.md
@@ -1,0 +1,90 @@
+# Payment Plans
+
+Offer customers flexible payment options by splitting invoices into installments. Great for large projects where customers need to pay over time.
+
+---
+
+## Overview
+
+Payment Plans let you break an unpaid invoice into multiple scheduled payments. Instead of asking for $5,000 upfront, you can split it into 5 monthly payments of $1,000.
+
+---
+
+## Creating a Payment Plan
+
+1. Go to **Payment Plans** in the sidebar
+2. Click **+ New Payment Plan**
+3. Select the **unpaid invoice** to link the plan to
+4. Configure the installments:
+   - **Number of Payments** — How many installments (e.g., 3, 6, 12)
+   - **Frequency** — How often (weekly, bi-weekly, monthly)
+   - **Start Date** — When the first payment is due
+5. The system auto-calculates the amount per installment
+6. Add **Notes** if needed (e.g., "Customer requested monthly payments")
+7. Click **Create Plan**
+
+---
+
+## Managing Payment Plans
+
+### Payment Plan Dashboard
+
+The Payment Plans page shows:
+- All active payment plans
+- Customer name and linked invoice
+- Installment schedule with due dates
+- Payment status for each installment (paid vs. pending)
+
+### Tracking Installments
+
+Each payment plan displays:
+- **Total amount** — Full invoice value
+- **Per-installment amount** — Auto-calculated split
+- **Due dates** — When each payment is expected
+- **Status** — Paid, pending, or overdue for each installment
+
+### Recording Payments
+
+When a customer makes an installment payment:
+1. Find the payment plan
+2. Mark the installment as **Paid**
+3. The plan updates to show remaining balance
+
+### Deleting a Plan
+
+If a customer decides to pay in full or the plan is no longer needed:
+1. Click **Delete** on the payment plan
+2. The original invoice remains unchanged
+
+---
+
+## Tips
+
+1. **Use for large projects** — Roof replacements, full HVAC installs, landscape redesigns
+2. **Set clear expectations** — Discuss the payment schedule with the customer before creating the plan
+3. **Follow up on missed payments** — Check the Payment Plans page regularly for overdue installments
+4. **Keep notes** — Document any special arrangements in the plan's notes field
+
+---
+
+## How It Connects
+
+```
+Quote → Invoice → Payment Plan
+                      ↓
+              Installment 1 (Paid)
+              Installment 2 (Due March 15)
+              Installment 3 (Due April 15)
+```
+
+- Payment Plans are linked to **Invoices** — one plan per invoice
+- The invoice status updates as installments are paid
+- View all plans from the **Payment Plans** sidebar item
+
+---
+
+## Need Help?
+
+- **Email:** support@tooltimepro.com
+- **Phone:** 1-888-980-8665
+- **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Reports-and-Analytics.md
+++ b/wiki/Reports-and-Analytics.md
@@ -1,0 +1,115 @@
+# Reports & Analytics
+
+Track your business performance with revenue charts, worker analytics, customer insights, and lead conversion metrics.
+
+---
+
+## Accessing Reports
+
+Go to **Reports** in the sidebar (available to account owners and admins).
+
+---
+
+## Dashboard Metrics
+
+### Key Stats
+
+At the top of the Reports page, you'll see:
+
+| Metric | What It Shows |
+|--------|--------------|
+| **Total Revenue** | Revenue collected in the selected period |
+| **Outstanding Invoices** | Unpaid invoice balance |
+| **Avg Job Value** | Average revenue per completed job |
+| **Jobs Completed** | Number of jobs finished in the period |
+
+### Revenue Chart
+
+- **Area chart** showing revenue over time (by month)
+- Visualize trends — are you growing month over month?
+- Spot seasonal patterns in your business
+
+---
+
+## Date Range Filters
+
+Filter all reports by time period:
+
+| Filter | Period |
+|--------|--------|
+| **This Week** | Current 7-day period |
+| **This Month** | Current calendar month |
+| **This Quarter** | Current 3-month quarter |
+| **This Year** | Current calendar year |
+| **Custom** | Pick your own start and end dates |
+
+---
+
+## Available Reports
+
+### Revenue Breakdown
+
+- Monthly revenue trends with visual charts
+- Compare periods to track growth
+- Identify your best-performing months
+
+### Worker Hours
+
+- **Bar chart** showing hours worked by each team member
+- See who's working the most and who has capacity
+- Useful for workload balancing and overtime monitoring
+
+### Top Customers
+
+- Ranked list of customers by total revenue
+- Identify your most valuable accounts
+- Focus retention efforts on high-value customers
+
+### New Customers
+
+- Count of new customers added during the period
+- Track customer acquisition over time
+
+### Lead Conversion Rate
+
+- Percentage of leads that converted to customers
+- Monitor your sales pipeline effectiveness
+- Identify if your follow-up process needs improvement
+
+---
+
+## Exporting Reports
+
+- Click **Download** to export report data as CSV
+- Use exported data for:
+  - Accountant or bookkeeper review
+  - Tax preparation
+  - Business loan applications
+  - Custom analysis in Excel or Google Sheets
+
+---
+
+## Revenue Trend (Dashboard)
+
+A quick revenue chart also appears on your main **Dashboard** page, showing your monthly revenue trend without navigating to the full Reports page.
+
+---
+
+## Plan Availability
+
+| Feature | Starter | Pro | Elite |
+|---------|:-------:|:---:|:-----:|
+| Basic revenue reports | Yes | Yes | Yes |
+| Worker hours report | — | Yes | Yes |
+| Top customers | — | Yes | Yes |
+| Lead conversion rate | — | Yes | Yes |
+| Advanced analytics | — | — | Yes |
+| CSV export | Yes | Yes | Yes |
+
+---
+
+## Need Help?
+
+- **Email:** support@tooltimepro.com
+- **Phone:** 1-888-980-8665
+- **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Settings-and-Integrations.md
+++ b/wiki/Settings-and-Integrations.md
@@ -1,0 +1,157 @@
+# Settings & Integrations
+
+Configure your company profile, connect third-party tools, manage your subscription, and set up webhooks for custom integrations.
+
+---
+
+## Settings
+
+Go to **Settings** in the sidebar to access your account configuration.
+
+### Account Tab
+
+Update your company information:
+
+| Field | Description |
+|-------|-------------|
+| **Company Name** | Your business name |
+| **Email** | Main contact email |
+| **Phone** | Business phone number |
+| **Address** | Office or business address |
+| **Website** | Your company website URL |
+| **Quote Terms** | Default terms and conditions for quotes |
+
+Click **Save** to update your changes.
+
+### Integrations Tab
+
+Connect third-party tools to ToolTime Pro:
+
+#### QuickBooks Online
+
+Sync your financial data between ToolTime Pro and QuickBooks:
+
+- **Two-way sync** — Invoices, payments, and customers sync automatically
+- **Setup:**
+  1. Go to Settings → Integrations
+  2. Click **Connect QuickBooks**
+  3. Sign in to your QuickBooks account
+  4. Authorize the connection
+- **What syncs:**
+  - Invoices created in ToolTime Pro appear in QuickBooks
+  - Payments recorded in either system sync across
+  - Customer records stay in sync
+- **Monitoring:** View last sync time and sync status
+- **Disconnect:** Click **Disconnect QuickBooks** if you need to unlink
+
+> **Pricing:** QuickBooks Sync is included with Elite plans, or available as an add-on for $12/mo.
+
+#### Google Calendar
+
+Sync your job schedule with Google Calendar:
+
+- Jobs appear as events on your Google Calendar
+- Changes sync both ways
+- Great for managing your schedule alongside personal events
+
+### Subscription Tab
+
+View and manage your plan:
+- Current plan name and tier
+- Monthly or annual pricing
+- Billing period
+- Upgrade or downgrade options
+
+---
+
+## Webhooks
+
+Webhooks let you send real-time notifications to external systems when events happen in ToolTime Pro. Perfect for custom integrations, Zapier connections, or internal tools.
+
+### Setting Up a Webhook
+
+1. Go to **Webhooks** in the sidebar
+2. Click **+ New Webhook**
+3. Configure:
+   - **URL** — The endpoint to receive webhook events
+   - **Events** — Select which events trigger the webhook:
+
+| Category | Available Events |
+|----------|-----------------|
+| **Jobs** | Job created, updated, completed, cancelled |
+| **Invoicing** | Invoice created, sent, paid, overdue |
+| **Quotes** | Quote created, sent, accepted, rejected |
+| **Customers** | Customer created, updated |
+| **Leads** | Lead created, status changed |
+| **Bookings** | Booking created, cancelled |
+| **Reviews** | Review received |
+| **Worker Actions** | Clock-in, clock-out, break start/end |
+
+4. Save — a **webhook secret** is auto-generated for security
+
+### Managing Webhooks
+
+- **Enable/Disable** — Toggle webhooks on or off without deleting
+- **View Logs** — See the last 20 events with:
+  - Timestamp
+  - Event type
+  - Success/failure status
+  - Response time
+- **Failure Count** — Track how many deliveries have failed
+- **Last Triggered** — See when the webhook last fired
+
+### Webhook Security
+
+Each webhook gets a unique secret key. Use it to verify that incoming requests are genuinely from ToolTime Pro:
+
+1. ToolTime Pro signs each webhook payload with your secret
+2. Your server verifies the signature before processing
+3. Reject any requests with invalid signatures
+
+### Common Webhook Use Cases
+
+- **Slack notifications** — Post to a channel when a new booking comes in
+- **Zapier automation** — Trigger workflows when invoices are paid
+- **Custom CRM** — Sync customer data to your own system
+- **SMS alerts** — Send a text when a worker clocks in late
+- **Accounting sync** — Push invoice data to custom accounting tools
+
+---
+
+## Stripe Payments
+
+ToolTime Pro uses Stripe for payment processing. Your customers can pay invoices by credit card.
+
+### How It Works
+
+- When you send an invoice, customers receive a payment link
+- They enter their card details on a secure Stripe-hosted page
+- Payment is deposited to your connected Stripe account
+- ToolTime Pro automatically marks the invoice as paid
+
+### Connecting Stripe
+
+Stripe is set up during your initial account configuration. If you need to reconnect:
+1. Go to **Settings** → **Integrations**
+2. Follow the Stripe connection prompts
+3. Verify your bank account for payouts
+
+---
+
+## Plan Availability
+
+| Feature | Starter | Pro | Elite |
+|---------|:-------:|:---:|:-----:|
+| Company settings | Yes | Yes | Yes |
+| Stripe payments | Yes | Yes | Yes |
+| Google Calendar | Yes | Yes | Yes |
+| Webhooks | Yes | Yes | Yes |
+| QuickBooks Sync | Add-on $12 | Add-on $12 | Included |
+
+---
+
+## Need Help?
+
+- **Email:** support@tooltimepro.com
+- **Phone:** 1-888-980-8665
+- **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Time-Tracking.md
+++ b/wiki/Time-Tracking.md
@@ -1,0 +1,137 @@
+# Time Tracking
+
+Track worker hours with GPS-verified clock-in/out, break tracking, and manager approvals. Stay compliant with labor laws and export timesheets for payroll.
+
+---
+
+## Overview
+
+The **Time Logs** page (sidebar) gives managers a complete view of worker hours across your team.
+
+### What You'll See
+
+- Clock-in and clock-out times for each worker
+- Total hours worked per entry
+- Job association — which job the time was logged against
+- Status indicators (active, approved, edited)
+- Worker avatars and names
+
+---
+
+## How Workers Clock In
+
+Workers use the **ToolTime Pro Worker App** on their phone:
+
+1. Open the Worker App
+2. Tap **Clock In**
+3. GPS location is captured automatically (verifies they're at the job site)
+4. Start working — the timer runs in the background
+5. Tap **Clock Out** when done
+
+### GPS Verification
+
+- Clock-in captures the worker's GPS coordinates
+- Managers can verify workers are at the correct job site
+- Helps prevent time theft and ensures accountability
+
+### Photo Verification *(Elite Plan)*
+
+- Workers take a selfie at clock-in for identity verification
+- Prevents buddy punching
+- Photos are stored with the time log entry
+
+---
+
+## Break Tracking
+
+ToolTime Pro tracks meal and rest breaks for labor law compliance — especially important in California and other strict states.
+
+### How It Works
+
+- Workers tap **Start Break** and **End Break** in the app
+- Break duration is recorded and tracked
+- The system flags missed or short breaks
+
+### California Compliance
+
+For California-based businesses, ToolTime Pro monitors:
+- **Meal Breaks** — 30-minute unpaid meal break before the 5th hour
+- **Rest Breaks** — 10-minute paid rest break per 4 hours worked
+- **Overtime** — Time-and-a-half after 8 hours/day or 40 hours/week
+
+> **See Also:** [ToolTime Shield](ToolTime-Shield) for full compliance monitoring.
+
+---
+
+## Managing Time Logs
+
+### Filtering
+
+- **By Worker** — Select a specific team member
+- **By Status** — Active (currently clocked in), Approved, Edited
+- **By Date** — View specific days or date ranges
+- **Search** — Find entries by worker name or job
+
+### Approving Time
+
+Managers can review and approve time entries:
+
+1. Go to **Time Logs** in the sidebar
+2. Review pending entries
+3. Click **Approve** to confirm the hours
+4. Or **Reject** if something looks wrong — add a note explaining why
+
+### Editing Time
+
+If a worker forgot to clock out or made an error:
+1. Find the time entry
+2. Click **Edit**
+3. Adjust the clock-in or clock-out time
+4. The entry is marked as "Edited" for audit purposes
+
+---
+
+## Exporting Timesheets
+
+Export time data for payroll processing:
+
+1. Set your date range filter
+2. Click **Export to CSV**
+3. The CSV includes:
+   - Worker name
+   - Date
+   - Clock-in/out times
+   - Total hours
+   - Job association
+   - Status (approved/edited)
+4. Import into your payroll system or QuickBooks
+
+---
+
+## Time Tracking + Other Features
+
+- **Jobs** — Time entries are linked to specific jobs for accurate job costing
+- **Reports** — Worker hours feed into the Reports dashboard
+- **Compliance** — Break data feeds into ToolTime Shield compliance monitoring
+- **Invoicing** — Track labor hours for accurate customer billing
+
+---
+
+## Plan Availability
+
+| Feature | Starter | Pro | Elite |
+|---------|:-------:|:---:|:-----:|
+| Basic time tracking | Yes | Yes | Yes |
+| GPS clock-in | Yes | Yes | Yes |
+| Break tracking | — | Yes | Yes |
+| Photo verification | — | — | Yes |
+| Compliance alerts | — | Yes | Yes |
+| CSV export | Yes | Yes | Yes |
+
+---
+
+## Need Help?
+
+- **Email:** support@tooltimepro.com
+- **Phone:** 1-888-980-8665
+- **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Website-and-Blog.md
+++ b/wiki/Website-and-Blog.md
@@ -1,0 +1,129 @@
+# Website Builder & Blog
+
+Build a professional website for your business and publish SEO-optimized blog posts to attract more customers — no coding required.
+
+---
+
+## Website Builder
+
+### Getting Started
+
+1. Go to **Website Builder** in the sidebar
+2. If you don't have a site yet, the **Website Wizard** will guide you:
+   - **Choose your trade** — Select your industry category
+   - **Pick a template** — Choose from professional designs built for contractors
+   - **Customize colors** — Set primary and secondary brand colors
+   - **Choose fonts** — Select typography that matches your brand
+   - **Add your content** — Company info, services, photos, testimonials
+3. Click **Publish** to take your site live
+
+### Website Features
+
+Your ToolTime Pro website includes:
+- **Professional design** — Mobile-responsive templates built for field service businesses
+- **Online booking integration** — Customers can book appointments directly from your site
+- **Jenny AI chatbot** — Lead capture widget built right in
+- **Service catalog** — Showcase your services with descriptions and pricing
+- **Contact information** — Phone, email, address prominently displayed
+- **SEO optimized** — Built to rank on Google for local searches
+
+### Customization Options
+
+| Setting | What You Can Change |
+|---------|-------------------|
+| **Colors** | Primary and secondary brand colors |
+| **Fonts** | Typography style |
+| **Layout** | Page structure and sections |
+| **Content** | Text, images, service descriptions |
+| **Pages** | Add or remove pages (based on plan) |
+
+### Page Limits by Plan
+
+| Plan | Pages Included |
+|------|:--------------:|
+| Starter ($49/mo) | 1 page |
+| Pro ($79/mo) | 3 pages |
+| Elite ($129/mo) | 5 pages |
+| Extra Page add-on | +$10/mo per page |
+
+### Managing Your Website
+
+Once your site is live, the Website Builder dashboard shows:
+- **Site status** — Live, draft, or building
+- **Leads collected** — How many leads your site has generated
+- **Edit options** — Update content, colors, and layout anytime
+- **Auto-recovery** — If a build goes stale, it auto-recovers
+
+### Website Add-On ($25/mo)
+
+Want a custom-built website instead of DIY? The **Website Builder add-on** includes:
+- Custom branded landing page designed for your business
+- Professional copywriting and layout
+- Mobile-optimized design
+
+---
+
+## Blog
+
+Publish blog posts to attract more customers through search engines and establish your expertise.
+
+### Why Blog?
+
+- **SEO traffic** — Blog posts rank on Google for industry-related searches
+- **Lead nurturing** — Educate potential customers and build trust
+- **Local authority** — Become the go-to expert in your service area
+- **Social content** — Share posts on social media to drive engagement
+
+### Creating a Blog Post
+
+1. Go to **Blog** in the sidebar
+2. Click **+ New Post**
+3. Write your post:
+   - **Title** — Make it descriptive and keyword-rich
+   - **Content** — Write helpful, informative content
+   - **Status** — Save as draft or publish immediately
+4. Click **Publish** when ready
+
+### AI-Powered Blog Writing
+
+ToolTime Pro can **generate blog posts for you** using AI:
+
+1. Browse **topic suggestions** tailored to your trade:
+   - Landscaper? Topics like "5 Spring Lawn Care Tips" or "How to Choose the Right Mulch"
+   - Plumber? Topics like "When to Call an Emergency Plumber" or "How to Prevent Frozen Pipes"
+   - HVAC? Topics like "How Often Should You Change Your Air Filter?" or "Signs Your AC Needs Repair"
+   - And more for painters, electricians, roofers, cleaners, pest control, etc.
+2. Click **Generate** on any suggested topic
+3. Jenny AI writes a full blog post for you
+4. Review, edit if needed, and publish
+
+### Blog Post Management
+
+- **View all posts** in a list with status, date, and title
+- **Edit** any post to update content
+- **Delete** posts you no longer need
+- **Filter** by status (published, draft)
+- **Export** posts for use on other platforms
+
+### Blog + Website
+
+Published blog posts appear on your ToolTime Pro website automatically, giving you fresh content that helps with search engine rankings.
+
+---
+
+## Plan Availability
+
+| Feature | Starter | Pro | Elite |
+|---------|:-------:|:---:|:-----:|
+| Website Builder | 1 page | 3 pages | 5 pages |
+| Blog | — | Yes | Yes |
+| Extra Page add-on | $10/mo | $10/mo | $10/mo |
+| Website Builder add-on | $25/mo | $25/mo | $25/mo |
+
+---
+
+## Need Help?
+
+- **Email:** support@tooltimepro.com
+- **Phone:** 1-888-980-8665
+- **Live Chat:** Click the chat icon in your dashboard


### PR DESCRIPTION
## Summary
Added a new "Set up online booking" task to the Getting Started Checklist that tracks whether a company has created services for customer booking.

## Key Changes
- Imported `CalendarCheck` icon from lucide-react for the new booking task
- Added `hasBooking` state to track if the company has active services
- Extended the database query to fetch active services from the `services` table
- Added a new checklist item that:
  - Displays "Set up online booking" with description about adding services
  - Links to `/dashboard/services` page
  - Shows completion status based on whether active services exist
  - Uses the `CalendarCheck` icon for visual consistency

## Implementation Details
- The booking task completion is determined by querying the `services` table for records where `company_id` matches and `is_active` is true
- The new task is inserted into the checklist items array alongside existing tasks (website, customers, jobs, team)
- Follows the same pattern as other checklist items with id, label, description, href, completed status, and icon

https://claude.ai/code/session_01LyfwssUssjB1JMDTyJQX5M