### PR TITLE
Persist session inactivity timer across browser restarts

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useEffect, useState, useRef, useMemo, useCal
 import { User, Session } from '@supabase/supabase-js';
 import { supabase, isSupabaseConfigured } from '@/lib/supabase';
 import { User as DbUser, Company } from '@/types/database';
+import { LAST_ACTIVITY_KEY, DEFAULT_TIMEOUT_MS } from '@/hooks/useSessionTimeout';
 
 // Timeout for auth initialization to prevent infinite loading
 const AUTH_TIMEOUT_MS = 5000;
@@ -129,13 +130,36 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (error) {
           console.error('Error getting session:', error);
           setAuthError(error.message);
-        } else {
-          setSession(initialSession);
-          setUser(initialSession?.user ?? null);
+        } else if (initialSession?.user) {
+          // Check if the session is stale — i.e. the user closed the tab/browser
+          // and has been inactive longer than the session timeout threshold.
+          let sessionStale = false;
+          try {
+            const lastActivity = localStorage.getItem(LAST_ACTIVITY_KEY);
+            if (lastActivity) {
+              const elapsed = Date.now() - Number(lastActivity);
+              if (elapsed > DEFAULT_TIMEOUT_MS) {
+                sessionStale = true;
+              }
+            }
+          } catch {}
 
-          if (initialSession?.user) {
+          if (sessionStale) {
+            // Expired due to inactivity — sign them out so they see the
+            // landing / login page instead of auto-redirecting to the dashboard.
+            console.info('Session expired due to inactivity, signing out');
+            await supabase.auth.signOut();
+            try { localStorage.removeItem(LAST_ACTIVITY_KEY); } catch {}
+            setSession(null);
+            setUser(null);
+          } else {
+            setSession(initialSession);
+            setUser(initialSession.user);
             await fetchUserData(initialSession.user.id);
           }
+        } else {
+          setSession(null);
+          setUser(null);
         }
 
         // Mark as complete and stop loading
@@ -266,6 +290,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return { error };
       }
 
+      // Stamp last-activity so the inactivity timer starts from login
+      try { localStorage.setItem(LAST_ACTIVITY_KEY, String(Date.now())); } catch {}
+
       // Update last_login_at to clear "Pending Activation" status
       if (data.user?.id) {
         await supabase
@@ -284,6 +311,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (!isSupabaseConfigured) return;
 
     await supabase.auth.signOut();
+    try { localStorage.removeItem(LAST_ACTIVITY_KEY); } catch {}
     setUser(null);
     setDbUser(null);
     setCompany(null);

--- a/src/hooks/useSessionTimeout.ts
+++ b/src/hooks/useSessionTimeout.ts
@@ -3,9 +3,12 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 
 // Default: 30 minutes of inactivity before logout
-const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+export const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 // Show warning 5 minutes before logout
 const DEFAULT_WARNING_MS = 5 * 60 * 1000;
+
+// localStorage key for persisting last activity across tab closes / browser restarts
+export const LAST_ACTIVITY_KEY = 'tooltime_last_activity';
 
 const ACTIVITY_EVENTS = [
   'mousedown',
@@ -74,7 +77,9 @@ export function useSessionTimeout({
 
   const startTimers = useCallback(() => {
     clearAllTimers();
-    lastActivityRef.current = Date.now();
+    const now = Date.now();
+    lastActivityRef.current = now;
+    try { localStorage.setItem(LAST_ACTIVITY_KEY, String(now)); } catch {};
 
     // Timer to show the warning
     const warningDelay = timeoutMs - warningMs;


### PR DESCRIPTION
## Summary
This PR implements session persistence across browser restarts by tracking the last user activity timestamp in localStorage. When a user closes and reopens their browser, the app now checks if their session has expired due to inactivity (30 minutes by default) and signs them out accordingly, rather than automatically restoring an expired session.

## Key Changes
- **Export timeout constants** from `useSessionTimeout` hook to share with `AuthContext`:
  - `DEFAULT_TIMEOUT_MS` (30 minutes)
  - `LAST_ACTIVITY_KEY` (localStorage key for persistence)

- **Update AuthContext initialization** to validate session freshness:
  - Check localStorage for last activity timestamp on app startup
  - Compare elapsed time against the inactivity timeout threshold
  - Sign out users if their session has expired due to inactivity
  - Clear localStorage activity record on logout

- **Update useSessionTimeout hook** to persist activity:
  - Write last activity timestamp to localStorage whenever timers are reset
  - Enables inactivity tracking to survive browser restarts

- **Update login flow** to initialize activity tracking:
  - Stamp last activity timestamp in localStorage after successful login
  - Ensures inactivity timer starts fresh from login time

## Implementation Details
- All localStorage operations are wrapped in try-catch blocks to handle quota/permission errors gracefully
- Session staleness check only occurs when an initial session exists; users without sessions are handled separately
- The inactivity check happens during auth initialization before the user is logged in, preventing auto-redirect to dashboard for expired sessions

https://claude.ai/code/session_01YUU87kLZg54ETVTHcyEhth