### PR TITLE
Add proper customer-driven SMS consent tracking for TCPA compliance

### DIFF
--- a/src/app/api/jenny-actions/route.ts
+++ b/src/app/api/jenny-actions/route.ts
@@ -326,8 +326,48 @@ async function runLeadFollowUp(
 
   const now = new Date();
 
+  // Batch-check SMS consent for leads that have a linked customer
+  const leadsWithCustomer = coldLeads.filter((l: { customer_id?: string }) => l.customer_id);
+  const customerIds = leadsWithCustomer.map((l: { customer_id: string }) => l.customer_id);
+  const consentMap = new Map<string, boolean>();
+
+  if (customerIds.length > 0) {
+    const { data: customers } = await supabase
+      .from('customers')
+      .select('id, sms_consent')
+      .in('id', customerIds);
+
+    for (const c of (customers || [])) {
+      consentMap.set(c.id, c.sms_consent === true);
+    }
+  }
+
   for (const lead of coldLeads) {
     if (!lead.phone) continue;
+
+    // TCPA compliance: only send SMS if customer has explicitly opted in
+    if (lead.customer_id) {
+      const hasConsent = consentMap.get(lead.customer_id);
+      if (!hasConsent) {
+        // Log skipped follow-up for audit trail
+        await supabase.from('jenny_action_log').insert({
+          company_id: companyId,
+          action_type: 'lead_follow_up',
+          title: `Follow-up skipped for ${lead.name} — no SMS consent`,
+          description: `Jenny skipped SMS follow-up to ${lead.name} (${lead.phone}) because the customer has not opted in to text messages.`,
+          status: 'skipped',
+          target_id: lead.id,
+          target_type: 'lead',
+          target_name: lead.name,
+          metadata: { reason: 'no_sms_consent', phone: lead.phone },
+          executed_at: new Date().toISOString(),
+        });
+        continue;
+      }
+    } else {
+      // Lead has no linked customer record — skip SMS (no way to verify consent)
+      continue;
+    }
 
     const leadAge = Math.floor((now.getTime() - new Date(lead.created_at).getTime()) / (1000 * 60 * 60 * 24));
     const attemptsDone = followUpMap.get(lead.id) || 0;
@@ -347,7 +387,7 @@ async function runLeadFollowUp(
 
     // Build message from template
     const messageTemplate = messages[attemptsDone]?.sms_template ||
-      `Hi ${lead.name}, following up from ${company.name} about your project. Still interested? Call us at ${company.phone || 'our office'}.`;
+      `Hi ${lead.name}, following up from ${company.name} about your project. Still interested? Call us at ${company.phone || 'our office'}. Reply STOP to opt out.`;
 
     const message = messageTemplate
       .replace(/{customer_name}/g, lead.name || 'there')

--- a/src/app/api/portal/route.ts
+++ b/src/app/api/portal/route.ts
@@ -412,6 +412,23 @@ export async function GET(request: NextRequest) {
   }
 
   // ============================================================
+  // SMS PREFERENCES: Get customer SMS consent status
+  // ============================================================
+  if (action === 'sms_preferences') {
+    const { data: customer } = await supabase
+      .from('customers')
+      .select('sms_consent, sms_consent_date, phone')
+      .eq('id', session.customer_id)
+      .single();
+
+    return NextResponse.json({
+      sms_consent: customer?.sms_consent || false,
+      sms_consent_date: customer?.sms_consent_date || null,
+      phone: customer?.phone || null,
+    });
+  }
+
+  // ============================================================
   // PORTAL PRO: Check if company has Portal Pro addon
   // ============================================================
   if (action === 'check_pro') {
@@ -645,6 +662,41 @@ export async function POST(request: NextRequest) {
     await query;
 
     return NextResponse.json({ success: true });
+  }
+
+  // Update SMS preferences
+  if (action === 'update_sms_preferences') {
+    const { sms_consent } = body;
+
+    if (typeof sms_consent !== 'boolean') {
+      return NextResponse.json({ error: 'sms_consent must be a boolean' }, { status: 400 });
+    }
+
+    const updateData: Record<string, unknown> = {
+      sms_consent,
+      sms_consent_date: new Date().toISOString(),
+    };
+
+    const { error } = await supabase
+      .from('customers')
+      .update(updateData)
+      .eq('id', session.customer_id);
+
+    if (error) {
+      // Retry without sms_consent_date if column doesn't exist yet
+      if (error.message?.includes('sms_consent_date')) {
+        await supabase
+          .from('customers')
+          .update({ sms_consent })
+          .eq('id', session.customer_id);
+      } else {
+        return NextResponse.json({ error: 'Failed to update preferences' }, { status: 500 });
+      }
+    }
+
+    await logPortalAccess(supabase, session.company_id, session.customer_id, 'sms_consent_updated', clientIp, `SMS consent set to ${sms_consent}`);
+
+    return NextResponse.json({ success: true, sms_consent });
   }
 
   // Logout — deactivate session

--- a/src/app/api/quote/sms-consent/route.ts
+++ b/src/app/api/quote/sms-consent/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+export async function POST(request: NextRequest) {
+  try {
+    const { customerId, quoteId, consent } = await request.json()
+
+    if (!customerId || typeof consent !== 'boolean') {
+      return NextResponse.json({ error: 'customerId and consent are required' }, { status: 400 })
+    }
+
+    // Validate UUID format
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    if (!uuidRegex.test(customerId)) {
+      return NextResponse.json({ error: 'Invalid customer ID' }, { status: 400 })
+    }
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+    if (!supabaseUrl || !supabaseServiceKey) {
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // Verify the customer exists and is linked to the quote (prevents unauthorized consent changes)
+    if (quoteId) {
+      const { data: quote } = await supabase
+        .from('quotes')
+        .select('customer_id')
+        .eq('id', quoteId)
+        .single()
+
+      if (!quote || quote.customer_id !== customerId) {
+        return NextResponse.json({ error: 'Customer not found for this quote' }, { status: 404 })
+      }
+    }
+
+    // Update SMS consent on the customer record
+    const updateData: Record<string, unknown> = {
+      sms_consent: consent,
+      sms_consent_date: new Date().toISOString(),
+    }
+
+    const { error } = await supabase
+      .from('customers')
+      .update(updateData)
+      .eq('id', customerId)
+
+    if (error) {
+      // Retry without sms_consent_date if column doesn't exist yet
+      if (error.message?.includes('sms_consent_date')) {
+        await supabase
+          .from('customers')
+          .update({ sms_consent: consent })
+          .eq('id', customerId)
+      } else {
+        return NextResponse.json({ error: 'Failed to update consent' }, { status: 500 })
+      }
+    }
+
+    return NextResponse.json({ success: true, sms_consent: consent })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/jenny-lite/page.tsx
+++ b/src/app/dashboard/jenny-lite/page.tsx
@@ -12,6 +12,7 @@ interface ChatbotSettings {
   faqs: { question: string; answer: string }[];
   accentColor: string;
   position: 'right' | 'left';
+  smsConsentText: string;
 }
 
 const DEFAULT_SETTINGS: ChatbotSettings = {
@@ -26,6 +27,7 @@ const DEFAULT_SETTINGS: ChatbotSettings = {
   ],
   accentColor: '#f5a623',
   position: 'right',
+  smsConsentText: 'By providing your phone number, you agree to receive SMS updates about your inquiry. Message & data rates may apply. Reply STOP to opt out.',
 };
 
 const STORAGE_KEY = 'tooltimepro_jenny_lite_settings';
@@ -34,7 +36,14 @@ function loadSettings(company: { name: string; phone: string | null; industry: s
   if (typeof window === 'undefined') return DEFAULT_SETTINGS;
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) return JSON.parse(stored);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      // Ensure smsConsentText exists for backward compatibility
+      if (!parsed.smsConsentText) {
+        parsed.smsConsentText = DEFAULT_SETTINGS.smsConsentText;
+      }
+      return parsed;
+    }
   } catch { /* ignore */ }
   return {
     ...DEFAULT_SETTINGS,
@@ -91,6 +100,7 @@ export default function JennyLitePage() {
     accentColor: ${JSON.stringify(settings.accentColor)},
     position: ${JSON.stringify(settings.position)},
     companyId: ${JSON.stringify(company?.id || null)},
+    smsConsentText: ${JSON.stringify(settings.smsConsentText)},
     faqs: ${JSON.stringify(settings.faqs.filter(f => f.question && f.answer), null, 2)}
   };
 </script>
@@ -301,6 +311,24 @@ export default function JennyLitePage() {
                 ))}
               </div>
             </div>
+          </div>
+
+          {/* SMS Consent Disclosure */}
+          <div className="bg-white rounded-xl border border-gray-200 p-6">
+            <h3 className="font-bold text-gray-900 mb-2">SMS Consent Disclosure</h3>
+            <p className="text-sm text-gray-500 mb-3">
+              This message is shown to visitors before they submit their phone number. Required for TCPA compliance.
+            </p>
+            <textarea
+              value={settings.smsConsentText}
+              onChange={e => setSettings({ ...settings, smsConsentText: e.target.value })}
+              rows={2}
+              className="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500 text-sm"
+              placeholder="By providing your phone number, you agree to receive SMS updates..."
+            />
+            <p className="text-xs text-gray-400 mt-1">
+              Visitors must see this notice before providing contact info. Jenny will display it in the chat.
+            </p>
           </div>
 
           {/* FAQs */}

--- a/src/app/dashboard/smart-quote/page.tsx
+++ b/src/app/dashboard/smart-quote/page.tsx
@@ -726,12 +726,8 @@ export default function SmartQuotingPage() {
         state: newCustomer.state.toUpperCase() || null,
         zip: newCustomer.zip || null,
         notes: newCustomer.notes || null,
-        sms_consent: newCustomer.sms_consent,
+        sms_consent: false,
       };
-
-      if (newCustomer.sms_consent) {
-        insertData.sms_consent_date = new Date().toISOString();
-      }
 
       const { data: created, error } = await supabase
         .from('customers')
@@ -791,7 +787,7 @@ export default function SmartQuotingPage() {
   };
 
   // Send quote
-  const [sendMethod, setSendMethod] = useState<'sms' | 'email' | 'both'>('both');
+  const [sendMethod, setSendMethod] = useState<'sms' | 'email' | 'both'>('email');
   const [isSending, setIsSending] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [quoteSent, setQuoteSent] = useState(false);
@@ -966,9 +962,10 @@ export default function SmartQuotingPage() {
 
       const sendErrors: string[] = [];
 
-      // Send SMS notification (only if customer has consented)
+      // Send SMS notification (only if customer has previously opted in)
       const hasConsent = selectedCustomer?.sms_consent;
-      if (customerPhone && hasConsent && (sendMethod === 'sms' || sendMethod === 'both')) {
+      const effectiveSendMethod = hasConsent ? sendMethod : 'email';
+      if (customerPhone && hasConsent && (effectiveSendMethod === 'sms' || effectiveSendMethod === 'both')) {
         try {
           const smsRes = await fetch('/api/sms', {
             method: 'POST',
@@ -995,7 +992,7 @@ export default function SmartQuotingPage() {
       }
 
       // Send email notification
-      if (customerEmail && (sendMethod === 'email' || sendMethod === 'both')) {
+      if (customerEmail && (effectiveSendMethod === 'email' || effectiveSendMethod === 'both')) {
         try {
           const emailRes = await fetch('/api/quote/send', {
             method: 'POST',
@@ -1353,8 +1350,10 @@ export default function SmartQuotingPage() {
                         {selectedCustomer.address && (
                           <div className="text-sm text-gray-500">{selectedCustomer.address}</div>
                         )}
-                        {selectedCustomer.sms_consent && (
+                        {selectedCustomer.sms_consent ? (
                           <span className="inline-block mt-1 text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full">SMS Opted In</span>
+                        ) : (
+                          <span className="inline-block mt-1 text-xs bg-gray-100 text-gray-500 px-2 py-0.5 rounded-full">No SMS consent — email only</span>
                         )}
                       </div>
                     </div>
@@ -1574,22 +1573,17 @@ export default function SmartQuotingPage() {
                           />
                         </div>
 
-                        {/* SMS Consent */}
-                        <div className="border rounded-lg p-3 bg-white">
-                          <label className="flex items-start gap-3 cursor-pointer">
-                            <input
-                              type="checkbox"
-                              checked={newCustomer.sms_consent}
-                              onChange={(e) => setNewCustomer(prev => ({ ...prev, sms_consent: e.target.checked }))}
-                              className="mt-1 h-4 w-4 rounded border-gray-300 text-gold-600 focus:ring-gold-500"
-                            />
+                        {/* SMS Consent Notice */}
+                        <div className="border rounded-lg p-3 bg-blue-50 border-blue-200">
+                          <div className="flex items-start gap-3">
+                            <span className="mt-0.5 text-blue-500 text-lg">&#x2139;</span>
                             <div>
-                              <span className="text-sm font-medium text-gray-700">Customer agrees to receive text messages</span>
-                              <p className="text-xs text-gray-500 mt-0.5">
-                                Required for sending SMS quotes, invoices, and reminders. Customer can opt out anytime by replying STOP.
+                              <span className="text-sm font-medium text-blue-800">SMS consent will be collected from the customer</span>
+                              <p className="text-xs text-blue-600 mt-0.5">
+                                The quote will be sent via email first. The customer can opt in to text messages when they view or approve the quote.
                               </p>
                             </div>
-                          </label>
+                          </div>
                         </div>
 
                         {/* Save & Select Button */}
@@ -2109,21 +2103,48 @@ export default function SmartQuotingPage() {
               <div className="mt-6 space-y-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">Send via:</label>
-                  <div className="flex gap-2">
-                    {['sms', 'email', 'both'].map((method) => (
-                      <button
-                        key={method}
-                        onClick={() => setSendMethod(method as typeof sendMethod)}
-                        className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                          sendMethod === method
-                            ? 'bg-navy-500 text-white'
-                            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                        }`}
-                      >
-                        {method === 'sms' ? '📱 SMS' : method === 'email' ? '📧 Email' : '📱+📧 Both'}
-                      </button>
-                    ))}
-                  </div>
+                  {selectedCustomer?.sms_consent ? (
+                    <div className="flex gap-2">
+                      {['sms', 'email', 'both'].map((method) => (
+                        <button
+                          key={method}
+                          onClick={() => setSendMethod(method as typeof sendMethod)}
+                          className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                            sendMethod === method
+                              ? 'bg-navy-500 text-white'
+                              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                          }`}
+                        >
+                          {method === 'sms' ? 'SMS' : method === 'email' ? 'Email' : 'Both'}
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <div>
+                      <div className="flex gap-2">
+                        <div className="flex-1 px-3 py-2 rounded-lg text-sm font-medium bg-navy-500 text-white text-center">
+                          Email
+                        </div>
+                        <button
+                          disabled
+                          className="flex-1 px-3 py-2 rounded-lg text-sm font-medium bg-gray-100 text-gray-400 cursor-not-allowed"
+                          title="Customer must opt in to SMS first"
+                        >
+                          SMS
+                        </button>
+                        <button
+                          disabled
+                          className="flex-1 px-3 py-2 rounded-lg text-sm font-medium bg-gray-100 text-gray-400 cursor-not-allowed"
+                          title="Customer must opt in to SMS first"
+                        >
+                          Both
+                        </button>
+                      </div>
+                      <p className="text-xs text-amber-600 mt-2 flex items-center gap-1">
+                        <span>&#9888;</span> SMS unavailable — customer hasn&apos;t opted in yet. They can opt in when they view the quote.
+                      </p>
+                    </div>
+                  )}
                 </div>
 
                 {/* Error display */}

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useEffect, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { Calendar, FileText, Home, LogOut, Truck, Camera, MessageSquare, FolderOpen, Clock, Lock, X } from 'lucide-react';
+import { Calendar, FileText, Home, LogOut, Truck, Camera, MessageSquare, FolderOpen, Clock, Lock, X, Settings } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
 
@@ -153,6 +153,9 @@ function PortalLayoutInner({ children }: { children: React.ReactNode }) {
                 </Link>
               </div>
             )}
+            <Link href="/portal/preferences" className={`p-2 rounded-lg hover:bg-gray-100 ${pathname === '/portal/preferences' ? 'bg-gray-100' : ''}`} title="Preferences">
+              <Settings className="w-4 h-4 text-gray-500" />
+            </Link>
             <button onClick={handleLogout} className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1">
               <LogOut className="w-4 h-4" />
             </button>

--- a/src/app/portal/preferences/page.tsx
+++ b/src/app/portal/preferences/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { MessageSquare, Check, AlertCircle } from 'lucide-react';
+
+interface SmsPreferences {
+  sms_consent: boolean;
+  sms_consent_date: string | null;
+  phone: string | null;
+}
+
+export default function PortalPreferencesPage() {
+  const [prefs, setPrefs] = useState<SmsPreferences | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem('portal_token');
+    if (!token) return;
+
+    fetch('/api/portal?action=sms_preferences', {
+      headers: { 'x-portal-token': token },
+    })
+      .then(res => res.json())
+      .then(data => {
+        setPrefs(data);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError('Failed to load preferences');
+        setLoading(false);
+      });
+  }, []);
+
+  const updateConsent = async (consent: boolean) => {
+    const token = localStorage.getItem('portal_token');
+    if (!token) return;
+
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+
+    try {
+      const res = await fetch('/api/portal', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-portal-token': token,
+        },
+        body: JSON.stringify({ action: 'update_sms_preferences', sms_consent: consent }),
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to update preferences');
+      }
+
+      setPrefs(prev => prev ? {
+        ...prev,
+        sms_consent: consent,
+        sms_consent_date: new Date().toISOString(),
+      } : null);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch {
+      setError('Failed to update preferences. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="text-center py-12 text-gray-400">Loading preferences...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-bold text-gray-900">Communication Preferences</h1>
+        <p className="text-sm text-gray-500 mt-1">Manage how you receive notifications</p>
+      </div>
+
+      {/* SMS Preferences */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+        <div className="p-6">
+          <div className="flex items-start gap-4">
+            <div className="w-10 h-10 bg-blue-100 rounded-xl flex items-center justify-center flex-shrink-0">
+              <MessageSquare className="w-5 h-5 text-blue-600" />
+            </div>
+            <div className="flex-1">
+              <h2 className="font-semibold text-gray-900">Text Message Notifications</h2>
+              <p className="text-sm text-gray-500 mt-1">
+                Receive SMS updates about quotes, appointments, and invoices.
+              </p>
+
+              {prefs?.phone ? (
+                <div className="mt-4 space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="text-sm font-medium text-gray-700">SMS notifications</div>
+                      <div className="text-xs text-gray-500">
+                        Sent to {prefs.phone}
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => updateConsent(!prefs.sms_consent)}
+                      disabled={saving}
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+                        prefs.sms_consent ? 'bg-green-500' : 'bg-gray-300'
+                      } ${saving ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                    >
+                      <span
+                        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                          prefs.sms_consent ? 'translate-x-6' : 'translate-x-1'
+                        }`}
+                      />
+                    </button>
+                  </div>
+
+                  {prefs.sms_consent && prefs.sms_consent_date && (
+                    <p className="text-xs text-gray-400">
+                      Opted in on {new Date(prefs.sms_consent_date).toLocaleDateString()}
+                    </p>
+                  )}
+
+                  <div className="text-xs text-gray-400 border-t border-gray-100 pt-3">
+                    <p>Message &amp; data rates may apply. You can also opt out anytime by replying STOP to any text message.</p>
+                  </div>
+                </div>
+              ) : (
+                <div className="mt-4 p-3 bg-gray-50 rounded-lg">
+                  <p className="text-sm text-gray-500">
+                    No phone number on file. Contact your service provider to add your phone number.
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Status Messages */}
+      {saved && (
+        <div className="flex items-center gap-2 p-3 bg-green-50 border border-green-200 rounded-lg">
+          <Check className="w-4 h-4 text-green-600" />
+          <span className="text-sm text-green-700">Preferences saved</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-lg">
+          <AlertCircle className="w-4 h-4 text-red-600" />
+          <span className="text-sm text-red-700">{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/quote/[id]/QuoteViewClient.tsx
+++ b/src/app/quote/[id]/QuoteViewClient.tsx
@@ -41,6 +41,7 @@ export default function CustomerQuoteView({ params }: { params: { id: string } }
   const [requestingSchedule, setRequestingSchedule] = useState(false);
   const [preferredContact, setPreferredContact] = useState<string>('');
   const [depositPaid, setDepositPaid] = useState(false);
+  const [smsOptIn, setSmsOptIn] = useState(false);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const contextRef = useRef<CanvasRenderingContext2D | null>(null);
@@ -179,6 +180,19 @@ export default function CustomerQuoteView({ params }: { params: { id: string } }
         if (!res.ok) {
           const data = await res.json();
           throw new Error(data.error || 'Failed to approve');
+        }
+
+        // Save SMS consent if customer opted in
+        if (smsOptIn && quote.customer?.id) {
+          try {
+            await fetch('/api/quote/sms-consent', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ customerId: quote.customer.id, quoteId: quote.id, consent: true }),
+            });
+          } catch {
+            // SMS consent save is best-effort, don't block approval
+          }
         }
 
         // Notify company owner that customer approved the quote
@@ -741,9 +755,32 @@ export default function CustomerQuoteView({ params }: { params: { id: string } }
           </div>
         )}
 
-        {/* Action Buttons */}
+        {/* SMS Opt-In + Action Buttons */}
         {quoteStatus === 'viewing' && !isExpired && !showRejectReason && (
           <div className="bg-white rounded-xl shadow-sm p-6">
+            {/* SMS Opt-In */}
+            {quote.customer?.phone && (
+              <div className="mb-5 border border-gray-200 rounded-lg p-4 bg-gray-50">
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={smsOptIn}
+                    onChange={(e) => setSmsOptIn(e.target.checked)}
+                    className="mt-1 h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+                  />
+                  <div>
+                    <span className="text-sm font-medium text-gray-800">
+                      I&apos;d like to receive text message updates
+                    </span>
+                    <p className="text-xs text-gray-500 mt-0.5">
+                      Get SMS notifications about your quote status, appointment reminders, and invoices.
+                      Message &amp; data rates may apply. You can opt out anytime by replying STOP.
+                    </p>
+                  </div>
+                </label>
+              </div>
+            )}
+
             <div className="flex flex-col sm:flex-row gap-4">
               <button
                 onClick={approveQuote}
@@ -757,11 +794,11 @@ export default function CustomerQuoteView({ params }: { params: { id: string } }
                   </>
                 ) : signature ? (
                   <>
-                    ✓ Approve Quote (${(quote.total || 0).toFixed(2)})
+                    &#10003; Approve Quote (${(quote.total || 0).toFixed(2)})
                   </>
                 ) : (
                   <>
-                    ✍️ Sign & Approve
+                    Sign &amp; Approve
                   </>
                 )}
               </button>


### PR DESCRIPTION
Previously, SMS consent was checked by the contractor on behalf of the customer, which doesn't constitute valid TCPA consent. This change ensures customers themselves opt in to SMS through customer-facing flows.

Changes:
- Smart Quote: enforce email-first delivery when customer hasn't opted in, replace contractor consent checkbox with informational notice, disable SMS/Both send options until customer has consented
- Quote View: add customer-facing SMS opt-in checkbox so customers can consent when viewing/approving quotes
- Jenny AI: add sms_consent check before automated lead follow-up SMS, skip leads without consent and log for audit trail
- Jenny Lite Widget: add configurable SMS consent disclosure text shown before collecting contact info
- Customer Portal: add /portal/preferences page with SMS toggle so customers can manage their own text message preferences
- Portal API: add sms_preferences GET and update_sms_preferences POST endpoints with audit logging

https://claude.ai/code/session_01WsRHNQ9mNKPfvHCUaQ7ebP