### PR TITLE
Fix Stripe Connect "Failed to create Stripe connection" error

### DIFF
--- a/src/app/api/stripe/connect/route.js
+++ b/src/app/api/stripe/connect/route.js
@@ -90,14 +90,17 @@ export async function POST(request) {
           .eq('id', userData.company_id)
       } catch (createErr) {
         console.error('Failed to create Stripe account:', createErr)
-        const msg = createErr?.message?.includes('api_key')
-          ? 'Stripe API key is invalid. Please contact support.'
-          : 'Failed to create Stripe account. Please try again.'
+        let msg = 'Failed to create Stripe account. Please try again.'
+        if (createErr?.message?.includes('api_key')) {
+          msg = 'Stripe API key is invalid. Please contact support.'
+        } else if (createErr?.type === 'StripeInvalidRequestError' || createErr?.message?.includes('connect')) {
+          msg = 'Stripe Connect is not enabled on this account. Please enable Connect in your Stripe dashboard at https://dashboard.stripe.com/connect/overview'
+        }
         return NextResponse.json({ error: msg }, { status: 500 })
       }
     }
 
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://tooltimepro.com'
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://tooltimepro.com'
 
     // Create onboarding link
     try {


### PR DESCRIPTION
## Summary
- Convert all Stripe Connect API routes from `.ts` to `.js` per project guidelines (TypeScript inference issues with Stripe SDK types)
- Add granular error handling: missing API key, stale account recovery, account creation failures, and account link failures now return specific user-friendly error messages instead of one generic catch-all
- Handle stale Stripe Connect account IDs: if a stored account no longer exists in Stripe, clear it and create a fresh one instead of failing
- Fix URL fallback to use `NEXT_PUBLIC_SITE_URL` when `NEXT_PUBLIC_APP_URL` is not configured
- Add specific error message when Stripe Connect is not enabled on the platform account

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Verify `npm test` passes (413 tests)
- [ ] Verify clicking "Connect Stripe" in dashboard Settings > Integrations redirects to Stripe onboarding
- [ ] Verify specific error messages appear when Stripe is misconfigured (instead of generic "Failed to create Stripe connection")

https://claude.ai/code/session_01Ah1qdYnom1sqHtyVjUjCHz