### PR TITLE
Fix quote creation failing when deposit columns don't exist in DB

### DIFF
--- a/src/app/api/quote/save/route.ts
+++ b/src/app/api/quote/save/route.ts
@@ -66,13 +66,19 @@ export async function POST(request: NextRequest) {
     if (quoteError) {
       console.error('Error creating quote:', quoteError)
 
-      // If the error is about created_by/sent_by columns not existing,
+      // If the error is about columns not existing in schema cache,
       // retry without those fields
       if (quoteError.message?.includes('created_by') || quoteError.message?.includes('sent_by') || quoteError.message?.includes('terms') || quoteError.code === '42703') {
         const retryData = { ...quoteData }
         delete retryData.created_by
         delete retryData.terms
         delete retryData.sent_by
+        delete retryData.deposit_amount
+        delete retryData.deposit_required
+        delete retryData.deposit_percentage
+        delete retryData.deposit_paid
+        delete retryData.deposit_paid_at
+        delete retryData.deposit_stripe_payment_id
 
         const { data: retryQuote, error: retryError } = await adminClient
           .from('quotes')

--- a/src/app/dashboard/quotes/page.tsx
+++ b/src/app/dashboard/quotes/page.tsx
@@ -1276,9 +1276,12 @@ function QuoteModal({ quote, companyId, userId, customers, defaultQuoteTerms, is
       tax_amount: Number(tax_amount) || 0,
       total: Number(total) || 0,
       status: quote?.status || 'draft',
-      deposit_required: depositRequired,
-      deposit_amount: depositRequired && depositType === 'fixed' ? Number(depositValue) || null : null,
-      deposit_percentage: depositRequired && depositType === 'percentage' ? Number(depositValue) || null : null,
+    }
+    // Only include deposit fields if deposit is required (columns may not exist in DB yet)
+    if (depositRequired) {
+      quoteData.deposit_required = true
+      quoteData.deposit_amount = depositType === 'fixed' ? Number(depositValue) || null : null
+      quoteData.deposit_percentage = depositType === 'percentage' ? Number(depositValue) || null : null
     }
     if (!quote && userId) {
       quoteData.created_by = userId


### PR DESCRIPTION
The migration adding deposit_amount/deposit_required/deposit_percentage columns to the quotes table hasn't been applied to production. The code was always sending these fields, causing Supabase to reject the insert.

- Client: only include deposit fields when deposit is actually required
- API: strip deposit fields in the retry logic for missing columns

https://claude.ai/code/session_01XHaNMhcRfTMQ29HvuET9rT