### PR TITLE
Add payment instructions field to company settings and invoices

### DIFF
--- a/messages/en/misc.json
+++ b/messages/en/misc.json
@@ -205,6 +205,7 @@
       "payNow": "Pay Now",
       "securePayment": "Secure payment powered by Stripe",
       "notes": "Notes",
+      "paymentInstructions": "Other Ways to Pay",
       "questionsCall": "Questions? Call us at",
       "poweredBy": "Powered by"
     },

--- a/messages/es/misc.json
+++ b/messages/es/misc.json
@@ -205,6 +205,7 @@
       "payNow": "Pagar Ahora",
       "securePayment": "Pago seguro con Stripe",
       "notes": "Notas",
+      "paymentInstructions": "Otras Formas de Pago",
       "questionsCall": "Preguntas? Llamanos al",
       "poweredBy": "Desarrollado por"
     },

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -17,6 +17,7 @@ interface CompanyForm {
   zip: string
   website: string
   default_quote_terms: string
+  payment_instructions: string
 }
 
 // Plan display configuration mapping plan IDs to human-readable names and prices
@@ -53,6 +54,7 @@ function SettingsContent() {
     zip: '',
     website: '',
     default_quote_terms: '',
+    payment_instructions: '',
   })
 
   // Initialize form when company data loads
@@ -68,6 +70,7 @@ function SettingsContent() {
         zip: company.zip || '',
         website: company.website || '',
         default_quote_terms: (company as unknown as Record<string, unknown>).default_quote_terms as string || '',
+        payment_instructions: company.payment_instructions || '',
       })
     }
   }, [company])
@@ -128,6 +131,7 @@ function SettingsContent() {
           zip: companyForm.zip,
           website: companyForm.website,
           default_quote_terms: companyForm.default_quote_terms,
+          payment_instructions: companyForm.payment_instructions || null,
           updated_at: new Date().toISOString(),
         }
 
@@ -136,9 +140,10 @@ function SettingsContent() {
         .update(updateData)
         .eq('id', company.id)
 
-      // Retry without default_quote_terms if column doesn't exist
-      if (error?.message?.includes('default_quote_terms')) {
+      // Retry without optional columns if they don't exist yet
+      if (error?.message?.includes('default_quote_terms') || error?.message?.includes('payment_instructions')) {
         delete updateData.default_quote_terms
+        delete updateData.payment_instructions
         const retry = await supabase.from('companies').update(updateData).eq('id', company.id)
         error = retry.error
       }
@@ -370,6 +375,22 @@ function SettingsContent() {
                   />
                   <p className="text-xs text-gray-500 mt-1">
                     These terms will auto-populate on new quotes. You can edit them per quote.
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Payment Instructions
+                  </label>
+                  <textarea
+                    value={companyForm.payment_instructions}
+                    onChange={(e) => setCompanyForm({ ...companyForm, payment_instructions: e.target.value })}
+                    rows={3}
+                    className="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="e.g. Zelle: maria@email.com &#10;Venmo: @MariasLandscaping &#10;Checks payable to: ABC Landscaping LLC"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">
+                    These instructions will appear on your invoices so customers know how to pay you outside of Stripe.
                   </p>
                 </div>
 

--- a/src/app/invoice/[id]/InvoiceViewClient.tsx
+++ b/src/app/invoice/[id]/InvoiceViewClient.tsx
@@ -368,6 +368,16 @@ export default function InvoiceViewClient({ params }: { params: { id: string } }
             </div>
           )}
 
+          {/* Payment Instructions */}
+          {invoice.company?.payment_instructions && invoice.status !== 'paid' && balanceDue > 0 && !paymentSuccess && (
+            <div className="px-6 pb-6">
+              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                <div className="text-sm font-medium text-blue-800 mb-2">{t('paymentInstructions')}</div>
+                <div className="text-sm text-blue-700 whitespace-pre-wrap">{invoice.company.payment_instructions}</div>
+              </div>
+            </div>
+          )}
+
           {/* Notes */}
           {invoice.notes && (
             <div className="px-6 pb-6">

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -37,6 +37,7 @@ export interface Database {
           welcome_email_sent_at: string | null
           is_beta_tester: boolean
           beta_notes: string | null
+          payment_instructions: string | null
           created_at: string
           updated_at: string
         }
@@ -64,6 +65,7 @@ export interface Database {
           welcome_email_sent_at?: string | null
           is_beta_tester?: boolean
           beta_notes?: string | null
+          payment_instructions?: string | null
           created_at?: string
           updated_at?: string
         }
@@ -91,6 +93,7 @@ export interface Database {
           welcome_email_sent_at?: string | null
           is_beta_tester?: boolean
           beta_notes?: string | null
+          payment_instructions?: string | null
           created_at?: string
           updated_at?: string
         }

--- a/supabase/migrations/20260410000000_add_payment_instructions.sql
+++ b/supabase/migrations/20260410000000_add_payment_instructions.sql
@@ -1,0 +1,6 @@
+-- Add payment_instructions column to companies table
+-- Allows contractors to display alternative payment details (Zelle, Venmo, check info, etc.)
+-- on customer-facing invoices
+
+ALTER TABLE companies
+ADD COLUMN IF NOT EXISTS payment_instructions TEXT DEFAULT NULL;


### PR DESCRIPTION
## Summary
This PR adds support for displaying alternative payment methods on invoices. Contractors can now configure payment instructions (e.g., Zelle, Venmo, check details) in their company settings, which will be displayed on customer-facing invoices as an alternative to Stripe payments.

## Key Changes
- **Database**: Added `payment_instructions` column to the `companies` table via migration
- **Settings Page**: Added textarea input field in company settings to allow contractors to enter payment instructions with helpful placeholder text
- **Invoice Display**: Payment instructions now render on invoices when:
  - Instructions are configured
  - Invoice status is not "paid"
  - Balance due is greater than 0
  - Payment hasn't been successfully processed
- **Type Definitions**: Updated TypeScript database types to include the new `payment_instructions` field
- **Internationalization**: Added translation keys for "Other Ways to Pay" in English and Spanish
- **Error Handling**: Enhanced the settings save logic to gracefully handle cases where the new column doesn't exist yet by retrying without optional fields

## Implementation Details
- The payment instructions are displayed in a blue-highlighted box on invoices to distinguish them from other invoice content
- Instructions preserve formatting with `whitespace-pre-wrap` to support multi-line payment methods
- The feature includes backward compatibility by checking for column existence before attempting to save
- Conditional rendering ensures instructions only appear when relevant (unpaid invoices with balance due)

https://claude.ai/code/session_01Rt4fKJK9aLfCxxKRGxV9Bj