### PR TITLE
Add CRM data migration and customer import feature

### DIFF
--- a/database/migrations/028_crm_data_import.sql
+++ b/database/migrations/028_crm_data_import.sql
@@ -1,0 +1,45 @@
+-- Migration: CRM Data Import tracking
+-- Tracks bulk customer import jobs from other CRMs (HouseCall Pro, Jobber, etc.)
+
+CREATE TABLE IF NOT EXISTS import_jobs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+
+    -- Import source info
+    source_crm VARCHAR(100) NOT NULL,       -- housecall_pro, jobber, servicetitan, etc.
+    file_name VARCHAR(500),
+    total_rows INTEGER DEFAULT 0,
+    imported_rows INTEGER DEFAULT 0,
+    skipped_rows INTEGER DEFAULT 0,
+    failed_rows INTEGER DEFAULT 0,
+
+    -- Field mapping used (stored for audit/re-import)
+    field_mapping JSONB DEFAULT '{}',
+
+    -- Status tracking
+    status VARCHAR(30) DEFAULT 'pending',   -- pending, validating, previewing, importing, completed, failed
+    error_log JSONB DEFAULT '[]',           -- Array of { row, field, message }
+
+    -- Who ran it
+    created_by UUID REFERENCES auth.users(id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    completed_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX IF NOT EXISTS idx_import_jobs_company ON import_jobs(company_id);
+CREATE INDEX IF NOT EXISTS idx_import_jobs_status ON import_jobs(status);
+
+-- ROW LEVEL SECURITY
+ALTER TABLE import_jobs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users see own company import jobs"
+    ON import_jobs FOR SELECT
+    USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
+
+CREATE POLICY "Users create own company import jobs"
+    ON import_jobs FOR INSERT
+    WITH CHECK (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
+
+CREATE POLICY "Users update own company import jobs"
+    ON import_jobs FOR UPDATE
+    USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));

--- a/src/app/api/import-customers/route.js
+++ b/src/app/api/import-customers/route.js
@@ -1,0 +1,222 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+/**
+ * POST /api/import-customers
+ *
+ * Accepts a JSON body with:
+ *   - companyId: string
+ *   - sourceCrm: string
+ *   - fileName: string
+ *   - fieldMapping: Record<string, string>
+ *   - rows: Record<string, string>[]   (raw CSV rows as objects)
+ *   - skipDuplicates: boolean
+ *
+ * Validates, transforms, and bulk-inserts customers.
+ */
+export async function POST(request) {
+  try {
+    // Get auth token from request
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+
+    // Create authenticated client to verify user
+    const supabaseAuth = createClient(supabaseUrl, supabaseServiceKey);
+    const { data: { user }, error: authError } = await supabaseAuth.auth.getUser(token);
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { companyId, sourceCrm, fileName, fieldMapping, rows, skipDuplicates = true } = body;
+
+    if (!companyId || !rows || !Array.isArray(rows) || rows.length === 0) {
+      return NextResponse.json(
+        { error: 'Missing required fields: companyId, rows' },
+        { status: 400 }
+      );
+    }
+
+    // Verify user belongs to this company
+    const { data: userRecord } = await supabaseAuth
+      .from('users')
+      .select('company_id')
+      .eq('id', user.id)
+      .single();
+
+    if (!userRecord || userRecord.company_id !== companyId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Transform rows using field mapping
+    const validFields = ['name', 'email', 'phone', 'address', 'city', 'state', 'zip', 'notes', 'source'];
+    const transformed = [];
+    const errors = [];
+    const skipped = [];
+
+    for (let i = 0; i < rows.length; i++) {
+      const raw = rows[i];
+      const customer = { company_id: companyId };
+      let firstName = '';
+      let lastName = '';
+
+      // Apply field mapping
+      for (const [csvHeader, tooltimeField] of Object.entries(fieldMapping)) {
+        if (!tooltimeField || tooltimeField === 'skip') continue;
+        const value = (raw[csvHeader] || '').trim();
+        if (!value) continue;
+
+        if (tooltimeField === '_first_name') {
+          firstName = value;
+        } else if (tooltimeField === '_last_name') {
+          lastName = value;
+        } else if (validFields.includes(tooltimeField)) {
+          if (tooltimeField === 'notes' && customer.notes) {
+            customer.notes += '; ' + value;
+          } else if (!customer[tooltimeField]) {
+            customer[tooltimeField] = value;
+          }
+        }
+      }
+
+      // Merge first + last name
+      if (!customer.name && (firstName || lastName)) {
+        customer.name = [firstName, lastName].filter(Boolean).join(' ');
+      }
+
+      // Normalize phone
+      if (customer.phone) {
+        const digits = customer.phone.replace(/\D/g, '');
+        const clean = digits.length === 11 && digits.startsWith('1') ? digits.slice(1) : digits;
+        if (clean.length === 10) {
+          customer.phone = `(${clean.slice(0, 3)}) ${clean.slice(3, 6)}-${clean.slice(6)}`;
+        }
+      }
+
+      // Validate
+      const rowErrors = [];
+      if (!customer.name || customer.name.trim().length === 0) {
+        rowErrors.push('Name is required');
+      }
+      if (customer.email) {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(customer.email)) {
+          rowErrors.push(`Invalid email: ${customer.email}`);
+        }
+      }
+
+      if (rowErrors.length > 0) {
+        errors.push({ row: i + 1, errors: rowErrors, data: raw });
+        continue;
+      }
+
+      // Set source to CRM name if not mapped
+      if (!customer.source) {
+        customer.source = `Import: ${sourceCrm || 'CSV'}`;
+      }
+
+      transformed.push(customer);
+    }
+
+    // Duplicate detection
+    let duplicateCount = 0;
+    if (skipDuplicates && transformed.length > 0) {
+      // Fetch existing customers for this company
+      const { data: existing } = await supabaseAuth
+        .from('customers')
+        .select('name, email, phone')
+        .eq('company_id', companyId);
+
+      if (existing && existing.length > 0) {
+        const existingSet = new Set();
+        for (const c of existing) {
+          if (c.email) existingSet.add(`email:${c.email.toLowerCase()}`);
+          if (c.phone) existingSet.add(`phone:${c.phone.replace(/\D/g, '')}`);
+          if (c.name) existingSet.add(`name:${c.name.toLowerCase()}`);
+        }
+
+        const deduped = [];
+        for (const customer of transformed) {
+          const emailMatch = customer.email && existingSet.has(`email:${customer.email.toLowerCase()}`);
+          const phoneMatch = customer.phone && existingSet.has(`phone:${customer.phone.replace(/\D/g, '')}`);
+
+          if (emailMatch || phoneMatch) {
+            duplicateCount++;
+            skipped.push({ ...customer, reason: 'Duplicate (matched by ' + (emailMatch ? 'email' : 'phone') + ')' });
+          } else {
+            deduped.push(customer);
+          }
+        }
+        transformed.length = 0;
+        transformed.push(...deduped);
+      }
+    }
+
+    // Bulk insert in batches of 100
+    let importedCount = 0;
+    const batchSize = 100;
+    const insertErrors = [];
+
+    for (let i = 0; i < transformed.length; i += batchSize) {
+      const batch = transformed.slice(i, i + batchSize);
+      const { error: insertError, data: inserted } = await supabaseAuth
+        .from('customers')
+        .insert(batch)
+        .select('id');
+
+      if (insertError) {
+        insertErrors.push({ batch: Math.floor(i / batchSize) + 1, error: insertError.message });
+      } else {
+        importedCount += (inserted?.length || batch.length);
+      }
+    }
+
+    // Log the import job
+    try {
+      await supabaseAuth.from('import_jobs').insert({
+        company_id: companyId,
+        source_crm: sourceCrm || 'generic_csv',
+        file_name: fileName || 'unknown.csv',
+        total_rows: rows.length,
+        imported_rows: importedCount,
+        skipped_rows: skipped.length,
+        failed_rows: errors.length,
+        field_mapping: fieldMapping,
+        status: insertErrors.length > 0 ? 'failed' : 'completed',
+        error_log: [...errors.map(e => ({ row: e.row, message: e.errors.join(', ') })), ...insertErrors],
+        created_by: user.id,
+        completed_at: new Date().toISOString(),
+      });
+    } catch {
+      // import_jobs table may not exist yet — non-critical
+      console.warn('Could not log import job (table may not exist yet)');
+    }
+
+    return NextResponse.json({
+      success: true,
+      summary: {
+        totalRows: rows.length,
+        imported: importedCount,
+        skipped: skipped.length,
+        duplicates: duplicateCount,
+        failed: errors.length,
+      },
+      errors: errors.slice(0, 50), // Limit error detail to 50 rows
+      skipped: skipped.slice(0, 50),
+      insertErrors,
+    });
+  } catch (err) {
+    console.error('Import error:', err);
+    return NextResponse.json(
+      { error: 'Import failed: ' + (err.message || 'Unknown error') },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/customers/page.tsx
+++ b/src/app/dashboard/customers/page.tsx
@@ -108,15 +108,23 @@ export default function CustomersPage() {
     <div className="p-6 max-w-7xl mx-auto">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold text-gray-900">Customers</h1>
-        <button
-          onClick={() => {
-            setEditingCustomer(null)
-            setShowModal(true)
-          }}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700"
-        >
-          + Add Customer
-        </button>
+        <div className="flex gap-3">
+          <Link
+            href="/dashboard/import-customers"
+            className="border border-blue-600 text-blue-600 px-4 py-2 rounded-lg hover:bg-blue-50"
+          >
+            Import from CRM
+          </Link>
+          <button
+            onClick={() => {
+              setEditingCustomer(null)
+              setShowModal(true)
+            }}
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700"
+          >
+            + Add Customer
+          </button>
+        </div>
       </div>
 
       {/* Search */}

--- a/src/app/dashboard/import-customers/page.tsx
+++ b/src/app/dashboard/import-customers/page.tsx
@@ -1,0 +1,713 @@
+'use client';
+
+import { useState, useCallback, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/lib/supabase';
+import {
+  CRM_TEMPLATES,
+  TOOLTIME_CUSTOMER_FIELDS,
+  detectCrmTemplate,
+  autoMapHeaders,
+  transformRow,
+  validateRow,
+  normalizePhone,
+} from '@/lib/crm-field-mappings';
+import type { CrmTemplate } from '@/lib/crm-field-mappings';
+import {
+  Upload,
+  FileSpreadsheet,
+  ArrowRight,
+  ArrowLeft,
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
+  Users,
+  Download,
+  Loader2,
+} from 'lucide-react';
+
+type Step = 'select-crm' | 'upload' | 'map-fields' | 'preview' | 'importing' | 'complete';
+
+interface ParsedData {
+  headers: string[];
+  rows: Record<string, string>[];
+  fileName: string;
+}
+
+interface ImportResult {
+  success: boolean;
+  summary: {
+    totalRows: number;
+    imported: number;
+    skipped: number;
+    duplicates: number;
+    failed: number;
+  };
+  errors: { row: number; errors: string[]; data: Record<string, string> }[];
+  skipped: { name?: string; reason: string }[];
+}
+
+export default function ImportCustomersPage() {
+  const router = useRouter();
+  const { user, dbUser, isLoading: authLoading } = useAuth();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [step, setStep] = useState<Step>('select-crm');
+  const [selectedCrm, setSelectedCrm] = useState<string>('');
+  const [parsedData, setParsedData] = useState<ParsedData | null>(null);
+  const [fieldMapping, setFieldMapping] = useState<Record<string, string>>({});
+  const [skipDuplicates, setSkipDuplicates] = useState(true);
+  const [importResult, setImportResult] = useState<ImportResult | null>(null);
+  const [error, setError] = useState<string>('');
+  const [uploading, setUploading] = useState(false);
+
+  const companyId = dbUser?.company_id || null;
+
+  // CSV Parser — handles quoted fields, newlines in quotes, etc.
+  const parseCSV = useCallback((text: string): { headers: string[]; rows: Record<string, string>[] } => {
+    const lines: string[] = [];
+    let current = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < text.length; i++) {
+      const char = text[i];
+      if (char === '"') {
+        if (inQuotes && text[i + 1] === '"') {
+          current += '"';
+          i++; // Skip escaped quote
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if ((char === '\n' || char === '\r') && !inQuotes) {
+        if (current.trim()) lines.push(current);
+        current = '';
+        if (char === '\r' && text[i + 1] === '\n') i++; // Skip \r\n
+      } else {
+        current += char;
+      }
+    }
+    if (current.trim()) lines.push(current);
+
+    if (lines.length < 2) {
+      return { headers: [], rows: [] };
+    }
+
+    const splitRow = (line: string): string[] => {
+      const fields: string[] = [];
+      let field = '';
+      let quoted = false;
+      for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        if (ch === '"') {
+          if (quoted && line[i + 1] === '"') {
+            field += '"';
+            i++;
+          } else {
+            quoted = !quoted;
+          }
+        } else if (ch === ',' && !quoted) {
+          fields.push(field.trim());
+          field = '';
+        } else {
+          field += ch;
+        }
+      }
+      fields.push(field.trim());
+      return fields;
+    };
+
+    const headers = splitRow(lines[0]);
+    const rows = lines.slice(1).map(line => {
+      const values = splitRow(line);
+      const obj: Record<string, string> = {};
+      headers.forEach((h, i) => {
+        obj[h] = values[i] || '';
+      });
+      return obj;
+    });
+
+    return { headers, rows };
+  }, []);
+
+  const handleFileUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.name.endsWith('.csv')) {
+      setError('Please upload a CSV file (.csv)');
+      return;
+    }
+
+    if (file.size > 10 * 1024 * 1024) {
+      setError('File is too large. Maximum size is 10MB.');
+      return;
+    }
+
+    setError('');
+    setUploading(true);
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const text = event.target?.result as string;
+        const { headers, rows } = parseCSV(text);
+
+        if (headers.length === 0 || rows.length === 0) {
+          setError('Could not parse CSV file. Make sure the first row contains column headers.');
+          setUploading(false);
+          return;
+        }
+
+        // Auto-detect CRM if not selected
+        let crmId = selectedCrm;
+        if (!crmId) {
+          crmId = detectCrmTemplate(headers);
+          setSelectedCrm(crmId);
+        }
+
+        // Auto-map headers
+        const mapping = autoMapHeaders(headers, crmId);
+        setFieldMapping(mapping);
+
+        setParsedData({ headers, rows, fileName: file.name });
+        setStep('map-fields');
+      } catch {
+        setError('Failed to parse CSV file. Please check the format.');
+      }
+      setUploading(false);
+    };
+    reader.onerror = () => {
+      setError('Failed to read file.');
+      setUploading(false);
+    };
+    reader.readAsText(file);
+  }, [parseCSV, selectedCrm]);
+
+  const handleImport = useCallback(async () => {
+    if (!parsedData || !companyId) return;
+
+    setStep('importing');
+    setError('');
+
+    try {
+      const { data: session } = await supabase.auth.getSession();
+      const token = session?.session?.access_token;
+
+      if (!token) {
+        setError('Authentication expired. Please log in again.');
+        setStep('preview');
+        return;
+      }
+
+      const response = await fetch('/api/import-customers', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          companyId,
+          sourceCrm: selectedCrm,
+          fileName: parsedData.fileName,
+          fieldMapping,
+          rows: parsedData.rows,
+          skipDuplicates,
+        }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        setError(result.error || 'Import failed');
+        setStep('preview');
+        return;
+      }
+
+      setImportResult(result);
+      setStep('complete');
+    } catch {
+      setError('Import failed. Please try again.');
+      setStep('preview');
+    }
+  }, [parsedData, companyId, selectedCrm, fieldMapping, skipDuplicates]);
+
+  // Generate preview data
+  const getPreviewRows = useCallback(() => {
+    if (!parsedData) return [];
+    const preview = parsedData.rows.slice(0, 10).map((row, i) => {
+      const transformed = transformRow(row, fieldMapping);
+      if (transformed.phone) {
+        transformed.phone = normalizePhone(transformed.phone);
+      }
+      const errors = validateRow(transformed);
+      return { index: i + 1, raw: row, transformed, errors };
+    });
+    return preview;
+  }, [parsedData, fieldMapping]);
+
+  const getMappedFieldCount = useCallback(() => {
+    return Object.values(fieldMapping).filter(v => v && v !== 'skip').length;
+  }, [fieldMapping]);
+
+  const getValidRowCount = useCallback(() => {
+    if (!parsedData) return 0;
+    let valid = 0;
+    for (const row of parsedData.rows) {
+      const transformed = transformRow(row, fieldMapping);
+      const errors = validateRow(transformed);
+      if (errors.length === 0) valid++;
+    }
+    return valid;
+  }, [parsedData, fieldMapping]);
+
+  // Auth check
+  if (authLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    router.push('/auth/login');
+    return null;
+  }
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Import Customers</h1>
+          <p className="text-gray-600 mt-1">
+            Migrate your customer data from another CRM or CSV file
+          </p>
+        </div>
+        <Link
+          href="/dashboard/customers"
+          className="text-blue-600 hover:text-blue-700 text-sm font-medium"
+        >
+          Back to Customers
+        </Link>
+      </div>
+
+      {/* Progress Steps */}
+      <div className="flex items-center mb-8 gap-2">
+        {[
+          { id: 'select-crm', label: '1. Source' },
+          { id: 'upload', label: '2. Upload' },
+          { id: 'map-fields', label: '3. Map Fields' },
+          { id: 'preview', label: '4. Preview' },
+          { id: 'complete', label: '5. Import' },
+        ].map((s, i) => {
+          const steps: Step[] = ['select-crm', 'upload', 'map-fields', 'preview', 'complete'];
+          const currentIdx = steps.indexOf(step === 'importing' ? 'complete' : step);
+          const stepIdx = i;
+          const isActive = stepIdx === currentIdx;
+          const isComplete = stepIdx < currentIdx;
+
+          return (
+            <div key={s.id} className="flex items-center gap-2">
+              {i > 0 && <div className={`h-0.5 w-6 ${isComplete ? 'bg-blue-600' : 'bg-gray-200'}`} />}
+              <div
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium ${
+                  isActive
+                    ? 'bg-blue-600 text-white'
+                    : isComplete
+                    ? 'bg-blue-100 text-blue-700'
+                    : 'bg-gray-100 text-gray-500'
+                }`}
+              >
+                {isComplete && <CheckCircle2 className="w-4 h-4" />}
+                {s.label}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-start gap-3">
+          <XCircle className="w-5 h-5 text-red-500 mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="text-red-800 font-medium">Error</p>
+            <p className="text-red-700 text-sm">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Step 1: Select CRM */}
+      {step === 'select-crm' && (
+        <div>
+          <h2 className="text-lg font-semibold mb-4">Where are you importing from?</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {Object.values(CRM_TEMPLATES).map((template: CrmTemplate) => (
+              <button
+                key={template.id}
+                onClick={() => {
+                  setSelectedCrm(template.id);
+                  setStep('upload');
+                }}
+                className={`p-4 border-2 rounded-xl text-left hover:border-blue-500 hover:bg-blue-50 transition-colors ${
+                  selectedCrm === template.id ? 'border-blue-500 bg-blue-50' : 'border-gray-200'
+                }`}
+              >
+                <div className="flex items-center gap-3 mb-2">
+                  <FileSpreadsheet className="w-6 h-6 text-blue-600" />
+                  <span className="font-semibold text-gray-900">{template.name}</span>
+                </div>
+                <p className="text-sm text-gray-600">{template.description}</p>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Step 2: Upload CSV */}
+      {step === 'upload' && (
+        <div>
+          <h2 className="text-lg font-semibold mb-4">
+            Upload your CSV file
+            {selectedCrm && CRM_TEMPLATES[selectedCrm] && (
+              <span className="text-blue-600 ml-2">from {CRM_TEMPLATES[selectedCrm].name}</span>
+            )}
+          </h2>
+
+          {/* Export instructions */}
+          {selectedCrm && CRM_TEMPLATES[selectedCrm] && (
+            <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+              <h3 className="font-medium text-blue-900 mb-2">How to export your data:</h3>
+              <ol className="list-decimal list-inside space-y-1 text-sm text-blue-800">
+                {CRM_TEMPLATES[selectedCrm].exportInstructions.map((instruction, i) => (
+                  <li key={i}>{instruction}</li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          {/* Upload area */}
+          <div
+            className="border-2 border-dashed border-gray-300 rounded-xl p-12 text-center hover:border-blue-400 hover:bg-blue-50 transition-colors cursor-pointer"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            {uploading ? (
+              <Loader2 className="w-12 h-12 text-blue-600 mx-auto animate-spin" />
+            ) : (
+              <Upload className="w-12 h-12 text-gray-400 mx-auto" />
+            )}
+            <p className="mt-4 text-gray-700 font-medium">
+              {uploading ? 'Reading file...' : 'Click to upload or drag and drop'}
+            </p>
+            <p className="text-sm text-gray-500 mt-1">CSV files only, max 10MB</p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv"
+              onChange={handleFileUpload}
+              className="hidden"
+            />
+          </div>
+
+          <div className="mt-6 flex justify-between">
+            <button
+              onClick={() => setStep('select-crm')}
+              className="flex items-center gap-2 text-gray-600 hover:text-gray-800"
+            >
+              <ArrowLeft className="w-4 h-4" /> Back
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Step 3: Map Fields */}
+      {step === 'map-fields' && parsedData && (
+        <div>
+          <h2 className="text-lg font-semibold mb-2">Map CSV columns to customer fields</h2>
+          <p className="text-sm text-gray-600 mb-6">
+            We auto-detected {getMappedFieldCount()} field mappings from your {parsedData.headers.length} columns.
+            Adjust as needed.
+          </p>
+
+          <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
+            <div className="grid grid-cols-2 gap-4 p-4 bg-gray-50 border-b font-medium text-sm text-gray-700">
+              <div>CSV Column</div>
+              <div>ToolTime Pro Field</div>
+            </div>
+            <div className="divide-y">
+              {parsedData.headers.map((header) => {
+                const sampleValue = parsedData.rows[0]?.[header] || '';
+                return (
+                  <div key={header} className="grid grid-cols-2 gap-4 p-4 items-center">
+                    <div>
+                      <div className="font-medium text-gray-900">{header}</div>
+                      {sampleValue && (
+                        <div className="text-xs text-gray-500 mt-0.5 truncate">
+                          e.g. &quot;{sampleValue}&quot;
+                        </div>
+                      )}
+                    </div>
+                    <select
+                      value={fieldMapping[header] || 'skip'}
+                      onChange={(e) =>
+                        setFieldMapping({ ...fieldMapping, [header]: e.target.value })
+                      }
+                      className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    >
+                      <option value="skip">-- Skip this column --</option>
+                      {TOOLTIME_CUSTOMER_FIELDS.map((f) => (
+                        <option key={f.target} value={f.target}>
+                          {f.label} {f.required ? '(required)' : ''}
+                        </option>
+                      ))}
+                      <option value="_first_name">First Name (will combine with Last)</option>
+                      <option value="_last_name">Last Name (will combine with First)</option>
+                    </select>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="mt-6 flex justify-between">
+            <button
+              onClick={() => setStep('upload')}
+              className="flex items-center gap-2 text-gray-600 hover:text-gray-800"
+            >
+              <ArrowLeft className="w-4 h-4" /> Back
+            </button>
+            <button
+              onClick={() => setStep('preview')}
+              className="flex items-center gap-2 bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700"
+            >
+              Preview Import <ArrowRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Step 4: Preview */}
+      {step === 'preview' && parsedData && (
+        <div>
+          <h2 className="text-lg font-semibold mb-2">Preview Import</h2>
+
+          {/* Summary stats */}
+          <div className="grid grid-cols-3 gap-4 mb-6">
+            <div className="bg-white border rounded-xl p-4 text-center">
+              <div className="text-2xl font-bold text-gray-900">{parsedData.rows.length}</div>
+              <div className="text-sm text-gray-600">Total Rows</div>
+            </div>
+            <div className="bg-white border rounded-xl p-4 text-center">
+              <div className="text-2xl font-bold text-green-600">{getValidRowCount()}</div>
+              <div className="text-sm text-gray-600">Valid Rows</div>
+            </div>
+            <div className="bg-white border rounded-xl p-4 text-center">
+              <div className="text-2xl font-bold text-red-600">
+                {parsedData.rows.length - getValidRowCount()}
+              </div>
+              <div className="text-sm text-gray-600">Rows with Errors</div>
+            </div>
+          </div>
+
+          {/* Options */}
+          <div className="mb-6 p-4 bg-gray-50 border rounded-xl">
+            <label className="flex items-center gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={skipDuplicates}
+                onChange={(e) => setSkipDuplicates(e.target.checked)}
+                className="w-4 h-4 text-blue-600 rounded"
+              />
+              <div>
+                <span className="font-medium text-gray-900">Skip duplicates</span>
+                <p className="text-sm text-gray-600">
+                  Skip customers that already exist (matched by email or phone)
+                </p>
+              </div>
+            </label>
+          </div>
+
+          {/* Preview table */}
+          <div className="bg-white border rounded-xl overflow-hidden mb-6">
+            <div className="p-3 bg-gray-50 border-b">
+              <h3 className="font-medium text-sm text-gray-700">
+                First {Math.min(10, parsedData.rows.length)} rows preview
+              </h3>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-gray-50">
+                    <th className="px-3 py-2 text-left text-gray-600">#</th>
+                    <th className="px-3 py-2 text-left text-gray-600">Name</th>
+                    <th className="px-3 py-2 text-left text-gray-600">Email</th>
+                    <th className="px-3 py-2 text-left text-gray-600">Phone</th>
+                    <th className="px-3 py-2 text-left text-gray-600">Address</th>
+                    <th className="px-3 py-2 text-left text-gray-600">Status</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {getPreviewRows().map((row) => (
+                    <tr key={row.index} className={row.errors.length > 0 ? 'bg-red-50' : ''}>
+                      <td className="px-3 py-2 text-gray-500">{row.index}</td>
+                      <td className="px-3 py-2 font-medium">{row.transformed.name || '—'}</td>
+                      <td className="px-3 py-2 text-gray-700">{row.transformed.email || '—'}</td>
+                      <td className="px-3 py-2 text-gray-700">{row.transformed.phone || '—'}</td>
+                      <td className="px-3 py-2 text-gray-700">
+                        {[row.transformed.address, row.transformed.city, row.transformed.state, row.transformed.zip]
+                          .filter(Boolean)
+                          .join(', ') || '—'}
+                      </td>
+                      <td className="px-3 py-2">
+                        {row.errors.length === 0 ? (
+                          <span className="text-green-600 flex items-center gap-1">
+                            <CheckCircle2 className="w-4 h-4" /> Valid
+                          </span>
+                        ) : (
+                          <span className="text-red-600 flex items-center gap-1" title={row.errors.join(', ')}>
+                            <AlertTriangle className="w-4 h-4" /> {row.errors[0]}
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div className="flex justify-between">
+            <button
+              onClick={() => setStep('map-fields')}
+              className="flex items-center gap-2 text-gray-600 hover:text-gray-800"
+            >
+              <ArrowLeft className="w-4 h-4" /> Back to Field Mapping
+            </button>
+            <button
+              onClick={handleImport}
+              disabled={getValidRowCount() === 0}
+              className="flex items-center gap-2 bg-green-600 text-white px-6 py-2 rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Download className="w-4 h-4" /> Import {getValidRowCount()} Customers
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Importing... */}
+      {step === 'importing' && (
+        <div className="text-center py-16">
+          <Loader2 className="w-16 h-16 text-blue-600 mx-auto animate-spin" />
+          <h2 className="text-xl font-semibold mt-6 text-gray-900">Importing customers...</h2>
+          <p className="text-gray-600 mt-2">
+            Processing {parsedData?.rows.length || 0} rows. This may take a moment.
+          </p>
+        </div>
+      )}
+
+      {/* Step 5: Complete */}
+      {step === 'complete' && importResult && (
+        <div>
+          <div className="text-center py-8">
+            <CheckCircle2 className="w-16 h-16 text-green-500 mx-auto" />
+            <h2 className="text-xl font-semibold mt-4 text-gray-900">Import Complete!</h2>
+          </div>
+
+          {/* Results summary */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
+            <div className="bg-white border rounded-xl p-4 text-center">
+              <div className="text-2xl font-bold text-gray-900">
+                {importResult.summary.totalRows}
+              </div>
+              <div className="text-sm text-gray-600">Total Rows</div>
+            </div>
+            <div className="bg-green-50 border border-green-200 rounded-xl p-4 text-center">
+              <div className="text-2xl font-bold text-green-600">
+                {importResult.summary.imported}
+              </div>
+              <div className="text-sm text-green-700">Imported</div>
+            </div>
+            <div className="bg-yellow-50 border border-yellow-200 rounded-xl p-4 text-center">
+              <div className="text-2xl font-bold text-yellow-600">
+                {importResult.summary.skipped}
+              </div>
+              <div className="text-sm text-yellow-700">
+                Skipped{importResult.summary.duplicates > 0 && ` (${importResult.summary.duplicates} duplicates)`}
+              </div>
+            </div>
+            <div className="bg-red-50 border border-red-200 rounded-xl p-4 text-center">
+              <div className="text-2xl font-bold text-red-600">
+                {importResult.summary.failed}
+              </div>
+              <div className="text-sm text-red-700">Failed</div>
+            </div>
+          </div>
+
+          {/* Error details */}
+          {importResult.errors.length > 0 && (
+            <div className="mb-6 border border-red-200 rounded-xl overflow-hidden">
+              <div className="p-3 bg-red-50 border-b border-red-200">
+                <h3 className="font-medium text-red-800">
+                  Failed Rows ({importResult.errors.length})
+                </h3>
+              </div>
+              <div className="max-h-60 overflow-y-auto">
+                {importResult.errors.map((err, i) => (
+                  <div key={i} className="px-4 py-2 border-b border-red-100 text-sm">
+                    <span className="font-medium text-red-700">Row {err.row}:</span>{' '}
+                    <span className="text-red-600">{err.errors.join(', ')}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Skipped details */}
+          {importResult.skipped.length > 0 && (
+            <div className="mb-6 border border-yellow-200 rounded-xl overflow-hidden">
+              <div className="p-3 bg-yellow-50 border-b border-yellow-200">
+                <h3 className="font-medium text-yellow-800">
+                  Skipped Rows ({importResult.skipped.length})
+                </h3>
+              </div>
+              <div className="max-h-60 overflow-y-auto">
+                {importResult.skipped.map((skip, i) => (
+                  <div key={i} className="px-4 py-2 border-b border-yellow-100 text-sm">
+                    <span className="font-medium text-yellow-700">{skip.name || 'Unknown'}:</span>{' '}
+                    <span className="text-yellow-600">{skip.reason}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-center gap-4">
+            <Link
+              href="/dashboard/customers"
+              className="flex items-center gap-2 bg-blue-600 text-white px-6 py-2.5 rounded-lg hover:bg-blue-700"
+            >
+              <Users className="w-4 h-4" /> View Customers
+            </Link>
+            <button
+              onClick={() => {
+                setStep('select-crm');
+                setParsedData(null);
+                setFieldMapping({});
+                setImportResult(null);
+                setError('');
+                setSelectedCrm('');
+              }}
+              className="flex items-center gap-2 border border-gray-300 text-gray-700 px-6 py-2.5 rounded-lg hover:bg-gray-50"
+            >
+              <Upload className="w-4 h-4" /> Import More
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/onboarding-status/page.tsx
+++ b/src/app/dashboard/onboarding-status/page.tsx
@@ -233,6 +233,14 @@ export default function OnboardingStatusPage() {
                       <span className={`text-sm ${item.completed ? 'text-gray-500 line-through' : 'text-gray-700'}`}>
                         {item.label}
                       </span>
+                      {item.id === 'customer_import' && !item.completed && (
+                        <a
+                          href="/dashboard/import-customers"
+                          className="text-xs text-blue-600 hover:text-blue-700 font-medium ml-1"
+                        >
+                          Import now &rarr;
+                        </a>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/src/lib/crm-field-mappings.ts
+++ b/src/lib/crm-field-mappings.ts
@@ -1,0 +1,399 @@
+// CRM Field Mapping Templates
+// Maps exported CSV column headers from popular CRMs to ToolTime Pro customer fields
+
+export interface FieldMapping {
+  /** ToolTime Pro customer field name */
+  target: string;
+  /** Human-readable label */
+  label: string;
+  /** Whether this field is required for import */
+  required: boolean;
+}
+
+export interface CrmTemplate {
+  id: string;
+  name: string;
+  description: string;
+  /** Map of source CSV header (lowercase) -> ToolTime Pro field */
+  columnMap: Record<string, string>;
+  /** Tips for exporting from this CRM */
+  exportInstructions: string[];
+}
+
+// All importable fields on the ToolTime Pro customers table
+export const TOOLTIME_CUSTOMER_FIELDS: FieldMapping[] = [
+  { target: 'name', label: 'Full Name', required: true },
+  { target: 'email', label: 'Email', required: false },
+  { target: 'phone', label: 'Phone', required: false },
+  { target: 'address', label: 'Street Address', required: false },
+  { target: 'city', label: 'City', required: false },
+  { target: 'state', label: 'State', required: false },
+  { target: 'zip', label: 'ZIP Code', required: false },
+  { target: 'notes', label: 'Notes', required: false },
+  { target: 'source', label: 'Lead Source', required: false },
+];
+
+export const CRM_TEMPLATES: Record<string, CrmTemplate> = {
+  housecall_pro: {
+    id: 'housecall_pro',
+    name: 'Housecall Pro',
+    description: 'Import customers exported from Housecall Pro',
+    columnMap: {
+      'customer name': 'name',
+      'first name': '_first_name',
+      'last name': '_last_name',
+      'email': 'email',
+      'email address': 'email',
+      'phone': 'phone',
+      'phone number': 'phone',
+      'mobile phone': 'phone',
+      'address': 'address',
+      'street': 'address',
+      'street address': 'address',
+      'city': 'city',
+      'state': 'state',
+      'zip': 'zip',
+      'zip code': 'zip',
+      'zipcode': 'zip',
+      'postal code': 'zip',
+      'notes': 'notes',
+      'customer notes': 'notes',
+      'tags': 'notes',
+      'lead source': 'source',
+      'source': 'source',
+    },
+    exportInstructions: [
+      'In Housecall Pro, go to Customers from the left sidebar.',
+      'Click the "Export" button at the top-right of the customer list.',
+      'Select "CSV" as the export format.',
+      'Save the file and upload it here.',
+    ],
+  },
+
+  jobber: {
+    id: 'jobber',
+    name: 'Jobber',
+    description: 'Import customers exported from Jobber',
+    columnMap: {
+      'client name': 'name',
+      'name': 'name',
+      'first name': '_first_name',
+      'last name': '_last_name',
+      'email': 'email',
+      'phone number': 'phone',
+      'phone': 'phone',
+      'mobile number': 'phone',
+      'billing address street 1': 'address',
+      'street 1': 'address',
+      'street address': 'address',
+      'address': 'address',
+      'billing address city': 'city',
+      'city': 'city',
+      'billing address province': 'state',
+      'state': 'state',
+      'province': 'state',
+      'billing address postal code': 'zip',
+      'postal code': 'zip',
+      'zip': 'zip',
+      'zip code': 'zip',
+      'notes': 'notes',
+      'company': 'notes',
+      'lead source': 'source',
+      'source': 'source',
+    },
+    exportInstructions: [
+      'In Jobber, go to Clients in the left navigation.',
+      'Click the gear icon and select "Export clients".',
+      'Choose CSV format and download the file.',
+      'Upload the exported CSV file here.',
+    ],
+  },
+
+  servicetitan: {
+    id: 'servicetitan',
+    name: 'ServiceTitan',
+    description: 'Import customers exported from ServiceTitan',
+    columnMap: {
+      'customer name': 'name',
+      'name': 'name',
+      'first name': '_first_name',
+      'last name': '_last_name',
+      'email': 'email',
+      'email address': 'email',
+      'phone': 'phone',
+      'phone number': 'phone',
+      'mobile': 'phone',
+      'street': 'address',
+      'address': 'address',
+      'address line 1': 'address',
+      'service address': 'address',
+      'city': 'city',
+      'state': 'state',
+      'zip': 'zip',
+      'zip code': 'zip',
+      'postal code': 'zip',
+      'notes': 'notes',
+      'customer notes': 'notes',
+      'customer type': 'source',
+      'source': 'source',
+    },
+    exportInstructions: [
+      'In ServiceTitan, navigate to Reports > Customer Reports.',
+      'Select "Customer List" and click "Export".',
+      'Choose CSV format and download.',
+      'Upload the exported CSV file here.',
+    ],
+  },
+
+  fieldpulse: {
+    id: 'fieldpulse',
+    name: 'FieldPulse',
+    description: 'Import customers exported from FieldPulse',
+    columnMap: {
+      'customer name': 'name',
+      'name': 'name',
+      'first name': '_first_name',
+      'last name': '_last_name',
+      'email': 'email',
+      'phone': 'phone',
+      'phone number': 'phone',
+      'address': 'address',
+      'street': 'address',
+      'city': 'city',
+      'state': 'state',
+      'zip': 'zip',
+      'zip code': 'zip',
+      'notes': 'notes',
+      'source': 'source',
+    },
+    exportInstructions: [
+      'In FieldPulse, go to Contacts > Customers.',
+      'Click the "Export" button above the customer list.',
+      'Download the CSV file.',
+      'Upload the exported CSV file here.',
+    ],
+  },
+
+  gorilladesk: {
+    id: 'gorilladesk',
+    name: 'GorillaDesk',
+    description: 'Import customers exported from GorillaDesk',
+    columnMap: {
+      'customer name': 'name',
+      'name': 'name',
+      'first name': '_first_name',
+      'last name': '_last_name',
+      'email': 'email',
+      'phone': 'phone',
+      'address': 'address',
+      'city': 'city',
+      'state': 'state',
+      'zip': 'zip',
+      'zip code': 'zip',
+      'notes': 'notes',
+      'source': 'source',
+    },
+    exportInstructions: [
+      'In GorillaDesk, go to Customers.',
+      'Use the Export function to download your customer list as CSV.',
+      'Upload the exported CSV file here.',
+    ],
+  },
+
+  workiz: {
+    id: 'workiz',
+    name: 'Workiz',
+    description: 'Import customers exported from Workiz',
+    columnMap: {
+      'client name': 'name',
+      'name': 'name',
+      'first name': '_first_name',
+      'last name': '_last_name',
+      'email': 'email',
+      'phone': 'phone',
+      'phone number': 'phone',
+      'address': 'address',
+      'street': 'address',
+      'city': 'city',
+      'state': 'state',
+      'zip': 'zip',
+      'zip code': 'zip',
+      'zipcode': 'zip',
+      'notes': 'notes',
+      'source': 'source',
+      'lead source': 'source',
+    },
+    exportInstructions: [
+      'In Workiz, go to Contacts from the sidebar.',
+      'Click "Export" to download your client list as CSV.',
+      'Upload the exported CSV file here.',
+    ],
+  },
+
+  generic_csv: {
+    id: 'generic_csv',
+    name: 'Generic CSV / Spreadsheet',
+    description: 'Import from any CSV file — map your columns manually',
+    columnMap: {
+      'name': 'name',
+      'full name': 'name',
+      'customer name': 'name',
+      'client name': 'name',
+      'first name': '_first_name',
+      'last name': '_last_name',
+      'email': 'email',
+      'email address': 'email',
+      'phone': 'phone',
+      'phone number': 'phone',
+      'mobile': 'phone',
+      'address': 'address',
+      'street': 'address',
+      'street address': 'address',
+      'city': 'city',
+      'state': 'state',
+      'province': 'state',
+      'zip': 'zip',
+      'zip code': 'zip',
+      'zipcode': 'zip',
+      'postal code': 'zip',
+      'notes': 'notes',
+      'comments': 'notes',
+      'source': 'source',
+      'lead source': 'source',
+      'referral source': 'source',
+    },
+    exportInstructions: [
+      'Export your customer list as a CSV file from your current system.',
+      'Make sure the first row contains column headers.',
+      'Upload the CSV file here — we will auto-detect common column names.',
+      'You can adjust the field mapping before importing.',
+    ],
+  },
+};
+
+/**
+ * Auto-detect which CRM template best matches the CSV headers.
+ * Returns the template ID with the highest match count.
+ */
+export function detectCrmTemplate(headers: string[]): string {
+  const normalized = headers.map(h => h.toLowerCase().trim());
+  let bestMatch = 'generic_csv';
+  let bestScore = 0;
+
+  for (const [templateId, template] of Object.entries(CRM_TEMPLATES)) {
+    if (templateId === 'generic_csv') continue;
+    const sourceHeaders = Object.keys(template.columnMap);
+    const matchCount = normalized.filter(h => sourceHeaders.includes(h)).length;
+    if (matchCount > bestScore) {
+      bestScore = matchCount;
+      bestMatch = templateId;
+    }
+  }
+
+  // Only use a specific CRM template if we matched at least 3 headers
+  return bestScore >= 3 ? bestMatch : 'generic_csv';
+}
+
+/**
+ * Apply a CRM template's column map to auto-map CSV headers to ToolTime fields.
+ * Returns a mapping of csvHeader -> tooltimeField (or 'skip').
+ */
+export function autoMapHeaders(
+  csvHeaders: string[],
+  templateId: string
+): Record<string, string> {
+  const template = CRM_TEMPLATES[templateId] || CRM_TEMPLATES.generic_csv;
+  const mapping: Record<string, string> = {};
+
+  for (const header of csvHeaders) {
+    const normalized = header.toLowerCase().trim();
+    const matched = template.columnMap[normalized];
+    mapping[header] = matched || 'skip';
+  }
+
+  return mapping;
+}
+
+/**
+ * Transform a raw CSV row using the provided field mapping.
+ * Handles first_name + last_name merging into name.
+ */
+export function transformRow(
+  row: Record<string, string>,
+  fieldMapping: Record<string, string>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  let firstName = '';
+  let lastName = '';
+
+  for (const [csvHeader, tooltimeField] of Object.entries(fieldMapping)) {
+    if (tooltimeField === 'skip' || !tooltimeField) continue;
+
+    const value = (row[csvHeader] || '').trim();
+    if (!value) continue;
+
+    if (tooltimeField === '_first_name') {
+      firstName = value;
+    } else if (tooltimeField === '_last_name') {
+      lastName = value;
+    } else if (tooltimeField === 'name' && !result.name) {
+      result.name = value;
+    } else if (tooltimeField === 'notes' && result.notes) {
+      // Append multiple note-like fields
+      result.notes += '; ' + value;
+    } else {
+      result[tooltimeField] = value;
+    }
+  }
+
+  // Merge first + last name if no full name was directly mapped
+  if (!result.name && (firstName || lastName)) {
+    result.name = [firstName, lastName].filter(Boolean).join(' ');
+  }
+
+  return result;
+}
+
+/**
+ * Validate a transformed row. Returns array of error messages (empty = valid).
+ */
+export function validateRow(row: Record<string, string>): string[] {
+  const errors: string[] = [];
+
+  if (!row.name || row.name.trim().length === 0) {
+    errors.push('Name is required');
+  }
+
+  if (row.email) {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(row.email)) {
+      errors.push(`Invalid email: ${row.email}`);
+    }
+  }
+
+  if (row.phone) {
+    const digits = row.phone.replace(/\D/g, '');
+    if (digits.length > 0 && digits.length < 10) {
+      errors.push(`Phone number too short: ${row.phone}`);
+    }
+  }
+
+  if (row.state && row.state.length > 2) {
+    // Try to accept full state names but flag them
+    errors.push(`State should be 2-letter abbreviation: ${row.state}`);
+  }
+
+  return errors;
+}
+
+/**
+ * Normalize phone number to (XXX) XXX-XXXX format.
+ */
+export function normalizePhone(phone: string): string {
+  if (!phone) return '';
+  const digits = phone.replace(/\D/g, '');
+  // Handle 11-digit numbers starting with 1 (US country code)
+  const clean = digits.length === 11 && digits.startsWith('1') ? digits.slice(1) : digits;
+  if (clean.length !== 10) return phone; // Return as-is if not 10 digits
+  return `(${clean.slice(0, 3)}) ${clean.slice(3, 6)}-${clean.slice(6)}`;
+}


### PR DESCRIPTION
Build complete self-service customer import workflow for migrating from other CRMs (HouseCall Pro, Jobber, ServiceTitan, FieldPulse, GorillaDesk, Workiz) or generic CSV files. Includes 5-step wizard UI (select source, upload CSV, map fields, preview, import), auto-detection of CRM format, field mapping with first/last name merging, phone normalization, duplicate detection, batch insert API, and import job tracking table.

- database/migrations/028: import_jobs tracking table with RLS
- src/lib/crm-field-mappings.ts: templates for 6 CRMs + generic CSV
- src/app/api/import-customers/route.js: bulk import API with validation
- src/app/dashboard/import-customers/page.tsx: full import wizard UI
- Customers page: added "Import from CRM" button
- Onboarding status: added "Import now" link on customer_import step

https://claude.ai/code/session_01PchTbUy6cCzvS3mf9oxQqH