### PR TITLE
Fix stale session check for users with no prior activity timestamp

### DIFF
--- a/src/__tests__/contexts/AuthContext.test.js
+++ b/src/__tests__/contexts/AuthContext.test.js
@@ -87,6 +87,9 @@ describe('AuthContext', () => {
     const mockUser = { id: 'user-123', email: 'test@test.com' };
     const mockSession = { user: mockUser, access_token: 'token' };
 
+    // Simulate recent activity so the session is not treated as stale
+    localStorage.setItem('tooltime_last_activity', String(Date.now()));
+
     supabase.auth.getSession.mockResolvedValue({
       data: { session: mockSession },
       error: null,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -141,6 +141,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
               if (elapsed > DEFAULT_TIMEOUT_MS) {
                 sessionStale = true;
               }
+            } else {
+              // No timestamp recorded — this is a pre-existing session from
+              // before the inactivity check was added, or the key was cleared.
+              // Treat as stale so users aren't auto-logged in indefinitely.
+              sessionStale = true;
             }
           } catch {}
 


### PR DESCRIPTION
When no tooltime_last_activity key exists in localStorage (all existing sessions before this feature), treat the session as stale and sign out. Without this, users who never had the key set would bypass the inactivity check entirely.

Also updates the AuthContext test to set the activity timestamp so the "loads existing session" test simulates a fresh session correctly.

https://claude.ai/code/session_01YUU87kLZg54ETVTHcyEhth