### PR TITLE
Add quote approval workflow for team members

### DIFF
--- a/database/migrations/029_quote_approval_settings.sql
+++ b/database/migrations/029_quote_approval_settings.sql
@@ -1,0 +1,13 @@
+-- Migration 029: Add quote approval settings to companies
+-- Allows owners to configure whether quotes require internal approval before sending
+
+ALTER TABLE companies
+ADD COLUMN IF NOT EXISTS quote_approval_settings JSONB DEFAULT NULL;
+
+-- Structure:
+-- {
+--   "required": true/false,          -- whether quotes need approval before sending
+--   "approver_ids": ["uuid", ...]    -- user IDs who can approve & send. Empty array = owner only
+-- }
+
+COMMENT ON COLUMN companies.quote_approval_settings IS 'Quote approval workflow config: { required: bool, approver_ids: uuid[] }';

--- a/src/app/dashboard/quotes/page.tsx
+++ b/src/app/dashboard/quotes/page.tsx
@@ -476,6 +476,16 @@ function QuotesContent() {
   const { can } = usePermissions()
   const isOwnerOrAdmin = can('quotes')
 
+  // Quote approval workflow: determine if current user can send directly
+  const approvalSettings = (company as Record<string, unknown> | null)?.quote_approval_settings as { required?: boolean; approver_ids?: string[] } | null
+  const approvalRequired = approvalSettings?.required || false
+  const isOwner = dbUser?.role === 'owner'
+  const isDesignatedApprover = approvalSettings?.approver_ids?.includes(user?.id || '') || false
+  // Can send directly if: approval not required (and has quotes perm), OR user is owner, OR user is designated approver
+  const canSendDirectly = !approvalRequired ? isOwnerOrAdmin : (isOwner || isDesignatedApprover)
+  // Can approve pending quotes (same logic)
+  const canApproveQuotes = isOwner || isDesignatedApprover
+
   const submitForApproval = async (quote: Quote) => {
     if (!companyId) return
 
@@ -930,8 +940,8 @@ function QuotesContent() {
                   </td>
                   <td className="px-6 py-4">
                     <div className="flex gap-2 flex-wrap">
-                      {/* Draft: Owner/Admin can Send directly, workers submit for approval */}
-                      {quote.status === 'draft' && isOwnerOrAdmin && (
+                      {/* Draft: Send directly if allowed, otherwise submit for approval */}
+                      {quote.status === 'draft' && canSendDirectly && (
                         <button
                           onClick={() => sendQuote(quote)}
                           disabled={sendingQuoteId === quote.id}
@@ -940,7 +950,7 @@ function QuotesContent() {
                           {sendingQuoteId === quote.id ? 'Sending...' : 'Send'}
                         </button>
                       )}
-                      {quote.status === 'draft' && !isOwnerOrAdmin && (
+                      {quote.status === 'draft' && !canSendDirectly && (
                         <button
                           onClick={() => submitForApproval(quote)}
                           disabled={sendingQuoteId === quote.id}
@@ -949,8 +959,8 @@ function QuotesContent() {
                           {sendingQuoteId === quote.id ? 'Submitting...' : 'Submit for Approval'}
                         </button>
                       )}
-                      {/* Pending Approval: Owner/Admin can approve & send, or return to draft */}
-                      {quote.status === 'pending_approval' && isOwnerOrAdmin && (
+                      {/* Pending Approval: Approvers can approve & send, or return to draft */}
+                      {quote.status === 'pending_approval' && canApproveQuotes && (
                         <>
                           <button
                             onClick={() => approveAndSend(quote)}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -64,6 +64,12 @@ function SettingsContent() {
     syncStatus: string
   } | null>(null)
 
+  // Quote approval settings
+  const [quoteApprovalRequired, setQuoteApprovalRequired] = useState(false)
+  const [quoteApproverIds, setQuoteApproverIds] = useState<string[]>([])
+  const [teamMembers, setTeamMembers] = useState<{ id: string; full_name: string; role: string }[]>([])
+  const [savingApproval, setSavingApproval] = useState(false)
+
   // Company info form
   const [companyForm, setCompanyForm] = useState<CompanyForm>({
     name: '',
@@ -112,8 +118,28 @@ function SettingsContent() {
         default_hourly_rate: c.default_hourly_rate ? String(c.default_hourly_rate) : '',
         preferred_language: (c.preferred_language as string) || 'en',
       })
+      // Load quote approval settings
+      const approvalSettings = c.quote_approval_settings as { required?: boolean; approver_ids?: string[] } | null
+      if (approvalSettings) {
+        setQuoteApprovalRequired(approvalSettings.required || false)
+        setQuoteApproverIds(approvalSettings.approver_ids || [])
+      }
     }
   }, [company])
+
+  // Fetch team members for approver selection (owners only)
+  useEffect(() => {
+    const fetchTeamMembers = async () => {
+      if (!company?.id || dbUser?.role !== 'owner') return
+      const { data } = await supabase
+        .from('users')
+        .select('id, full_name, role')
+        .eq('company_id', company.id)
+        .order('full_name')
+      if (data) setTeamMembers(data)
+    }
+    fetchTeamMembers()
+  }, [company?.id, dbUser?.role])
 
   // Check for QBO connection status
   useEffect(() => {
@@ -250,6 +276,27 @@ function SettingsContent() {
     } catch {
       setSaveMessage({ type: 'error', text: 'Failed to disconnect QuickBooks' })
     }
+  }
+
+  const saveQuoteApprovalSettings = async () => {
+    if (!company) return
+    setSavingApproval(true)
+    const settings = {
+      required: quoteApprovalRequired,
+      approver_ids: quoteApprovalRequired ? quoteApproverIds : [],
+    }
+    const { error } = await supabase
+      .from('companies')
+      .update({ quote_approval_settings: settings, updated_at: new Date().toISOString() })
+      .eq('id', company.id)
+
+    if (error) {
+      setSaveMessage({ type: 'error', text: 'Failed to save approval settings: ' + error.message })
+    } else {
+      setSaveMessage({ type: 'success', text: 'Quote approval settings saved!' })
+      setTimeout(() => setSaveMessage(null), 3000)
+    }
+    setSavingApproval(false)
   }
 
   return (
@@ -688,6 +735,83 @@ function SettingsContent() {
               </div>
             )}
           </div>
+
+          {/* Quote Approval Workflow — Owner only */}
+          {dbUser?.role === 'owner' && company && (
+            <div className="bg-white rounded-xl border p-6">
+              <h2 className="text-lg font-semibold text-gray-900 mb-1">Quote Approval Workflow</h2>
+              <p className="text-sm text-gray-500 mb-4">
+                Control whether quotes need internal approval before being sent to customers.
+              </p>
+
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={quoteApprovalRequired}
+                  onChange={(e) => {
+                    setQuoteApprovalRequired(e.target.checked)
+                    if (!e.target.checked) setQuoteApproverIds([])
+                  }}
+                  className="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <div>
+                  <span className="text-sm font-medium text-gray-900">Require approval before sending quotes</span>
+                  <p className="text-xs text-gray-500">
+                    When enabled, team members must submit quotes for approval. Only designated approvers can send quotes to customers.
+                  </p>
+                </div>
+              </label>
+
+              {quoteApprovalRequired && (
+                <div className="mt-4 pl-8">
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Who can approve &amp; send quotes?
+                  </label>
+                  <p className="text-xs text-gray-500 mb-3">
+                    You (the owner) can always approve. Select additional team members below.
+                  </p>
+                  {teamMembers.filter(m => m.id !== user?.id).length === 0 ? (
+                    <p className="text-sm text-gray-400 italic">No other team members found. Only you can approve quotes.</p>
+                  ) : (
+                    <div className="space-y-2 max-h-48 overflow-y-auto">
+                      {teamMembers
+                        .filter(m => m.id !== user?.id)
+                        .map((member) => (
+                          <label key={member.id} className="flex items-center gap-3 cursor-pointer p-2 rounded-lg hover:bg-gray-50">
+                            <input
+                              type="checkbox"
+                              checked={quoteApproverIds.includes(member.id)}
+                              onChange={(e) => {
+                                if (e.target.checked) {
+                                  setQuoteApproverIds([...quoteApproverIds, member.id])
+                                } else {
+                                  setQuoteApproverIds(quoteApproverIds.filter(id => id !== member.id))
+                                }
+                              }}
+                              className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                            />
+                            <div>
+                              <span className="text-sm text-gray-900">{member.full_name}</span>
+                              <span className="text-xs text-gray-400 ml-2 capitalize">({member.role.replace('_', ' ')})</span>
+                            </div>
+                          </label>
+                        ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <div className="mt-4 pt-4 border-t">
+                <button
+                  onClick={saveQuoteApprovalSettings}
+                  disabled={savingApproval}
+                  className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                >
+                  {savingApproval ? 'Saving...' : 'Save Approval Settings'}
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -47,6 +47,7 @@ export interface Database {
           service_area_radius: number | null
           company_description: string | null
           default_hourly_rate: number | null
+          quote_approval_settings: Json | null
           preferred_language: string
           created_at: string
           updated_at: string
@@ -85,6 +86,7 @@ export interface Database {
           service_area_radius?: number | null
           company_description?: string | null
           default_hourly_rate?: number | null
+          quote_approval_settings?: Json | null
           preferred_language?: string
           created_at?: string
           updated_at?: string
@@ -123,6 +125,7 @@ export interface Database {
           service_area_radius?: number | null
           company_description?: string | null
           default_hourly_rate?: number | null
+          quote_approval_settings?: Json | null
           preferred_language?: string
           created_at?: string
           updated_at?: string


### PR DESCRIPTION
## Summary
Implements a quote approval workflow that allows company owners to require internal approval before quotes are sent to customers. This enables better control over quote quality and consistency by designating specific team members as approvers.

## Key Changes

- **Settings Page**: Added "Quote Approval Workflow" section (owner-only) with:
  - Toggle to enable/disable quote approval requirement
  - Multi-select checkboxes to designate team members as approvers
  - Owner is always an approver when enabled
  - Fetches and displays all team members with their roles

- **Quotes Page**: Updated quote action buttons based on approval settings:
  - When approval is required: non-approvers see "Submit for Approval" button instead of "Send"
  - Approvers (owner + designated members) can send directly or approve pending quotes
  - When approval is disabled: existing behavior preserved (owner/admin can send)

- **Database**: Added `quote_approval_settings` JSONB column to companies table with structure:
  ```json
  {
    "required": boolean,
    "approver_ids": ["uuid", ...]
  }
  ```

- **Type Definitions**: Updated Database types to include the new `quote_approval_settings` field

## Implementation Details

- Quote approval settings are loaded when company data is fetched
- Team members list is fetched only for owners (permission check)
- The owner is automatically excluded from the team member selection list
- Settings are persisted to Supabase with success/error feedback
- Permission logic: users can send directly if approval is disabled OR if they're an owner/designated approver

https://claude.ai/code/session_013v2FoR3zvWVQMGvmiEpwPJ