### PR TITLE
Fix quote approval page 5xx error on Netlify

### DIFF
--- a/src/__tests__/components/quote-customer-flow.test.jsx
+++ b/src/__tests__/components/quote-customer-flow.test.jsx
@@ -152,7 +152,7 @@ function mockFetchRespondError() {
 }
 
 function renderQuoteView(id = 'q-real-123') {
-  return render(<CustomerQuoteView params={{ id }} />);
+  return render(<CustomerQuoteView quoteId={id} />);
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/src/app/quote/[id]/QuoteViewClient.tsx
+++ b/src/app/quote/[id]/QuoteViewClient.tsx
@@ -22,7 +22,7 @@ interface QuoteWithDetails extends Quote {
 }
 
 
-export default function CustomerQuoteView({ params }: { params: { id: string } }) {
+export default function CustomerQuoteView({ quoteId }: { quoteId: string }) {
   const t = useTranslations('misc.quote');
   const [quote, setQuote] = useState<QuoteWithDetails | null>(null);
   const [items, setItems] = useState<QuoteLineItem[]>([]);
@@ -52,7 +52,7 @@ export default function CustomerQuoteView({ params }: { params: { id: string } }
 
     try {
       // Fetch quote via server-side API (bypasses RLS for public access)
-      const res = await fetch(`/api/quote/public?id=${encodeURIComponent(params.id)}`);
+      const res = await fetch(`/api/quote/public?id=${encodeURIComponent(quoteId)}`);
 
       if (!res.ok) {
         throw new Error('Quote not found');
@@ -74,7 +74,7 @@ export default function CustomerQuoteView({ params }: { params: { id: string } }
     } finally {
       setIsLoading(false);
     }
-  }, [params.id]);
+  }, [quoteId]);
 
   useEffect(() => {
     fetchQuote();

--- a/src/app/quote/[id]/page.tsx
+++ b/src/app/quote/[id]/page.tsx
@@ -1,10 +1,9 @@
 import QuoteViewClient from './QuoteViewClient';
 
-// Dynamic routes — no static prerendering of demo data
-export function generateStaticParams() {
-  return [];
-}
+// Force dynamic rendering — the root layout uses cookies() for i18n,
+// which is incompatible with ISR/SSG on Netlify and causes 5xx errors.
+export const dynamic = 'force-dynamic';
 
 export default function QuotePage({ params }: { params: { id: string } }) {
-  return <QuoteViewClient params={params} />;
+  return <QuoteViewClient quoteId={params.id} />;
 }


### PR DESCRIPTION
The public quote page (/quote/[id]) was using generateStaticParams() which caused ISR/SSG rendering mode. The root layout uses cookies() for i18n locale detection, which is incompatible with static generation on Netlify and caused server errors when customers clicked quote links from email.

- Switch from SSG (generateStaticParams) to dynamic rendering
- Pass quoteId string directly instead of params object to avoid potential serialization issues with Next.js params proxy
- Update tests to match new prop interface

https://claude.ai/code/session_0174TpYXVdxvF6JgNc9hrEos