### PR TITLE
feat: automate wiki updates from code changes with Crisp helpdesk sync

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,5 +1,8 @@
 name: Sync Wiki
 
+# NOTE: Wiki sync is now handled by update-wiki.yml which also
+# auto-generates content and syncs to Crisp. This workflow is kept
+# as a fallback for direct wiki/ edits that don't trigger the main workflow.
 on:
   push:
     branches: [main]
@@ -8,6 +11,8 @@ on:
 
 jobs:
   sync-wiki:
+    # Skip if update-wiki.yml already ran (it covers wiki/** paths too)
+    if: github.event.head_commit.author.name != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -1,0 +1,70 @@
+name: Auto-Update Wiki & Crisp Helpdesk
+
+# Triggers when source-of-truth files change on main
+on:
+  push:
+    branches: [main]
+    paths:
+      # Pricing / product catalog changes
+      - 'scripts/setup-stripe-products.js'
+      - 'src/lib/stripe-prices.js'
+      # API route changes
+      - 'src/app/api/**/route.*'
+      # Cron / function changes
+      - 'netlify.toml'
+      - 'netlify/functions/**'
+      # Manual wiki edits (still sync to Crisp)
+      - 'wiki/**'
+
+  # Allow manual trigger from GitHub Actions UI
+  workflow_dispatch:
+
+jobs:
+  update-wiki:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Step 1: Regenerate wiki pages from source code
+      - name: Generate wiki content from source code
+        run: node scripts/generate-wiki.js
+
+      # Step 2: Check if wiki content actually changed
+      - name: Check for wiki changes
+        id: wiki-changes
+        run: |
+          git diff --quiet wiki/ && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
+
+      # Step 3: Commit updated wiki pages back to the repo
+      - name: Commit wiki updates
+        if: steps.wiki-changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add wiki/
+          git commit -m "docs: auto-update wiki from source code changes"
+          git push
+
+      # Step 4: Sync wiki/ directory to GitHub Wiki tab
+      - name: Sync to GitHub Wiki
+        uses: Andrew-Chen-Wang/github-wiki-action@v4
+        with:
+          path: wiki/
+
+      # Step 5: Sync to Crisp Knowledge Base (if secrets are configured)
+      - name: Sync to Crisp Helpdesk
+        if: env.CRISP_API_IDENTIFIER != ''
+        env:
+          CRISP_API_IDENTIFIER: ${{ secrets.CRISP_API_IDENTIFIER }}
+          CRISP_API_KEY: ${{ secrets.CRISP_API_KEY }}
+          CRISP_WEBSITE_ID: ${{ secrets.CRISP_WEBSITE_ID }}
+        run: node scripts/sync-to-crisp.js

--- a/scripts/generate-wiki.js
+++ b/scripts/generate-wiki.js
@@ -1,0 +1,490 @@
+#!/usr/bin/env node
+/**
+ * ToolTime Pro — Wiki Content Generator
+ *
+ * Auto-generates wiki pages from source code so documentation stays in sync.
+ * Run manually or via GitHub Actions on push to main.
+ *
+ * Generated pages:
+ *   - wiki/Pricing-and-Plans.md  (from PRODUCTS array in setup-stripe-products.js)
+ *   - wiki/API-Reference.md      (from src/app/api/ directory scan)
+ *   - wiki/System-Automation.md   (from netlify.toml cron schedules + functions)
+ *
+ * Usage:
+ *   node scripts/generate-wiki.js
+ *   node scripts/generate-wiki.js --dry-run   (prints to stdout, no file writes)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const WIKI_DIR = path.join(ROOT, 'wiki');
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function writeWikiPage(filename, content) {
+  const filePath = path.join(WIKI_DIR, filename);
+  if (DRY_RUN) {
+    console.log(`\n--- ${filename} ---\n`);
+    console.log(content);
+    return;
+  }
+  fs.writeFileSync(filePath, content, 'utf8');
+  console.log(`  Updated: wiki/${filename}`);
+}
+
+function formatDollars(cents) {
+  return `$${(cents / 100).toFixed(0)}`;
+}
+
+// ============================================================
+// 1. Pricing & Plans — parsed from setup-stripe-products.js
+// ============================================================
+
+function extractProducts() {
+  const scriptPath = path.join(ROOT, 'scripts', 'setup-stripe-products.js');
+  const src = fs.readFileSync(scriptPath, 'utf8');
+
+  // Extract the PRODUCTS array using a regex that captures the array content
+  const match = src.match(/const PRODUCTS\s*=\s*\[([\s\S]*?)\n\];/);
+  if (!match) {
+    console.error('Could not parse PRODUCTS array from setup-stripe-products.js');
+    process.exit(1);
+  }
+
+  // Parse individual product objects
+  const products = [];
+  const objRegex = /\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}/g;
+  let objMatch;
+  while ((objMatch = objRegex.exec(match[1])) !== null) {
+    const block = objMatch[1];
+
+    const id = (block.match(/id:\s*'([^']+)'/) || [])[1];
+    const name = (block.match(/name:\s*'([^']+)'/) || [])[1];
+    const desc = (block.match(/description:\s*'([^']+)'/) || [])[1];
+
+    // Extract prices
+    const prices = [];
+    const priceRegex = /\{\s*key:\s*'(\w+)',\s*amount:\s*(\d+)(?:,\s*interval:\s*'(\w+)')?\s*\}/g;
+    let priceMatch;
+    while ((priceMatch = priceRegex.exec(block)) !== null) {
+      prices.push({
+        key: priceMatch[1],
+        amount: parseInt(priceMatch[2], 10),
+        interval: priceMatch[3] || null,
+      });
+    }
+
+    if (id && name) {
+      products.push({ id, name, description: desc, prices });
+    }
+  }
+
+  return products;
+}
+
+function categorizeProd(id) {
+  if (['starter', 'pro', 'elite'].includes(id)) return 'core';
+  if (['booking_only', 'invoicing_only'].includes(id)) return 'standalone';
+  if (id.startsWith('jenny_')) return 'jenny';
+  if (['assisted_onboarding', 'white_glove'].includes(id)) return 'setup';
+  return 'addon';
+}
+
+function generatePricingPage(products) {
+  const core = products.filter((p) => categorizeProd(p.id) === 'core');
+  const standalone = products.filter((p) => categorizeProd(p.id) === 'standalone');
+  const jenny = products.filter((p) => categorizeProd(p.id) === 'jenny');
+  const addons = products.filter((p) => categorizeProd(p.id) === 'addon');
+  const setup = products.filter((p) => categorizeProd(p.id) === 'setup');
+
+  let md = `# Pricing & Plans
+
+<!-- AUTO-GENERATED from scripts/setup-stripe-products.js — do not edit manually -->
+<!-- To update: change PRODUCTS in setup-stripe-products.js, then run: node scripts/generate-wiki.js -->
+
+ToolTime Pro offers three core plans, standalone options, and powerful add-ons. No surprise per-user fees — competitors charge $20/vehicle or $250+/technician. We don't.
+
+---
+
+## Core Plans
+
+| Feature | Starter — ${formatDollars(core[0]?.prices[0]?.amount)}/mo | Pro — ${formatDollars(core[1]?.prices[0]?.amount)}/mo | Elite — ${formatDollars(core[2]?.prices[0]?.amount)}/mo |
+|---------|:-----------------:|:------------:|:----------------:|
+| **Annual Price** | ${formatDollars(core[0]?.prices[1]?.amount)}/yr | ${formatDollars(core[1]?.prices[1]?.amount)}/yr | ${formatDollars(core[2]?.prices[1]?.amount)}/yr |
+| **Workers** | Owner + 2 | Up to 15 | Unlimited |
+| Professional website | 1 page | 3 pages | 5 pages |
+| Online booking page | Yes | Yes | Yes |
+| Smart quoting + e-signatures | Yes | Yes | Yes |
+| Invoicing + card payments | Yes | Yes | Yes |
+| GPS clock-in (worker app) | Yes | Yes | Yes |
+| ToolTime Shield (compliance) | Yes | Yes | Yes |
+| HR document library (10+ templates) | Yes | Yes | Yes |
+| Spanish language support | Yes | Yes | Yes |
+| Chat & email support | Yes | Yes | Yes |
+| Review Machine (auto 5-star requests) | — | Yes | Yes |
+| Jenny Lite chatbot (lead capture) | — | Yes | Yes |
+| Break tracking + CA compliance | — | Yes | Yes |
+| Team scheduling + dispatch | — | Yes | Yes |
+| QuickBooks sync | — | Add-on | Included |
+| Phone support | — | Yes | Yes |
+| Full compliance toolkit | — | Yes | Yes |
+| Jenny Pro (phone + SMS) | — | — | Included |
+| Dispatch Board + Route Optimization | — | — | Yes |
+| Customer Portal Pro | — | — | Included |
+| Advanced reporting + analytics | — | — | Yes |
+| Photo verification (clock-in selfies) | — | — | Yes |
+| Compliance dashboard | — | — | Yes |
+| Priority support + account manager | — | — | Yes |
+| HR On-Demand access | — | — | Yes |
+
+> **Annual plans save 2 months free.** A Pro plan at ${formatDollars(core[1]?.prices[0]?.amount)}/month is just ${formatDollars(core[1]?.prices[1]?.amount)}/year (vs $${((core[1]?.prices[0]?.amount * 12) / 100).toFixed(0)} monthly).
+
+---
+
+## Standalone Plans
+
+For businesses that only need one feature:
+
+| Plan | Price | What's Included |
+|------|-------|-----------------|
+`;
+
+  for (const p of standalone) {
+    const monthly = p.prices.find((pr) => pr.interval === 'month');
+    const annual = p.prices.find((pr) => pr.interval === 'year');
+    const label = p.name.replace('ToolTime Pro — ', '');
+    md += `| **${label}** | ${formatDollars(monthly?.amount)}/mo (${formatDollars(annual?.amount)}/yr) | ${p.description} |\n`;
+  }
+
+  md += `
+---
+
+## Jenny AI Tiers
+
+Jenny AI is your AI-powered back-office assistant. Every plan includes access to Jenny:
+
+| Tier | Price | Capabilities |
+|------|-------|-------------|
+`;
+
+  for (const p of jenny) {
+    const monthly = p.prices.find((pr) => pr.interval === 'month');
+    const annual = p.prices.find((pr) => pr.interval === 'year');
+    const label = p.name.split(' — ')[0];
+    const annualStr = annual ? ` (${formatDollars(annual.amount)}/yr)` : '';
+    md += `| **${label}** | ${formatDollars(monthly?.amount)}/mo${annualStr} | ${p.description} |\n`;
+  }
+
+  md += `
+---
+
+## Add-Ons
+
+Extend your plan with powerful add-ons:
+
+| Add-On | Monthly | Annual | Description |
+|--------|---------|--------|-------------|
+`;
+
+  for (const p of addons) {
+    const monthly = p.prices.find((pr) => pr.interval === 'month');
+    const annual = p.prices.find((pr) => pr.interval === 'year');
+    const label = p.name.replace(' Add-on', '');
+    md += `| **${label}** | ${formatDollars(monthly?.amount)} | ${annual ? formatDollars(annual.amount) + '/yr' : '—'} | ${p.description} |\n`;
+  }
+
+  md += `
+---
+
+## One-Time Setup Services
+
+| Service | Price | What's Included |
+|---------|-------|-----------------|
+`;
+
+  for (const p of setup) {
+    const price = p.prices[0];
+    md += `| **${p.name}** | ${formatDollars(price?.amount)} | ${p.description} |\n`;
+  }
+
+  md += `
+---
+
+## Choosing the Right Plan
+
+- **Solo operators or tiny teams (1-3 people):** Start with **Starter** at ${formatDollars(core[0]?.prices[0]?.amount)}/mo
+- **Growing businesses (4-15 workers):** Go with **Pro** at ${formatDollars(core[1]?.prices[0]?.amount)}/mo for scheduling, reviews, and compliance
+- **Established operations (15+ workers):** Choose **Elite** at ${formatDollars(core[2]?.prices[0]?.amount)}/mo for dispatch board, route optimization, and unlimited workers
+- **Just need booking or invoicing?** Try a **Standalone** plan at ${formatDollars(standalone[0]?.prices[0]?.amount)}/mo
+
+---
+
+## Upgrading or Downgrading
+
+- Go to **Settings** > **Billing** in your dashboard
+- Changes take effect at the start of your next billing cycle
+- Upgrading mid-cycle is prorated — you only pay the difference
+- All your data is preserved when changing plans
+
+---
+
+## Need Help Choosing?
+
+Contact us:
+- **Email:** support@tooltimepro.com
+- **Phone:** 1-888-980-8665
+- **Live Chat:** Available in your dashboard
+`;
+
+  return md;
+}
+
+// ============================================================
+// 2. API Reference — scanned from src/app/api/ directory tree
+// ============================================================
+
+function scanApiRoutes(dir, prefix) {
+  const routes = [];
+  if (!fs.existsSync(dir)) return routes;
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      routes.push(...scanApiRoutes(fullPath, `${prefix}/${entry.name}`));
+    } else if (/^route\.(ts|js|tsx|jsx)$/.test(entry.name)) {
+      // Read the file to detect HTTP methods
+      const content = fs.readFileSync(fullPath, 'utf8');
+      const methods = [];
+      for (const m of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']) {
+        if (new RegExp(`export\\s+(async\\s+)?function\\s+${m}\\b`).test(content)) {
+          methods.push(m);
+        }
+      }
+      routes.push({ path: prefix, methods, file: fullPath.replace(ROOT + '/', '') });
+    }
+  }
+  return routes;
+}
+
+function generateApiReference() {
+  const apiDir = path.join(ROOT, 'src', 'app', 'api');
+  const routes = scanApiRoutes(apiDir, '/api');
+
+  // Group by top-level segment
+  const groups = {};
+  for (const r of routes) {
+    const parts = r.path.split('/').filter(Boolean); // ['api', 'auth', 'login']
+    const group = parts[1] || 'other';
+    if (!groups[group]) groups[group] = [];
+    groups[group].push(r);
+  }
+
+  let md = `# API Reference
+
+<!-- AUTO-GENERATED from src/app/api/ directory scan — do not edit manually -->
+<!-- To update: add/modify API routes, then run: node scripts/generate-wiki.js -->
+
+Complete list of ToolTime Pro API endpoints, auto-generated from source code.
+
+**Base URL:** \`https://app.tooltimepro.com\` (production) or \`http://localhost:3000\` (local dev)
+
+---
+
+`;
+
+  const groupOrder = Object.keys(groups).sort();
+  for (const group of groupOrder) {
+    const label = group
+      .split('-')
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ');
+    md += `## ${label}\n\n`;
+    md += `| Endpoint | Methods | Source |\n`;
+    md += `|----------|---------|--------|\n`;
+
+    for (const r of groups[group].sort((a, b) => a.path.localeCompare(b.path))) {
+      const methodBadges = r.methods.length ? r.methods.map((m) => `\`${m}\``).join(' ') : '_dynamic_';
+      md += `| \`${r.path}\` | ${methodBadges} | \`${r.file}\` |\n`;
+    }
+    md += '\n';
+  }
+
+  md += `---
+
+> **Total endpoints:** ${routes.length} routes across ${groupOrder.length} groups
+
+_Last generated: ${new Date().toISOString().split('T')[0]}_
+`;
+
+  return md;
+}
+
+// ============================================================
+// 3. System Automation — parsed from netlify.toml + functions
+// ============================================================
+
+function generateSystemAutomation() {
+  const tomlPath = path.join(ROOT, 'netlify.toml');
+  const toml = fs.readFileSync(tomlPath, 'utf8');
+
+  // Parse cron schedules from netlify.toml
+  // Look for comment blocks immediately above [functions."name"] blocks
+  const cronJobs = [];
+  const tomlLines = toml.split('\n');
+
+  for (let i = 0; i < tomlLines.length; i++) {
+    const funcMatch = tomlLines[i].match(/^\[functions\."([^"]+)"\]/);
+    if (!funcMatch) continue;
+
+    // Check next line for schedule
+    const schedLine = tomlLines[i + 1] || '';
+    const schedMatch = schedLine.match(/^\s*schedule\s*=\s*"([^"]+)"/);
+    if (!schedMatch) continue;
+
+    // Collect comment lines directly above (stop at any blank or non-comment line)
+    const commentLines = [];
+    for (let j = i - 1; j >= 0; j--) {
+      const line = tomlLines[j].trim();
+      if (line.startsWith('#') && !line.startsWith('# ===')) {
+        commentLines.unshift(line.replace(/^#\s*/, ''));
+      } else {
+        break;
+      }
+    }
+
+    const title = commentLines[0] || funcMatch[1];
+    const description = commentLines.slice(1).join(' ').trim();
+
+    cronJobs.push({
+      name: funcMatch[1],
+      schedule: schedMatch[1],
+      title,
+      description,
+    });
+  }
+
+  // Scan netlify/functions for all serverless functions
+  const functionsDir = path.join(ROOT, 'netlify', 'functions');
+  const functions = [];
+  if (fs.existsSync(functionsDir)) {
+    for (const file of fs.readdirSync(functionsDir)) {
+      if (!/\.(js|ts)$/.test(file)) continue;
+      const name = file.replace(/\.(js|ts)$/, '');
+      const isCron = cronJobs.some((c) => c.name === name);
+      const content = fs.readFileSync(path.join(functionsDir, file), 'utf8');
+
+      // Try to extract the first JSDoc or comment block
+      const docMatch = content.match(/\/\*\*[\s\S]*?\*\//);
+      const desc = docMatch
+        ? docMatch[0]
+            .replace(/\/\*\*|\*\//g, '')
+            .replace(/^\s*\*\s?/gm, '')
+            .trim()
+            .split('\n')[0]
+        : '';
+
+      functions.push({ name, file, isCron, description: desc });
+    }
+  }
+
+  let md = `# System Automation
+
+<!-- AUTO-GENERATED from netlify.toml and netlify/functions/ — do not edit manually -->
+<!-- To update: modify cron schedules or functions, then run: node scripts/generate-wiki.js -->
+
+ToolTime Pro runs automated background tasks via Netlify Scheduled Functions and serverless endpoints.
+
+---
+
+## Scheduled Jobs (Cron)
+
+These run automatically on a schedule defined in \`netlify.toml\`:
+
+| Job | Schedule | Description |
+|-----|----------|-------------|
+`;
+
+  for (const job of cronJobs) {
+    md += `| **${job.name}** | \`${job.schedule}\` | ${job.title}${job.description ? '. ' + job.description : ''} |\n`;
+  }
+
+  md += `
+### Schedule Reference
+
+| Pattern | Meaning |
+|---------|---------|
+| \`*/15 * * * *\` | Every 15 minutes |
+| \`0 7 * * *\` | Daily at 7:00 AM UTC |
+| \`0 9 * * *\` | Daily at 9:00 AM UTC |
+| \`0 7 * * 1\` | Every Monday at 7:00 AM UTC |
+| \`0 8 * * 1\` | Every Monday at 8:00 AM UTC |
+| \`0 6 */3 * *\` | Every 3 days at 6:00 AM UTC |
+
+---
+
+## Serverless Functions
+
+All functions live in \`netlify/functions/\` and are deployed automatically:
+
+| Function | Type | Description |
+|----------|------|-------------|
+`;
+
+  for (const fn of functions.sort((a, b) => a.name.localeCompare(b.name))) {
+    const type = fn.isCron ? 'Scheduled' : 'On-demand';
+    md += `| **${fn.name}** | ${type} | ${fn.description} |\n`;
+  }
+
+  md += `
+---
+
+> **Total:** ${cronJobs.length} scheduled jobs, ${functions.filter((f) => !f.isCron).length} on-demand functions
+
+_Last generated: ${new Date().toISOString().split('T')[0]}_
+`;
+
+  return md;
+}
+
+// ============================================================
+// Main
+// ============================================================
+
+function main() {
+  console.log('ToolTime Pro — Wiki Content Generator\n');
+
+  // Ensure wiki directory exists
+  if (!fs.existsSync(WIKI_DIR)) {
+    fs.mkdirSync(WIKI_DIR, { recursive: true });
+  }
+
+  // 1. Pricing
+  console.log('Generating Pricing & Plans...');
+  const products = extractProducts();
+  console.log(`  Found ${products.length} products`);
+  const pricingMd = generatePricingPage(products);
+  writeWikiPage('Pricing-and-Plans.md', pricingMd);
+
+  // 2. API Reference
+  console.log('Generating API Reference...');
+  const apiMd = generateApiReference();
+  writeWikiPage('API-Reference.md', apiMd);
+
+  // 3. System Automation
+  console.log('Generating System Automation...');
+  const automationMd = generateSystemAutomation();
+  writeWikiPage('System-Automation.md', automationMd);
+
+  console.log('\nDone!');
+  if (DRY_RUN) {
+    console.log('(Dry run — no files were written)');
+  }
+}
+
+main();

--- a/scripts/sync-to-crisp.js
+++ b/scripts/sync-to-crisp.js
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+/**
+ * ToolTime Pro — Crisp Knowledge Base Sync
+ *
+ * Syncs wiki markdown files to Crisp Helpdesk (Knowledge Base) articles.
+ * Each wiki/*.md file becomes a Crisp helpdesk article, organized into categories.
+ *
+ * Required env vars:
+ *   CRISP_API_IDENTIFIER  — Crisp API plugin identifier (from marketplace.crisp.chat)
+ *   CRISP_API_KEY         — Crisp API plugin secret key
+ *   CRISP_WEBSITE_ID      — Your Crisp website ID
+ *
+ * Usage:
+ *   CRISP_API_IDENTIFIER=xxx CRISP_API_KEY=yyy CRISP_WEBSITE_ID=zzz node scripts/sync-to-crisp.js
+ *   node scripts/sync-to-crisp.js --dry-run   (prints what would be synced, no API calls)
+ *
+ * Crisp Helpdesk API docs: https://docs.crisp.chat/references/rest-api/v1/#list-helpdesk-articles
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const WIKI_DIR = path.resolve(__dirname, '..', 'wiki');
+const LOCALE = 'en';
+
+// Map wiki filenames to Crisp helpdesk categories
+const CATEGORY_MAP = {
+  'Getting Started': [
+    'Home.md',
+    'Getting-Started.md',
+    'Pricing-and-Plans.md',
+  ],
+  'Core Features': [
+    'Jobs-and-Scheduling.md',
+    'Online-Booking.md',
+    'Customers-and-Leads.md',
+    'Quotes-and-Estimates.md',
+    'Invoicing-and-Payments.md',
+    'Payment-Plans-Guide.md',
+    'Time-Tracking.md',
+    'Adding-Services.md',
+  ],
+  'AI & Website': [
+    'Jenny-AI.md',
+    'Website-and-Blog.md',
+    'Customer-Portal.md',
+  ],
+  'Team & Compliance': [
+    'Team-Management.md',
+    'Mobile-and-Worker-App.md',
+    'ToolTime-Shield.md',
+    'Reports-and-Analytics.md',
+  ],
+  'Settings & Support': [
+    'Settings-and-Integrations.md',
+    'Troubleshooting.md',
+    'FAQ.md',
+  ],
+  'Developer Reference': [
+    'API-Reference.md',
+    'System-Automation.md',
+  ],
+};
+
+// ============================================================
+// Crisp API Client
+// ============================================================
+
+class CrispClient {
+  constructor(identifier, key, websiteId) {
+    this.websiteId = websiteId;
+    this.baseUrl = `https://api.crisp.chat/v1/website/${websiteId}/helpdesk`;
+    this.auth = 'Basic ' + Buffer.from(`${identifier}:${key}`).toString('base64');
+  }
+
+  async request(method, endpoint, body) {
+    const url = `${this.baseUrl}${endpoint}`;
+    const options = {
+      method,
+      headers: {
+        'Authorization': this.auth,
+        'Content-Type': 'application/json',
+        'X-Crisp-Tier': 'plugin',
+      },
+    };
+    if (body) {
+      options.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(url, options);
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Crisp API ${method} ${endpoint}: ${response.status} — ${text}`);
+    }
+    const json = await response.json();
+    return json.data;
+  }
+
+  // --- Categories ---
+
+  async listCategories() {
+    return this.request('GET', `/locale/${LOCALE}/categories/1`);
+  }
+
+  async createCategory(name, order) {
+    return this.request('POST', `/locale/${LOCALE}/category`, {
+      name,
+      order,
+    });
+  }
+
+  // --- Articles ---
+
+  async listArticles(pageNumber = 1) {
+    return this.request('GET', `/locale/${LOCALE}/articles/${pageNumber}`);
+  }
+
+  async getAllArticles() {
+    const all = [];
+    let page = 1;
+    while (true) {
+      try {
+        const articles = await this.listArticles(page);
+        if (!articles || articles.length === 0) break;
+        all.push(...articles);
+        page++;
+      } catch {
+        break;
+      }
+    }
+    return all;
+  }
+
+  async createArticle(title, content, categoryId, order) {
+    return this.request('POST', `/locale/${LOCALE}/article`, {
+      title,
+      content,
+      category_id: categoryId,
+      order,
+      status: 'published',
+    });
+  }
+
+  async updateArticle(articleId, title, content, categoryId) {
+    return this.request('PATCH', `/locale/${LOCALE}/article/${articleId}`, {
+      title,
+      content,
+      category_id: categoryId,
+      status: 'published',
+    });
+  }
+}
+
+// ============================================================
+// Markdown → HTML (basic conversion for Crisp)
+// ============================================================
+
+function markdownToBasicHtml(md) {
+  let html = md;
+
+  // Remove the auto-generated comment markers
+  html = html.replace(/<!-- .*? -->\n?/g, '');
+
+  // Headers
+  html = html.replace(/^#### (.+)$/gm, '<h4>$1</h4>');
+  html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+  html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+  html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+
+  // Bold and italic
+  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
+
+  // Inline code
+  html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+  // Links — convert GitHub wiki links to relative
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+
+  // Horizontal rules
+  html = html.replace(/^---$/gm, '<hr>');
+
+  // Blockquotes
+  html = html.replace(/^>\s*(.+)$/gm, '<blockquote>$1</blockquote>');
+
+  // Tables — convert to HTML tables
+  const lines = html.split('\n');
+  const result = [];
+  let inTable = false;
+  let headerDone = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.startsWith('|') && line.endsWith('|')) {
+      const cells = line.split('|').filter((c) => c.trim() !== '');
+
+      // Check if next line is separator
+      if (!inTable) {
+        inTable = true;
+        headerDone = false;
+        result.push('<table>');
+        result.push('<thead><tr>');
+        for (const cell of cells) {
+          result.push(`<th>${cell.trim()}</th>`);
+        }
+        result.push('</tr></thead>');
+        continue;
+      }
+
+      // Skip separator line
+      if (cells.every((c) => /^[-:]+$/.test(c.trim()))) {
+        headerDone = true;
+        result.push('<tbody>');
+        continue;
+      }
+
+      // Data row
+      result.push('<tr>');
+      for (const cell of cells) {
+        result.push(`<td>${cell.trim()}</td>`);
+      }
+      result.push('</tr>');
+    } else {
+      if (inTable) {
+        if (headerDone) result.push('</tbody>');
+        result.push('</table>');
+        inTable = false;
+        headerDone = false;
+      }
+
+      // Unordered list
+      if (/^[-*]\s+/.test(line)) {
+        result.push(`<li>${line.replace(/^[-*]\s+/, '')}</li>`);
+      } else if (line === '') {
+        result.push('<br>');
+      } else if (!line.startsWith('<')) {
+        result.push(`<p>${line}</p>`);
+      } else {
+        result.push(line);
+      }
+    }
+  }
+  if (inTable) {
+    if (headerDone) result.push('</tbody>');
+    result.push('</table>');
+  }
+
+  return result.join('\n');
+}
+
+// ============================================================
+// Sync Logic
+// ============================================================
+
+function getTitleFromMd(content) {
+  const match = content.match(/^#\s+(.+)$/m);
+  return match ? match[1].trim() : null;
+}
+
+async function main() {
+  const identifier = process.env.CRISP_API_IDENTIFIER;
+  const key = process.env.CRISP_API_KEY;
+  const websiteId = process.env.CRISP_WEBSITE_ID;
+
+  if (!DRY_RUN && (!identifier || !key || !websiteId)) {
+    console.error('Missing required env vars: CRISP_API_IDENTIFIER, CRISP_API_KEY, CRISP_WEBSITE_ID');
+    console.error('Run with --dry-run to test without API access.');
+    process.exit(1);
+  }
+
+  console.log(`ToolTime Pro — Crisp Knowledge Base Sync${DRY_RUN ? ' (DRY RUN)' : ''}\n`);
+
+  const client = DRY_RUN ? null : new CrispClient(identifier, key, websiteId);
+
+  // Build file → category mapping
+  const fileToCategory = {};
+  for (const [catName, files] of Object.entries(CATEGORY_MAP)) {
+    for (const file of files) {
+      fileToCategory[file] = catName;
+    }
+  }
+
+  // Read all wiki files
+  const wikiFiles = fs.readdirSync(WIKI_DIR).filter((f) => f.endsWith('.md'));
+  console.log(`Found ${wikiFiles.length} wiki files\n`);
+
+  if (DRY_RUN) {
+    console.log('Would sync the following articles to Crisp:\n');
+    for (const file of wikiFiles) {
+      const content = fs.readFileSync(path.join(WIKI_DIR, file), 'utf8');
+      const title = getTitleFromMd(content) || file.replace('.md', '').replace(/-/g, ' ');
+      const category = fileToCategory[file] || 'Uncategorized';
+      console.log(`  [${category}] ${title} (${file})`);
+    }
+    console.log('\nDry run complete. Set CRISP_API_IDENTIFIER, CRISP_API_KEY, and CRISP_WEBSITE_ID to sync.');
+    return;
+  }
+
+  // Get or create categories in Crisp
+  console.log('Syncing categories...');
+  let existingCategories = [];
+  try {
+    existingCategories = await client.listCategories() || [];
+  } catch {
+    existingCategories = [];
+  }
+
+  const categoryIds = {};
+  let order = 0;
+  for (const catName of Object.keys(CATEGORY_MAP)) {
+    const existing = existingCategories.find((c) => c.name === catName);
+    if (existing) {
+      categoryIds[catName] = existing.category_id;
+      console.log(`  Exists: ${catName}`);
+    } else {
+      const created = await client.createCategory(catName, order);
+      categoryIds[catName] = created.category_id;
+      console.log(`  Created: ${catName}`);
+    }
+    order++;
+  }
+
+  // Get existing articles to determine create vs update
+  console.log('\nFetching existing articles...');
+  const existingArticles = await client.getAllArticles();
+  const articlesByTitle = {};
+  for (const a of existingArticles) {
+    articlesByTitle[a.title] = a;
+  }
+
+  // Sync each wiki file
+  console.log('\nSyncing articles...');
+  let created = 0;
+  let updated = 0;
+  let articleOrder = 0;
+
+  for (const file of wikiFiles) {
+    const mdContent = fs.readFileSync(path.join(WIKI_DIR, file), 'utf8');
+    const title = getTitleFromMd(mdContent) || file.replace('.md', '').replace(/-/g, ' ');
+    const htmlContent = markdownToBasicHtml(mdContent);
+    const category = fileToCategory[file] || 'Uncategorized';
+    const categoryId = categoryIds[category];
+
+    if (!categoryId) {
+      console.log(`  Skipped: ${title} (no category ID for "${category}")`);
+      continue;
+    }
+
+    const existing = articlesByTitle[title];
+    if (existing) {
+      await client.updateArticle(existing.article_id, title, htmlContent, categoryId);
+      console.log(`  Updated: ${title}`);
+      updated++;
+    } else {
+      await client.createArticle(title, htmlContent, categoryId, articleOrder);
+      console.log(`  Created: ${title}`);
+      created++;
+    }
+    articleOrder++;
+
+    // Rate limiting: Crisp API has limits, small delay between calls
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+
+  console.log(`\nDone! Created: ${created}, Updated: ${updated}, Total: ${created + updated}`);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -1,0 +1,270 @@
+# API Reference
+
+<!-- AUTO-GENERATED from src/app/api/ directory scan — do not edit manually -->
+<!-- To update: add/modify API routes, then run: node scripts/generate-wiki.js -->
+
+Complete list of ToolTime Pro API endpoints, auto-generated from source code.
+
+**Base URL:** `https://app.tooltimepro.com` (production) or `http://localhost:3000` (local dev)
+
+---
+
+## Admin
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/admin/companies` | `GET` `POST` | `src/app/api/admin/companies/route.ts` |
+| `/api/admin/companies/[id]` | `GET` | `src/app/api/admin/companies/[id]/route.ts` |
+| `/api/admin/companies/[id]/actions` | `POST` | `src/app/api/admin/companies/[id]/actions/route.ts` |
+| `/api/admin/settings/admins` | `GET` `POST` `DELETE` | `src/app/api/admin/settings/admins/route.ts` |
+| `/api/admin/stats` | `GET` | `src/app/api/admin/stats/route.ts` |
+| `/api/admin/verify` | `GET` | `src/app/api/admin/verify/route.ts` |
+
+## Ai Photo Analysis
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/ai-photo-analysis` | `POST` | `src/app/api/ai-photo-analysis/route.ts` |
+
+## Ai Quote
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/ai-quote` | `POST` | `src/app/api/ai-quote/route.ts` |
+
+## Auth
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/auth/2fa/check-device` | `POST` | `src/app/api/auth/2fa/check-device/route.ts` |
+| `/api/auth/2fa/send-code` | `POST` | `src/app/api/auth/2fa/send-code/route.ts` |
+| `/api/auth/2fa/settings` | `GET` `POST` `DELETE` | `src/app/api/auth/2fa/settings/route.ts` |
+| `/api/auth/2fa/verify-code` | `POST` | `src/app/api/auth/2fa/verify-code/route.ts` |
+| `/api/auth/check-needs-password` | `GET` | `src/app/api/auth/check-needs-password/route.ts` |
+| `/api/auth/password-setup-complete` | `POST` | `src/app/api/auth/password-setup-complete/route.ts` |
+| `/api/auth/session-guard` | `GET` `POST` | `src/app/api/auth/session-guard/route.ts` |
+| `/api/auth/signout-all` | `POST` | `src/app/api/auth/signout-all/route.ts` |
+
+## Blog
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/blog` | `GET` `POST` | `src/app/api/blog/route.js` |
+| `/api/blog/ai-generate` | `POST` | `src/app/api/blog/ai-generate/route.js` |
+
+## Bookings
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/bookings` | `POST` | `src/app/api/bookings/route.js` |
+
+## Checkout
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/checkout` | `GET` | `src/app/api/checkout/route.js` |
+| `/api/checkout/session` | `GET` | `src/app/api/checkout/session/route.js` |
+
+## Google Calendar
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/google-calendar/callback` | `GET` | `src/app/api/google-calendar/callback/route.js` |
+| `/api/google-calendar/connect` | `GET` | `src/app/api/google-calendar/connect/route.js` |
+| `/api/google-calendar/disconnect` | `POST` | `src/app/api/google-calendar/disconnect/route.js` |
+| `/api/google-calendar/sync` | `POST` | `src/app/api/google-calendar/sync/route.js` |
+
+## Invoice
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/invoice/pay` | `POST` | `src/app/api/invoice/pay/route.ts` |
+| `/api/invoice/send` | `POST` | `src/app/api/invoice/send/route.ts` |
+
+## Jenny Actions
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/jenny-actions` | `GET` `POST` | `src/app/api/jenny-actions/route.ts` |
+
+## Jenny Exec
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/jenny-exec/chat` | `POST` | `src/app/api/jenny-exec/chat/route.ts` |
+
+## Jenny Pro
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/jenny-pro/settings` | `GET` `POST` | `src/app/api/jenny-pro/settings/route.js` |
+| `/api/jenny-pro/sms-webhook` | `POST` | `src/app/api/jenny-pro/sms-webhook/route.js` |
+
+## Jobs
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/jobs/assign` | `POST` | `src/app/api/jobs/assign/route.ts` |
+| `/api/jobs/list` | `GET` | `src/app/api/jobs/list/route.ts` |
+| `/api/jobs/save` | `POST` | `src/app/api/jobs/save/route.ts` |
+
+## Material Price Logs
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/material-price-logs` | `GET` `POST` | `src/app/api/material-price-logs/route.ts` |
+
+## Platform Blog
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/platform-blog` | `GET` `POST` `PATCH` `DELETE` | `src/app/api/platform-blog/route.js` |
+| `/api/platform-blog/ai-generate` | `POST` | `src/app/api/platform-blog/ai-generate/route.js` |
+
+## Portal
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/portal` | `GET` `POST` | `src/app/api/portal/route.ts` |
+
+## Quickbooks
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/quickbooks/callback` | `GET` | `src/app/api/quickbooks/callback/route.ts` |
+| `/api/quickbooks/connect` | `GET` | `src/app/api/quickbooks/connect/route.ts` |
+| `/api/quickbooks/disconnect` | `POST` | `src/app/api/quickbooks/disconnect/route.ts` |
+| `/api/quickbooks/sync` | `POST` | `src/app/api/quickbooks/sync/route.ts` |
+
+## Quote
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/quote/delete` | `POST` | `src/app/api/quote/delete/route.ts` |
+| `/api/quote/deposit-pay` | `POST` | `src/app/api/quote/deposit-pay/route.ts` |
+| `/api/quote/notify-approval` | `POST` | `src/app/api/quote/notify-approval/route.ts` |
+| `/api/quote/notify-cancellation` | `POST` | `src/app/api/quote/notify-cancellation/route.ts` |
+| `/api/quote/notify-scheduling` | `POST` | `src/app/api/quote/notify-scheduling/route.ts` |
+| `/api/quote/public` | `GET` | `src/app/api/quote/public/route.ts` |
+| `/api/quote/request-scheduling` | `POST` | `src/app/api/quote/request-scheduling/route.ts` |
+| `/api/quote/respond` | `POST` | `src/app/api/quote/respond/route.ts` |
+| `/api/quote/save` | `POST` | `src/app/api/quote/save/route.ts` |
+| `/api/quote/save-items` | `POST` | `src/app/api/quote/save-items/route.ts` |
+| `/api/quote/send` | `POST` | `src/app/api/quote/send/route.ts` |
+
+## Reset Password
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/reset-password` | `POST` | `src/app/api/reset-password/route.ts` |
+
+## Reviews
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/reviews` | `GET` `POST` | `src/app/api/reviews/route.js` |
+| `/api/reviews/track` | `GET` | `src/app/api/reviews/track/route.ts` |
+
+## Routes
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/routes/optimize` | `POST` | `src/app/api/routes/optimize/route.ts` |
+| `/api/routes/saved` | `GET` `POST` | `src/app/api/routes/saved/route.ts` |
+| `/api/routes/saved/[id]` | `GET` `DELETE` | `src/app/api/routes/saved/[id]/route.ts` |
+| `/api/routes/settings` | `GET` `PUT` | `src/app/api/routes/settings/route.ts` |
+| `/api/routes/worker/[id]` | `GET` | `src/app/api/routes/worker/[id]/route.ts` |
+
+## Send Confirmation Email
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/send-confirmation-email` | `POST` | `src/app/api/send-confirmation-email/route.ts` |
+
+## Send Team Invite
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/send-team-invite` | `POST` | `src/app/api/send-team-invite/route.ts` |
+
+## Send Welcome Email
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/send-welcome-email` | `POST` | `src/app/api/send-welcome-email/route.ts` |
+
+## Signup
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/signup` | `POST` | `src/app/api/signup/route.ts` |
+
+## Sms
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/sms` | `GET` `POST` | `src/app/api/sms/route.js` |
+
+## Stripe
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/stripe/connect` | `POST` | `src/app/api/stripe/connect/route.ts` |
+| `/api/stripe/connect/callback` | `POST` | `src/app/api/stripe/connect/callback/route.ts` |
+| `/api/stripe/connect/status` | `GET` | `src/app/api/stripe/connect/status/route.ts` |
+| `/api/stripe/setup-products` | `GET` `POST` | `src/app/api/stripe/setup-products/route.js` |
+
+## Supplier Pricing
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/supplier-pricing` | `GET` `POST` | `src/app/api/supplier-pricing/route.ts` |
+
+## Team Member
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/team-member/create` | `POST` | `src/app/api/team-member/create/route.ts` |
+| `/api/team-member/delete` | `POST` | `src/app/api/team-member/delete/route.ts` |
+| `/api/team-member/toggle-status` | `POST` | `src/app/api/team-member/toggle-status/route.ts` |
+| `/api/team-member/update-email` | `POST` | `src/app/api/team-member/update-email/route.ts` |
+
+## Trial Reminders
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/trial-reminders` | `GET` | `src/app/api/trial-reminders/route.ts` |
+
+## Webhook
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/webhook/stripe` | `POST` | `src/app/api/webhook/stripe/route.js` |
+| `/api/webhook/stripe-connect` | `POST` | `src/app/api/webhook/stripe-connect/route.ts` |
+
+## Website Builder
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/website-builder/create-site` | `POST` | `src/app/api/website-builder/create-site/route.js` |
+| `/api/website-builder/delete-site` | `DELETE` | `src/app/api/website-builder/delete-site/route.js` |
+| `/api/website-builder/domain-register` | `POST` | `src/app/api/website-builder/domain-register/route.js` |
+| `/api/website-builder/domain-search` | `POST` | `src/app/api/website-builder/domain-search/route.js` |
+| `/api/website-builder/leads` | `POST` | `src/app/api/website-builder/leads/route.js` |
+| `/api/website-builder/public-site` | `GET` | `src/app/api/website-builder/public-site/route.js` |
+| `/api/website-builder/publish-status` | `GET` | `src/app/api/website-builder/publish-status/route.js` |
+| `/api/website-builder/status` | `GET` | `src/app/api/website-builder/status/route.js` |
+| `/api/website-builder/stock-photos` | `GET` | `src/app/api/website-builder/stock-photos/route.js` |
+| `/api/website-builder/update-site` | `PUT` | `src/app/api/website-builder/update-site/route.js` |
+
+## Workforce
+
+| Endpoint | Methods | Source |
+|----------|---------|--------|
+| `/api/workforce` | `GET` `POST` | `src/app/api/workforce/route.ts` |
+
+---
+
+> **Total endpoints:** 89 routes across 33 groups
+
+_Last generated: 2026-04-09_

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -63,6 +63,17 @@ ToolTime Pro is an AI-powered field service management platform built for contra
 
 ---
 
+## Developer Reference
+
+_These pages are auto-generated from source code and stay up to date automatically._
+
+| Guide | What You'll Learn |
+|-------|-------------------|
+| [API Reference](API-Reference) | Complete list of API endpoints with methods and source files |
+| [System Automation](System-Automation) | Cron jobs, scheduled tasks, and serverless functions |
+
+---
+
 ## Need Help?
 
 - **Email:** support@tooltimepro.com

--- a/wiki/Pricing-and-Plans.md
+++ b/wiki/Pricing-and-Plans.md
@@ -1,5 +1,8 @@
 # Pricing & Plans
 
+<!-- AUTO-GENERATED from scripts/setup-stripe-products.js — do not edit manually -->
+<!-- To update: change PRODUCTS in setup-stripe-products.js, then run: node scripts/generate-wiki.js -->
+
 ToolTime Pro offers three core plans, standalone options, and powerful add-ons. No surprise per-user fees — competitors charge $20/vehicle or $250+/technician. We don't.
 
 ---
@@ -8,7 +11,7 @@ ToolTime Pro offers three core plans, standalone options, and powerful add-ons. 
 
 | Feature | Starter — $49/mo | Pro — $79/mo | Elite — $129/mo |
 |---------|:-----------------:|:------------:|:----------------:|
-| **Annual Price** | $490/yr | $790/yr | $1,290/yr |
+| **Annual Price** | $490/yr | $790/yr | $1290/yr |
 | **Workers** | Owner + 2 | Up to 15 | Unlimited |
 | Professional website | 1 page | 3 pages | 5 pages |
 | Online booking page | Yes | Yes | Yes |
@@ -45,8 +48,8 @@ For businesses that only need one feature:
 
 | Plan | Price | What's Included |
 |------|-------|-----------------|
-| **Booking Only** | $15/mo ($150/yr) | Online booking page, customer scheduling, reminders |
-| **Invoicing Only** | $15/mo ($150/yr) | Professional invoices, card payments, payment tracking |
+| **Booking Only** | $15/mo ($150/yr) | Online booking page only. For businesses that just need scheduling. |
+| **Invoicing Only** | $15/mo ($150/yr) | Invoicing and card payments only. For businesses that just need to get paid. |
 
 ---
 
@@ -56,9 +59,9 @@ Jenny AI is your AI-powered back-office assistant. Every plan includes access to
 
 | Tier | Price | Capabilities |
 |------|-------|-------------|
-| **Jenny Lite** | Free (included) | 24/7 website chatbot, lead capture, FAQ answering, bilingual (English/Spanish) |
-| **Jenny Pro** | $49/mo ($490/yr) | AI phone answering 24/7, SMS messaging, bilingual voice, direct booking, emergency escalation |
-| **Jenny Exec Admin** | $79/mo ($790/yr) | Compliance advisor, HR law monitoring, workforce analytics, proactive business insights |
+| **Jenny Lite** | $19/mo ($190/yr) | 24/7 website chatbot. Lead capture, FAQ answering, appointment booking. Bilingual English/Spanish. Included free with all plans. |
+| **Jenny Pro** | $49/mo ($490/yr) | AI phone answering 24/7 with bilingual voice. SMS messaging, direct booking, emergency escalation. Included with Elite. |
+| **Jenny Exec Admin** | $79/mo ($790/yr) | Compliance advisor, HR law monitoring, workforce analytics, proactive business insights. |
 
 ---
 
@@ -68,12 +71,12 @@ Extend your plan with powerful add-ons:
 
 | Add-On | Monthly | Annual | Description |
 |--------|---------|--------|-------------|
-| **Website Builder** | $25 | $250/yr | Custom branded landing page built for you |
-| **Extra Website Page** | $10 | $100/yr | Additional pages for your site |
-| **Compliance Autopilot** | $29 | $290/yr | Automated compliance monitoring, law-change alerts, certification reminders |
-| **QuickBooks Sync** | $12 | $120/yr | Two-way sync with QuickBooks Online (invoices, payments, customers) |
-| **Customer Portal Pro** | $24 | $240/yr | Live job tracker, before/after photos, messaging, document vault, service history |
-| **Extra Worker** | $7/mo | — | Per additional worker beyond your plan limit |
+| **Website Builder** | $25 | $250/yr | Custom landing page built for your business. |
+| **Compliance Autopilot** | $29 | $290/yr | Automated compliance monitoring, law-change alerts, and cert renewal reminders. |
+| **Extra Website Page** | $10 | $100/yr | Add additional pages to your ToolTime Pro website. |
+| **QuickBooks Sync** | $12 | $120/yr | Two-way sync with QuickBooks Online. Invoices, payments, and customers auto-sync. |
+| **Customer Portal Pro** | $24 | $240/yr | Branded customer portal: job tracker, photo gallery, messaging, document vault, service history. Included with Elite. |
+| **Extra Worker/Technician** | $7 | — | Add additional workers beyond your plan limit. $7/user/month. |
 
 ---
 
@@ -81,15 +84,15 @@ Extend your plan with powerful add-ons:
 
 | Service | Price | What's Included |
 |---------|-------|-----------------|
-| **Assisted Onboarding** | $199 | Guided setup call, service catalog config, team invites, booking page setup |
-| **White-Glove Setup** | $499 | Full account configuration, data migration, custom website build, training session |
+| **Assisted Onboarding** | $199 | Guided setup with our team. Account setup, customer import, 30-minute training call. |
+| **White Glove Setup** | $499 | Full done-for-you setup. Website design, data import, 1-hour training, 30-day priority support. |
 
 ---
 
 ## Choosing the Right Plan
 
-- **Solo operators or tiny teams (1–3 people):** Start with **Starter** at $49/mo
-- **Growing businesses (4–15 workers):** Go with **Pro** at $79/mo for scheduling, reviews, and compliance
+- **Solo operators or tiny teams (1-3 people):** Start with **Starter** at $49/mo
+- **Growing businesses (4-15 workers):** Go with **Pro** at $79/mo for scheduling, reviews, and compliance
 - **Established operations (15+ workers):** Choose **Elite** at $129/mo for dispatch board, route optimization, and unlimited workers
 - **Just need booking or invoicing?** Try a **Standalone** plan at $15/mo
 
@@ -97,7 +100,7 @@ Extend your plan with powerful add-ons:
 
 ## Upgrading or Downgrading
 
-- Go to **Settings** → **Billing** in your dashboard
+- Go to **Settings** > **Billing** in your dashboard
 - Changes take effect at the start of your next billing cycle
 - Upgrading mid-cycle is prorated — you only pay the difference
 - All your data is preserved when changing plans

--- a/wiki/System-Automation.md
+++ b/wiki/System-Automation.md
@@ -1,0 +1,62 @@
+# System Automation
+
+<!-- AUTO-GENERATED from netlify.toml and netlify/functions/ — do not edit manually -->
+<!-- To update: modify cron schedules or functions, then run: node scripts/generate-wiki.js -->
+
+ToolTime Pro runs automated background tasks via Netlify Scheduled Functions and serverless endpoints.
+
+---
+
+## Scheduled Jobs (Cron)
+
+These run automatically on a schedule defined in `netlify.toml`:
+
+| Job | Schedule | Description |
+|-----|----------|-------------|
+| **jenny-actions-cron** | `*/15 * * * *` | Jenny Autonomous Actions — runs every 15 minutes. Checks for: unassigned jobs, cold leads to follow up, overdue invoices, completed jobs needing cost analysis |
+| **hr-law-update-cron** | `0 8 * * 1` | HR Law Update Check — runs every Monday at 8am UTC. Checks state employment law freshness (wages, classification, breaks) Alerts when compliance rules are older than 6 months |
+| **workforce-compliance-cron** | `0 7 * * 1` | Workforce Compliance — runs every Monday at 7am UTC. Checks: cert expirations, insurance expiry, missing W-9s, classification review cycles, contract end dates |
+| **daily-business-cron** | `0 7 * * *` | Daily Business Checks — runs every day at 7am UTC. Checks: quote expirations, contractor payment approvals, compliance alert escalation, review requests |
+| **trial-reminders-cron** | `0 9 * * *` | Trial Reminders — runs once per day at 9am UTC. Sends trial welcome, reminder, and expiration emails |
+| **supabase-keepalive-cron** | `0 6 */3 * *` | Supabase Keep-Alive — runs every 3 days at 6am UTC. Pings Supabase to prevent free-tier project from pausing (7-day inactivity limit) |
+
+### Schedule Reference
+
+| Pattern | Meaning |
+|---------|---------|
+| `*/15 * * * *` | Every 15 minutes |
+| `0 7 * * *` | Daily at 7:00 AM UTC |
+| `0 9 * * *` | Daily at 9:00 AM UTC |
+| `0 7 * * 1` | Every Monday at 7:00 AM UTC |
+| `0 8 * * 1` | Every Monday at 8:00 AM UTC |
+| `0 6 */3 * *` | Every 3 days at 6:00 AM UTC |
+
+---
+
+## Serverless Functions
+
+All functions live in `netlify/functions/` and are deployed automatically:
+
+| Function | Type | Description |
+|----------|------|-------------|
+| **ai-chatbot** | On-demand |  |
+| **ai-compliance** | On-demand |  |
+| **ai-helper** | On-demand |  |
+| **ai-photo-analysis** | On-demand |  |
+| **ai-quote** | On-demand |  |
+| **ai-review** | On-demand |  |
+| **booking-store** | On-demand |  |
+| **checkout** | On-demand |  |
+| **daily-business-cron** | Scheduled |  |
+| **hr-law-update-cron** | Scheduled |  |
+| **jenny-actions-cron** | Scheduled |  |
+| **stripe-price-management** | On-demand | Stripe Price Management — Admin-only Netlify Function |
+| **supabase-keepalive-cron** | Scheduled |  |
+| **trial-reminders-cron** | Scheduled |  |
+| **workforce-compliance-cron** | Scheduled |  |
+
+---
+
+> **Total:** 6 scheduled jobs, 9 on-demand functions
+
+_Last generated: 2026-04-09_


### PR DESCRIPTION
Add a wiki content generator (scripts/generate-wiki.js) that auto-generates Pricing, API Reference, and System Automation wiki pages from source code. Add Crisp Knowledge Base sync (scripts/sync-to-crisp.js) to push wiki content to Crisp helpdesk. GitHub Actions workflow triggers on relevant code changes, regenerates wiki, and syncs to both GitHub Wiki and Crisp.

https://claude.ai/code/session_018z9UdaccGX8hZiz3KppPCa