### PR TITLE
Add quotes support to customer dashboard and fix quote status terminology

### DIFF
--- a/src/app/dashboard/customers/[id]/page.tsx
+++ b/src/app/dashboard/customers/[id]/page.tsx
@@ -262,11 +262,11 @@ export default function CustomerDetailPage() {
         icon: 'filetext',
         color: 'purple',
       })
-      if (quote.status === 'accepted') {
+      if (quote.status === 'approved') {
         events.push({
           id: `quote-accepted-${quote.id}`,
           type: 'quote_accepted',
-          title: `Quote #${quote.quote_number} accepted`,
+          title: `Quote #${quote.quote_number} approved`,
           description: `$${(quote.total || 0).toLocaleString()}`,
           date: quote.created_at,
           link: '/dashboard/quotes',

--- a/src/app/dashboard/customers/page.tsx
+++ b/src/app/dashboard/customers/page.tsx
@@ -22,6 +22,7 @@ interface Customer {
   created_at: string
   jobs?: { id: string; status: string }[]
   invoices?: { id: string; status: string; total: number }[]
+  quotes?: { id: string; status: string }[]
 }
 
 export default function CustomersPage() {
@@ -62,7 +63,8 @@ export default function CustomersPage() {
       .select(`
         *,
         jobs:jobs(id, status),
-        invoices:invoices(id, status, total)
+        invoices:invoices(id, status, total),
+        quotes:quotes(id, status)
       `)
       .eq('company_id', companyId)
       .order('name')
@@ -227,6 +229,10 @@ export default function CustomersPage() {
                 <div>
                   <span className="text-gray-500">Invoices: </span>
                   <span className="font-medium">{customer.invoices?.length || 0}</span>
+                </div>
+                <div>
+                  <span className="text-gray-500">Quotes: </span>
+                  <span className="font-medium">{customer.quotes?.length || 0}</span>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
This PR adds quotes tracking to the customer dashboard and standardizes quote status terminology from "accepted" to "approved" across the application.

## Key Changes
- **Customer Dashboard**: Added quotes relationship to the Customer interface and included quotes data in the Supabase query
- **Customer List View**: Display quote count for each customer alongside existing jobs and invoices counts
- **Customer Detail Page**: Updated quote status terminology from "accepted" to "approved" in timeline events to maintain consistency with the quote management system

## Implementation Details
- Extended the Customer interface with an optional `quotes` property containing quote id and status
- Modified the Supabase `.select()` query to fetch quotes data: `quotes:quotes(id, status)`
- Added a new UI section in the customer card displaying the total number of quotes
- Standardized quote event titles and status checks to use "approved" instead of "accepted" for better clarity and consistency

https://claude.ai/code/session_01BBcXyyySVpoUyDN1f1eahd