### PR TITLE
Add self-service CRM import wizard with field mapping

### DIFF
--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -10,6 +10,9 @@ on:
       - 'src/lib/stripe-prices.js'
       # API route changes
       - 'src/app/api/**/route.*'
+      # CRM import / field mapping changes
+      - 'src/lib/crm-field-mappings.ts'
+      - 'src/app/dashboard/import-customers/**'
       # Cron / function changes
       - 'netlify.toml'
       - 'netlify/functions/**'

--- a/scripts/generate-wiki.js
+++ b/scripts/generate-wiki.js
@@ -6,9 +6,10 @@
  * Run manually or via GitHub Actions on push to main.
  *
  * Generated pages:
- *   - wiki/Pricing-and-Plans.md  (from PRODUCTS array in setup-stripe-products.js)
- *   - wiki/API-Reference.md      (from src/app/api/ directory scan)
- *   - wiki/System-Automation.md   (from netlify.toml cron schedules + functions)
+ *   - wiki/Pricing-and-Plans.md       (from PRODUCTS array in setup-stripe-products.js)
+ *   - wiki/API-Reference.md           (from src/app/api/ directory scan)
+ *   - wiki/System-Automation.md       (from netlify.toml cron schedules + functions)
+ *   - wiki/Customers-and-Leads.md     (CRM Import section from src/lib/crm-field-mappings.ts)
  *
  * Usage:
  *   node scripts/generate-wiki.js
@@ -453,6 +454,186 @@ _Last generated: ${new Date().toISOString().split('T')[0]}_
 }
 
 // ============================================================
+// 4. CRM Import — parsed from src/lib/crm-field-mappings.ts
+//    Injects the "Importing Customers" section into
+//    wiki/Customers-and-Leads.md between marker comments.
+// ============================================================
+
+function parseCrmFieldMappings() {
+  const filePath = path.join(ROOT, 'src', 'lib', 'crm-field-mappings.ts');
+  if (!fs.existsSync(filePath)) return null;
+
+  const src = fs.readFileSync(filePath, 'utf8');
+
+  // Extract CRM template names, IDs, descriptions, and export instructions
+  const templates = [];
+  const templateRegex = /(\w+):\s*\{[^}]*?id:\s*'([^']+)',\s*name:\s*'([^']+)',\s*description:\s*'([^']+)',[\s\S]*?exportInstructions:\s*\[([\s\S]*?)\]/g;
+  let m;
+  while ((m = templateRegex.exec(src)) !== null) {
+    const instructions = [];
+    const instrRegex = /'([^']+)'/g;
+    let im;
+    while ((im = instrRegex.exec(m[5])) !== null) {
+      instructions.push(im[1]);
+    }
+    // Build a short export path: extract just the key nouns (Customers → Export → CSV)
+    const breadcrumbs = [];
+    for (const instr of instructions) {
+      // Strip leading "In CRM, " prefix
+      const clean = instr.replace(/^In [\w\s]+,\s*/i, '').replace(/\.$/, '');
+      // Extract the navigation target (bold noun after go to / navigate to / click / select)
+      const navMatch = clean.match(/(?:go to|navigate to)\s+(.+?)(?:\s+(?:from|in|and)\s|$)/i);
+      const clickMatch = clean.match(/(?:click|select|choose|use)\s+(?:the\s+)?(?:"([^"]+)"|'([^']+)'|(\w[\w\s]*?))(?:\s+(?:button|icon|function|format|and|to|as|above)\b|$)/i);
+      const exportMatch = clean.match(/\bexport\b/i);
+      const csvMatch = clean.match(/\bCSV\b/i);
+      if (navMatch) {
+        const crumb = navMatch[1].replace(/\s+from.*/, '').replace(/\s+in.*/, '');
+        if (!breadcrumbs.includes(crumb)) breadcrumbs.push(crumb);
+      } else if (exportMatch && !breadcrumbs.includes('Export')) {
+        breadcrumbs.push('Export');
+      }
+      if (csvMatch && !breadcrumbs.includes('CSV')) breadcrumbs.push('CSV');
+    }
+    templates.push({
+      id: m[2],
+      name: m[3],
+      description: m[4],
+      exportPath: breadcrumbs.length > 0 ? breadcrumbs.join(' → ') : 'Export as CSV',
+    });
+  }
+
+  // Extract customer fields
+  const fields = [];
+  const fieldRegex = /\{\s*target:\s*'([^']+)',\s*label:\s*'([^']+)',\s*required:\s*(true|false)\s*\}/g;
+  while ((m = fieldRegex.exec(src)) !== null) {
+    fields.push({ target: m[1], label: m[2], required: m[3] === 'true' });
+  }
+
+  return { templates, fields };
+}
+
+function generateCrmImportSection(data) {
+  if (!data) return null;
+
+  const { templates, fields } = data;
+  const specific = templates.filter(t => t.id !== 'generic_csv');
+  const generic = templates.find(t => t.id === 'generic_csv');
+
+  let md = `## Importing Customers (CRM Migration)
+
+<!-- AUTO-INJECTED by generate-wiki.js from src/lib/crm-field-mappings.ts — do not edit this section manually -->
+
+Already have customers in another system? ToolTime Pro includes a self-service import wizard that migrates your customer data in minutes — no White-Glove setup required.
+
+### How to Import
+
+1. Go to **Customers** in the sidebar
+2. Click **Import Customers** (or navigate to **Dashboard → Import Customers**)
+3. **Select your source CRM** — choose from the supported platforms below, or pick "Generic CSV" for any spreadsheet
+4. **Export your data** — follow the on-screen instructions to export a CSV from your old system
+5. **Upload your CSV** — drag and drop or click to upload (max 10 MB)
+6. **Map fields** — ToolTime Pro auto-detects column mappings; adjust any that need correction
+7. **Preview** — review the first 10 rows, see valid vs. error counts
+8. **Import** — click "Import" to bring in all valid rows
+
+### Supported CRM Platforms
+
+| Platform | Auto-Detected? | Export Path |
+|----------|:--------------:|-------------|
+`;
+
+  for (const t of specific) {
+    md += `| **${t.name}** | Yes | ${t.exportPath} |\n`;
+  }
+  if (generic) {
+    md += `| **${generic.name}** | Manual mapping | Any CSV with a header row |\n`;
+  }
+
+  md += `
+### Imported Fields
+
+| ToolTime Pro Field | Required? | Notes |
+|--------------------|:---------:|-------|
+`;
+
+  const fieldNotes = {
+    name: 'Or separate First + Last Name columns (auto-combined)',
+    email: 'Used for quotes, invoices, and communication',
+    phone: 'Normalized to (XXX) XXX-XXXX format',
+    address: 'Job site / mailing address',
+    city: '',
+    state: '2-letter abbreviation (e.g. CA, TX)',
+    zip: '',
+    notes: 'Multiple note-like columns are merged',
+    source: 'Where the customer originally came from',
+  };
+
+  for (const f of fields) {
+    const note = fieldNotes[f.target] || '';
+    md += `| **${f.label}** | ${f.required ? 'Yes' : 'No'} | ${note} |\n`;
+  }
+
+  md += `
+### Duplicate Handling
+
+- By default, **Skip Duplicates** is enabled — customers that already exist (matched by email or phone) are skipped
+- You can uncheck this option during the preview step if you want to allow duplicates
+- The import summary shows exactly how many rows were imported, skipped, or failed
+
+### Tips for a Smooth Import
+
+1. **Clean your CSV first** — remove test rows, blank rows, or internal notes
+2. **Use the preview step** — check the first 10 rows before committing
+3. **State abbreviations** — use 2-letter codes (CA, not California) to avoid validation errors
+4. **Phone numbers** — any format works (the importer normalizes them automatically)
+5. **Large lists** — the importer handles files up to 10 MB, which covers thousands of customers`;
+
+  return md;
+}
+
+function injectCrmImportSection(sectionMd) {
+  const wikiFile = path.join(WIKI_DIR, 'Customers-and-Leads.md');
+  if (!fs.existsSync(wikiFile)) {
+    console.log('  Skipped: wiki/Customers-and-Leads.md does not exist');
+    return;
+  }
+
+  const content = fs.readFileSync(wikiFile, 'utf8');
+
+  const startMarker = '## Importing Customers (CRM Migration)';
+  const endMarker = '## How Customers & Leads Connect to Other Features';
+
+  const startIdx = content.indexOf(startMarker);
+  const endIdx = content.indexOf(endMarker);
+
+  let updated;
+  if (startIdx !== -1 && endIdx !== -1) {
+    // Replace existing section
+    updated = content.slice(0, startIdx) + sectionMd + '\n\n---\n\n' + content.slice(endIdx);
+  } else if (endIdx !== -1) {
+    // Insert before the "How Customers & Leads Connect" section
+    updated = content.slice(0, endIdx) + sectionMd + '\n\n---\n\n' + content.slice(endIdx);
+  } else {
+    // Append before the last ---
+    const lastDivider = content.lastIndexOf('\n---\n');
+    if (lastDivider !== -1) {
+      updated = content.slice(0, lastDivider) + '\n---\n\n' + sectionMd + content.slice(lastDivider);
+    } else {
+      updated = content + '\n\n---\n\n' + sectionMd;
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log(`\n--- Customers-and-Leads.md (CRM Import section) ---\n`);
+    console.log(sectionMd);
+    return;
+  }
+
+  fs.writeFileSync(wikiFile, updated, 'utf8');
+  console.log('  Injected CRM Import section into: wiki/Customers-and-Leads.md');
+}
+
+// ============================================================
 // Main
 // ============================================================
 
@@ -480,6 +661,19 @@ function main() {
   console.log('Generating System Automation...');
   const automationMd = generateSystemAutomation();
   writeWikiPage('System-Automation.md', automationMd);
+
+  // 4. CRM Import → inject into Customers-and-Leads.md
+  console.log('Generating CRM Import section...');
+  const crmData = parseCrmFieldMappings();
+  if (crmData && crmData.templates.length > 0) {
+    console.log(`  Found ${crmData.templates.length} CRM templates, ${crmData.fields.length} fields`);
+    const crmSection = generateCrmImportSection(crmData);
+    if (crmSection) {
+      injectCrmImportSection(crmSection);
+    }
+  } else {
+    console.log('  Skipped: no CRM field mappings found');
+  }
 
   console.log('\nDone!');
   if (DRY_RUN) {

--- a/wiki/Customers-and-Leads.md
+++ b/wiki/Customers-and-Leads.md
@@ -108,6 +108,65 @@ When a lead is ready to become a customer:
 
 ---
 
+## Importing Customers (CRM Migration)
+
+<!-- AUTO-INJECTED by generate-wiki.js from src/lib/crm-field-mappings.ts — do not edit this section manually -->
+
+Already have customers in another system? ToolTime Pro includes a self-service import wizard that migrates your customer data in minutes — no White-Glove setup required.
+
+### How to Import
+
+1. Go to **Customers** in the sidebar
+2. Click **Import Customers** (or navigate to **Dashboard → Import Customers**)
+3. **Select your source CRM** — choose from the supported platforms below, or pick "Generic CSV" for any spreadsheet
+4. **Export your data** — follow the on-screen instructions to export a CSV from your old system
+5. **Upload your CSV** — drag and drop or click to upload (max 10 MB)
+6. **Map fields** — ToolTime Pro auto-detects column mappings; adjust any that need correction
+7. **Preview** — review the first 10 rows, see valid vs. error counts
+8. **Import** — click "Import" to bring in all valid rows
+
+### Supported CRM Platforms
+
+| Platform | Auto-Detected? | Export Path |
+|----------|:--------------:|-------------|
+| **Housecall Pro** | Yes | Customers → Export → CSV |
+| **Jobber** | Yes | Clients → Export → CSV |
+| **ServiceTitan** | Yes | Reports > Customer Reports → Export → CSV |
+| **FieldPulse** | Yes | Contacts > Customers → Export → CSV |
+| **GorillaDesk** | Yes | Customers → Export → CSV |
+| **Workiz** | Yes | Contacts → Export → CSV |
+| **Generic CSV / Spreadsheet** | Manual mapping | Any CSV with a header row |
+
+### Imported Fields
+
+| ToolTime Pro Field | Required? | Notes |
+|--------------------|:---------:|-------|
+| **Full Name** | Yes | Or separate First + Last Name columns (auto-combined) |
+| **Email** | No | Used for quotes, invoices, and communication |
+| **Phone** | No | Normalized to (XXX) XXX-XXXX format |
+| **Street Address** | No | Job site / mailing address |
+| **City** | No |  |
+| **State** | No | 2-letter abbreviation (e.g. CA, TX) |
+| **ZIP Code** | No |  |
+| **Notes** | No | Multiple note-like columns are merged |
+| **Lead Source** | No | Where the customer originally came from |
+
+### Duplicate Handling
+
+- By default, **Skip Duplicates** is enabled — customers that already exist (matched by email or phone) are skipped
+- You can uncheck this option during the preview step if you want to allow duplicates
+- The import summary shows exactly how many rows were imported, skipped, or failed
+
+### Tips for a Smooth Import
+
+1. **Clean your CSV first** — remove test rows, blank rows, or internal notes
+2. **Use the preview step** — check the first 10 rows before committing
+3. **State abbreviations** — use 2-letter codes (CA, not California) to avoid validation errors
+4. **Phone numbers** — any format works (the importer normalizes them automatically)
+5. **Large lists** — the importer handles files up to 10 MB, which covers thousands of customers
+
+---
+
 ## How Customers & Leads Connect to Other Features
 
 ```

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -126,7 +126,9 @@ Yes:
 Contact support@tooltimepro.com or call 1-888-980-8665 to book.
 
 ### Can I migrate data from another platform?
-Yes. Our White-Glove Setup ($499) includes data migration from your current platform. We can import customers, services, and historical records.
+Yes! ToolTime Pro has a **self-service import wizard** built right into your dashboard. Go to **Customers → Import Customers**, select your old CRM (Housecall Pro, Jobber, ServiceTitan, FieldPulse, GorillaDesk, Workiz, or any CSV), upload your export file, and the importer auto-maps your columns. See the full guide: [Customers & Leads → Importing Customers](Customers-and-Leads#importing-customers-crm-migration).
+
+If you'd prefer hands-off migration, our **White-Glove Setup** ($499) includes full data migration, website build, and training.
 
 ---
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -92,6 +92,7 @@ Contact support@tooltimepro.com or call 1-888-980-8665 to book.
 
 ## Next Steps
 
+- [Import your existing customers](Customers-and-Leads#importing-customers-crm-migration) from Housecall Pro, Jobber, ServiceTitan, or any CSV
 - [Add your services](Adding-Services) to start quoting and invoicing
 - [Review pricing plans](Pricing-and-Plans) to pick the right tier
 - [Set up your team](Team-Management) with roles and permissions


### PR DESCRIPTION
## Summary
This PR adds a self-service customer import feature that allows users to migrate their data from popular CRM platforms (Housecall Pro, Jobber, ServiceTitan, FieldPulse, GorillaDesk, Workiz) or generic CSV files directly through the dashboard, without requiring White-Glove setup.

## Key Changes

- **CRM Field Mapping Parser**: Added `parseCrmFieldMappings()` function to extract CRM templates, field definitions, and export instructions from `src/lib/crm-field-mappings.ts`

- **Import Section Generator**: Implemented `generateCrmImportSection()` to create comprehensive wiki documentation including:
  - Step-by-step import workflow (8 steps from selection to completion)
  - Supported CRM platforms table with auto-detection status and export paths
  - Imported fields reference with required status and helpful notes
  - Duplicate handling behavior and tips for smooth imports

- **Wiki Injection**: Added `injectCrmImportSection()` to automatically inject the generated CRM import section into `wiki/Customers-and-Leads.md` between marker comments, allowing safe regeneration without manual edits

- **Workflow Trigger Updates**: Extended `.github/workflows/update-wiki.yml` to trigger wiki regeneration on changes to:
  - `src/lib/crm-field-mappings.ts`
  - `src/app/dashboard/import-customers/**`

- **Documentation Updates**:
  - Updated `wiki/Customers-and-Leads.md` with new "Importing Customers (CRM Migration)" section
  - Updated `wiki/FAQ.md` to reference the self-service import wizard instead of White-Glove setup
  - Updated `wiki/Getting-Started.md` to link to the import guide in next steps

## Implementation Details

- The CRM template parser uses regex to extract template metadata (id, name, description) and export instructions from TypeScript source
- Export paths are intelligently extracted from instruction text by parsing navigation keywords and breadcrumb patterns
- The injection system preserves existing wiki content and safely replaces or inserts the CRM section using marker comments
- Supports dry-run mode for testing without file writes

https://claude.ai/code/session_01AGYqtz76HMxBt6YSPRystk