### PR TITLE
Fix Google Calendar redirect URI to use request headers

### DIFF
--- a/src/app/api/google-calendar/callback/route.js
+++ b/src/app/api/google-calendar/callback/route.js
@@ -5,10 +5,19 @@ export const dynamic = 'force-dynamic'
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || ''
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || ''
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
-const REDIRECT_URI = `${APP_URL}/api/google-calendar/callback`
+
+function getAppUrl(request) {
+  if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL
+  const proto = request.headers.get('x-forwarded-proto') || 'https'
+  const host = request.headers.get('host')
+  if (host) return `${proto}://${host}`
+  return 'https://app.tooltimepro.com'
+}
 
 export async function GET(request) {
+  const APP_URL = getAppUrl(request)
+  const REDIRECT_URI = `${APP_URL}/api/google-calendar/callback`
+
   try {
     const { searchParams } = new URL(request.url)
     const code = searchParams.get('code')

--- a/src/app/api/google-calendar/connect/route.js
+++ b/src/app/api/google-calendar/connect/route.js
@@ -5,10 +5,19 @@ export const dynamic = 'force-dynamic'
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || ''
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || ''
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
-const REDIRECT_URI = `${APP_URL}/api/google-calendar/callback`
+
+function getAppUrl(request) {
+  if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL
+  const proto = request.headers.get('x-forwarded-proto') || 'https'
+  const host = request.headers.get('host')
+  if (host) return `${proto}://${host}`
+  return 'https://app.tooltimepro.com'
+}
 
 export async function GET(request) {
+  const APP_URL = getAppUrl(request)
+  const REDIRECT_URI = `${APP_URL}/api/google-calendar/callback`
+
   try {
     if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET) {
       console.error('Google Calendar environment variables not configured')


### PR DESCRIPTION
## Summary
Updated Google Calendar OAuth callback and connect routes to dynamically determine the application URL from request headers instead of relying solely on environment variables. This ensures the redirect URI matches the actual request origin, fixing OAuth flow issues in different deployment environments.

## Key Changes
- Extracted `getAppUrl()` function that intelligently determines the app URL with the following fallback logic:
  1. Uses `NEXT_PUBLIC_APP_URL` environment variable if set
  2. Falls back to constructing URL from request headers (`x-forwarded-proto` and `host`)
  3. Uses hardcoded fallback `https://app.tooltimepro.com` as last resort
- Updated both `/api/google-calendar/callback` and `/api/google-calendar/connect` routes to call `getAppUrl(request)` at request time instead of using a static module-level constant
- Moved `REDIRECT_URI` calculation into the request handler to use the dynamically determined `APP_URL`

## Implementation Details
- The `x-forwarded-proto` header is used to detect the protocol (http/https) in proxied environments
- The `host` header provides the actual hostname from the incoming request
- This approach ensures OAuth redirects work correctly across localhost development, staging, and production environments without requiring environment variable changes

https://claude.ai/code/session_013WqFLZ7AHScQi3PX9vzbb1