### PR TITLE
Add quote edit history tracking and revision management

### DIFF
--- a/database/migrations/030_quote_edit_history.sql
+++ b/database/migrations/030_quote_edit_history.sql
@@ -1,0 +1,30 @@
+-- Quote Edit Audit Trail
+-- Tracks every edit made to a quote after it has been sent, providing
+-- accountability on the business side and revision transparency for customers.
+
+-- Add revision_number to quotes (starts at 0, bumped each edit-after-send)
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS revision_number INTEGER DEFAULT 0;
+
+-- ============================================
+-- QUOTE_EDIT_HISTORY (Audit log for quote changes)
+-- ============================================
+CREATE TABLE IF NOT EXISTS quote_edit_history (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    quote_id UUID NOT NULL REFERENCES quotes(id) ON DELETE CASCADE,
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    edited_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    revision_number INTEGER NOT NULL DEFAULT 1,
+    change_summary TEXT NOT NULL,        -- Human-readable summary, e.g. "Updated total from $500 to $650"
+    changes JSONB NOT NULL DEFAULT '{}', -- Structured diff: { field: { old: X, new: Y } }
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_quote_edit_history_quote ON quote_edit_history(quote_id);
+CREATE INDEX IF NOT EXISTS idx_quote_edit_history_company ON quote_edit_history(company_id);
+
+-- RLS
+ALTER TABLE quote_edit_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Quote edit history belongs to company" ON quote_edit_history
+    FOR ALL USING (company_id = (SELECT company_id FROM users WHERE id = auth.uid()));

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -262,6 +262,7 @@ CREATE TABLE quotes (
     notes TEXT,
     created_by UUID REFERENCES users(id) ON DELETE SET NULL, -- Employee who created the quote
     sent_by UUID REFERENCES users(id) ON DELETE SET NULL, -- Employee who sent the quote
+    revision_number INTEGER DEFAULT 0, -- Incremented each time a sent quote is edited
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -278,6 +279,20 @@ CREATE TABLE quote_items (
     unit_price DECIMAL(10,2) NOT NULL,
     total_price DECIMAL(10,2) NOT NULL,
     sort_order INTEGER DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================
+-- QUOTE_EDIT_HISTORY (Audit log for quote changes)
+-- ============================================
+CREATE TABLE quote_edit_history (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    quote_id UUID NOT NULL REFERENCES quotes(id) ON DELETE CASCADE,
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    edited_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    revision_number INTEGER NOT NULL DEFAULT 1,
+    change_summary TEXT NOT NULL,
+    changes JSONB NOT NULL DEFAULT '{}',
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
@@ -530,6 +545,8 @@ CREATE INDEX idx_time_entries_date ON time_entries(clock_in);
 CREATE INDEX idx_quotes_company ON quotes(company_id);
 CREATE INDEX idx_quotes_created_by ON quotes(created_by);
 CREATE INDEX idx_quotes_sent_by ON quotes(sent_by);
+CREATE INDEX idx_quote_edit_history_quote ON quote_edit_history(quote_id);
+CREATE INDEX idx_quote_edit_history_company ON quote_edit_history(company_id);
 CREATE INDEX idx_invoices_company ON invoices(company_id);
 CREATE INDEX idx_invoices_status ON invoices(status);
 CREATE INDEX idx_compliance_alerts_company ON compliance_alerts(company_id);
@@ -563,6 +580,7 @@ ALTER TABLE time_entries ENABLE ROW LEVEL SECURITY;
 ALTER TABLE breaks ENABLE ROW LEVEL SECURITY;
 ALTER TABLE quotes ENABLE ROW LEVEL SECURITY;
 ALTER TABLE quote_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE quote_edit_history ENABLE ROW LEVEL SECURITY;
 ALTER TABLE invoices ENABLE ROW LEVEL SECURITY;
 ALTER TABLE invoice_items ENABLE ROW LEVEL SECURITY;
 ALTER TABLE payments ENABLE ROW LEVEL SECURITY;
@@ -673,6 +691,10 @@ CREATE POLICY "Job notes for company jobs" ON job_notes
             WHERE j.company_id = (SELECT company_id FROM users WHERE id = auth.uid())
         )
     );
+
+-- Quote edit history: users can view edit history for quotes in their company
+CREATE POLICY "Quote edit history belongs to company" ON quote_edit_history
+    FOR ALL USING (company_id = (SELECT company_id FROM users WHERE id = auth.uid()));
 
 -- Quote items: users can manage items for quotes in their company
 CREATE POLICY "Quote items for company quotes" ON quote_items

--- a/src/app/api/quote/edit-history/route.ts
+++ b/src/app/api/quote/edit-history/route.ts
@@ -1,0 +1,261 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/quote/edit-history?quoteId=xxx
+ * Returns the edit history for a quote (business-side, auth required).
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const quoteId = searchParams.get('quoteId')
+
+    if (!quoteId) {
+      return NextResponse.json({ error: 'Missing quoteId' }, { status: 400 })
+    }
+
+    const authHeader = request.headers.get('Authorization')
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const token = authHeader.replace('Bearer ', '')
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      return NextResponse.json({ error: 'Database not configured' }, { status: 500 })
+    }
+
+    const adminClient = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+
+    // Verify caller
+    const { data: { user }, error: authError } = await adminClient.auth.getUser(token)
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: callerProfile } = await adminClient
+      .from('users')
+      .select('company_id')
+      .eq('id', user.id)
+      .single()
+
+    if (!callerProfile?.company_id) {
+      return NextResponse.json({ error: 'User profile not found' }, { status: 403 })
+    }
+
+    // Verify quote belongs to caller's company
+    const { data: quote } = await adminClient
+      .from('quotes')
+      .select('id, company_id')
+      .eq('id', quoteId)
+      .single()
+
+    if (!quote || quote.company_id !== callerProfile.company_id) {
+      return NextResponse.json({ error: 'Quote not found' }, { status: 404 })
+    }
+
+    // Fetch edit history with editor names
+    const { data: history, error: historyError } = await adminClient
+      .from('quote_edit_history')
+      .select('*')
+      .eq('quote_id', quoteId)
+      .order('created_at', { ascending: false })
+
+    if (historyError) {
+      return NextResponse.json({ error: historyError.message }, { status: 500 })
+    }
+
+    // Fetch editor names
+    const editorIds = [...new Set((history || []).filter(h => h.edited_by).map(h => h.edited_by as string))]
+    let editorsMap: Record<string, string> = {}
+    if (editorIds.length > 0) {
+      const { data: editors } = await adminClient
+        .from('users')
+        .select('id, full_name')
+        .in('id', editorIds)
+      if (editors) {
+        for (const e of editors) {
+          editorsMap[e.id] = e.full_name
+        }
+      }
+    }
+
+    const enrichedHistory = (history || []).map(h => ({
+      ...h,
+      editor_name: h.edited_by ? editorsMap[h.edited_by] || 'Unknown' : 'System',
+    }))
+
+    return NextResponse.json({ history: enrichedHistory })
+  } catch (error) {
+    console.error('Error fetching quote edit history:', error)
+    return NextResponse.json({ error: 'Failed to fetch edit history' }, { status: 500 })
+  }
+}
+
+/**
+ * POST /api/quote/edit-history
+ * Log an edit to a quote. Compares old vs new values and records the diff.
+ * Also bumps the quote's revision_number if the quote was already sent.
+ *
+ * Body: { quoteId, oldData, newData, oldItems, newItems }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { quoteId, oldData, newData, oldItems, newItems } = body
+
+    if (!quoteId || !oldData || !newData) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
+    }
+
+    const authHeader = request.headers.get('Authorization')
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const token = authHeader.replace('Bearer ', '')
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      return NextResponse.json({ error: 'Database not configured' }, { status: 500 })
+    }
+
+    const adminClient = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+
+    // Verify caller
+    const { data: { user }, error: authError } = await adminClient.auth.getUser(token)
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: callerProfile } = await adminClient
+      .from('users')
+      .select('company_id')
+      .eq('id', user.id)
+      .single()
+
+    if (!callerProfile?.company_id) {
+      return NextResponse.json({ error: 'User profile not found' }, { status: 403 })
+    }
+
+    // Verify quote belongs to caller's company
+    const { data: quote } = await adminClient
+      .from('quotes')
+      .select('id, company_id, revision_number, status')
+      .eq('id', quoteId)
+      .single()
+
+    if (!quote || quote.company_id !== callerProfile.company_id) {
+      return NextResponse.json({ error: 'Quote not found' }, { status: 404 })
+    }
+
+    // Build the diff
+    const changes: Record<string, { old: unknown; new: unknown }> = {}
+    const summaryParts: string[] = []
+
+    // Compare tracked fields
+    const trackedFields = ['subtotal', 'tax_rate', 'tax_amount', 'total', 'notes', 'valid_until', 'customer_id', 'deposit_required', 'deposit_amount', 'deposit_percentage']
+    for (const field of trackedFields) {
+      const oldVal = oldData[field]
+      const newVal = newData[field]
+      if (String(oldVal ?? '') !== String(newVal ?? '')) {
+        changes[field] = { old: oldVal, new: newVal }
+        if (field === 'total') {
+          summaryParts.push(`Total: $${Number(oldVal || 0).toFixed(2)} → $${Number(newVal || 0).toFixed(2)}`)
+        } else if (field === 'notes') {
+          summaryParts.push('Notes updated')
+        } else if (field === 'valid_until') {
+          summaryParts.push(`Valid until: ${oldVal || 'none'} → ${newVal || 'none'}`)
+        } else if (field === 'deposit_required') {
+          summaryParts.push(newVal ? 'Deposit added' : 'Deposit removed')
+        } else if (field === 'deposit_amount' || field === 'deposit_percentage') {
+          // Already covered by deposit_required change in most cases
+        }
+      }
+    }
+
+    // Compare line items
+    if (oldItems && newItems) {
+      const oldItemsSorted = [...oldItems].sort((a: { description: string }, b: { description: string }) => a.description.localeCompare(b.description))
+      const newItemsSorted = [...newItems].sort((a: { description: string }, b: { description: string }) => a.description.localeCompare(b.description))
+
+      const oldItemsStr = JSON.stringify(oldItemsSorted.map((i: { description: string; quantity: number; unit_price: number }) => ({
+        d: i.description, q: Number(i.quantity), p: Number(i.unit_price),
+      })))
+      const newItemsStr = JSON.stringify(newItemsSorted.map((i: { description: string; quantity: number; unit_price: number }) => ({
+        d: i.description, q: Number(i.quantity), p: Number(i.unit_price),
+      })))
+
+      if (oldItemsStr !== newItemsStr) {
+        changes['line_items'] = {
+          old: oldItems.map((i: { description: string; quantity: number; unit_price: number }) => ({
+            description: i.description,
+            quantity: i.quantity,
+            unit_price: i.unit_price,
+          })),
+          new: newItems.map((i: { description: string; quantity: number; unit_price: number }) => ({
+            description: i.description,
+            quantity: i.quantity,
+            unit_price: i.unit_price,
+          })),
+        }
+
+        const added = newItems.length - oldItems.length
+        if (added > 0) {
+          summaryParts.push(`${added} line item(s) added`)
+        } else if (added < 0) {
+          summaryParts.push(`${Math.abs(added)} line item(s) removed`)
+        } else {
+          summaryParts.push('Line items modified')
+        }
+      }
+    }
+
+    // If nothing changed, skip
+    if (Object.keys(changes).length === 0) {
+      return NextResponse.json({ success: true, skipped: true })
+    }
+
+    const changeSummary = summaryParts.join('; ') || 'Quote updated'
+
+    // Bump revision_number on the quote
+    const newRevision = (quote.revision_number || 0) + 1
+
+    await adminClient
+      .from('quotes')
+      .update({ revision_number: newRevision })
+      .eq('id', quoteId)
+
+    // Insert audit log entry
+    const { error: insertError } = await adminClient
+      .from('quote_edit_history')
+      .insert({
+        quote_id: quoteId,
+        company_id: callerProfile.company_id,
+        edited_by: user.id,
+        revision_number: newRevision,
+        change_summary: changeSummary,
+        changes,
+      })
+
+    if (insertError) {
+      console.error('Error logging quote edit:', insertError)
+      // Don't fail the edit - the audit log is best-effort
+      return NextResponse.json({ success: true, auditError: insertError.message })
+    }
+
+    return NextResponse.json({ success: true, revision_number: newRevision })
+  } catch (error) {
+    console.error('Error logging quote edit:', error)
+    return NextResponse.json({ error: 'Failed to log edit' }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/quotes/page.tsx
+++ b/src/app/dashboard/quotes/page.tsx
@@ -84,6 +84,9 @@ function QuotesContent() {
   const [showNewQuoteDropdown, setShowNewQuoteDropdown] = useState(false)
   const [sendingQuoteId, setSendingQuoteId] = useState<string | null>(null)
   const [deletingQuoteId, setDeletingQuoteId] = useState<string | null>(null)
+  const [historyQuoteId, setHistoryQuoteId] = useState<string | null>(null)
+  const [editHistory, setEditHistory] = useState<{ id: string; editor_name: string; change_summary: string; revision_number: number; changes: Record<string, { old: unknown; new: unknown }>; created_at: string }[]>([])
+  const [loadingHistory, setLoadingHistory] = useState(false)
 
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -651,6 +654,26 @@ function QuotesContent() {
     if (companyId) fetchQuotes(companyId)
   }
 
+  const viewEditHistory = async (quoteId: string) => {
+    setHistoryQuoteId(quoteId)
+    setLoadingHistory(true)
+    try {
+      const { data: sessionData } = await supabase.auth.getSession()
+      const token = sessionData?.session?.access_token
+      if (!token) return
+
+      const res = await fetch(`/api/quote/edit-history?quoteId=${quoteId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const data = await res.json()
+      setEditHistory(data.history || [])
+    } catch {
+      console.error('Failed to load edit history')
+    } finally {
+      setLoadingHistory(false)
+    }
+  }
+
   const canDeleteQuote = (quote: Quote) => {
     // Approved quotes cannot be deleted by anyone
     if (quote.status === 'approved') return false
@@ -1032,6 +1055,14 @@ function QuotesContent() {
                       >
                         View
                       </Link>
+                      {['sent', 'viewed', 'approved', 'rejected'].includes(quote.status) && (
+                        <button
+                          onClick={() => viewEditHistory(quote.id)}
+                          className="text-gray-500 hover:text-gray-700 text-sm"
+                        >
+                          History
+                        </button>
+                      )}
                       {canDeleteQuote(quote) && (
                         <button
                           onClick={() => deleteQuote(quote)}
@@ -1052,6 +1083,102 @@ function QuotesContent() {
       </div>
         )
       })()}
+
+      {/* Edit History Modal */}
+      {historyQuoteId && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-xl max-w-lg w-full p-6 max-h-[80vh] overflow-y-auto">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-lg font-bold text-gray-900">Edit History</h2>
+              <button
+                onClick={() => { setHistoryQuoteId(null); setEditHistory([]) }}
+                className="text-gray-400 hover:text-gray-600 text-xl"
+              >
+                &times;
+              </button>
+            </div>
+            {loadingHistory ? (
+              <div className="flex items-center justify-center py-8">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+              </div>
+            ) : editHistory.length === 0 ? (
+              <div className="text-center py-8 text-gray-500">
+                <p className="text-2xl mb-2">&#128221;</p>
+                <p>No edits recorded for this quote.</p>
+                <p className="text-sm mt-1">Edits are tracked once a quote has been sent.</p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {editHistory.map((entry) => (
+                  <div key={entry.id} className="border border-gray-200 rounded-lg p-4">
+                    <div className="flex justify-between items-start mb-2">
+                      <div>
+                        <span className="inline-block px-2 py-0.5 bg-blue-100 text-blue-700 rounded text-xs font-medium mr-2">
+                          Rev. {entry.revision_number}
+                        </span>
+                        <span className="text-sm font-medium text-gray-900">
+                          {entry.editor_name}
+                        </span>
+                      </div>
+                      <span className="text-xs text-gray-500">
+                        {new Date(entry.created_at).toLocaleString()}
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-700 mb-2">{entry.change_summary}</p>
+                    {/* Detailed changes */}
+                    {entry.changes && Object.keys(entry.changes).length > 0 && (
+                      <div className="mt-2 space-y-1">
+                        {Object.entries(entry.changes).map(([field, diff]) => {
+                          if (field === 'line_items') {
+                            const oldItems = diff.old as { description: string; quantity: number; unit_price: number }[]
+                            const newItems = diff.new as { description: string; quantity: number; unit_price: number }[]
+                            return (
+                              <div key={field} className="text-xs bg-gray-50 rounded p-2">
+                                <span className="font-medium text-gray-600">Line Items:</span>
+                                <div className="mt-1 grid grid-cols-2 gap-2">
+                                  <div>
+                                    <span className="text-red-600 font-medium">Before ({oldItems.length}):</span>
+                                    <ul className="list-disc list-inside">
+                                      {oldItems.map((item, i) => (
+                                        <li key={i} className="text-gray-600 truncate">
+                                          {item.description} &times;{item.quantity} @ ${Number(item.unit_price).toFixed(2)}
+                                        </li>
+                                      ))}
+                                    </ul>
+                                  </div>
+                                  <div>
+                                    <span className="text-green-600 font-medium">After ({newItems.length}):</span>
+                                    <ul className="list-disc list-inside">
+                                      {newItems.map((item, i) => (
+                                        <li key={i} className="text-gray-600 truncate">
+                                          {item.description} &times;{item.quantity} @ ${Number(item.unit_price).toFixed(2)}
+                                        </li>
+                                      ))}
+                                    </ul>
+                                  </div>
+                                </div>
+                              </div>
+                            )
+                          }
+                          const label = field.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+                          return (
+                            <div key={field} className="text-xs flex items-center gap-2 bg-gray-50 rounded px-2 py-1">
+                              <span className="font-medium text-gray-600">{label}:</span>
+                              <span className="text-red-600 line-through">{String(diff.old ?? 'none')}</span>
+                              <span className="text-gray-400">&rarr;</span>
+                              <span className="text-green-600">{String(diff.new ?? 'none')}</span>
+                            </div>
+                          )
+                        })}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Add/Edit Modal */}
       {showModal && (
@@ -1300,12 +1427,73 @@ function QuoteModal({ quote, companyId, userId, customers, defaultQuoteTerms, is
     let quoteId = quote?.id
 
     if (quote) {
+      // Capture old data before updating for audit trail
+      const oldData = {
+        subtotal: quote.subtotal,
+        tax_rate: quote.tax_rate,
+        tax_amount: quote.tax_amount,
+        total: quote.total,
+        notes: quote.notes,
+        valid_until: quote.valid_until,
+        customer_id: quote.customer_id,
+        deposit_required: quote.deposit_required,
+        deposit_amount: quote.deposit_amount,
+        deposit_percentage: quote.deposit_percentage,
+      }
+
       // Update existing quote
       const { error: updateError } = await supabase.from('quotes').update(quoteData).eq('id', quote.id)
       if (updateError) {
         alert('Failed to update quote: ' + updateError.message)
         setSaving(false)
         return
+      }
+
+      // Log the edit if the quote has been sent (audit trail)
+      if (['sent', 'viewed', 'approved', 'rejected'].includes(quote.status)) {
+        try {
+          // Gather old items from what was loaded into the form
+          const oldItems = quote.items?.map(i => ({
+            description: i.description,
+            quantity: i.quantity,
+            unit_price: i.unit_price,
+          })) || []
+
+          const newItems = items.filter(i => i.description).map(i => ({
+            description: i.description,
+            quantity: Number(i.quantity),
+            unit_price: Number(i.unit_price),
+          }))
+
+          await fetch('/api/quote/edit-history', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({
+              quoteId: quote.id,
+              oldData,
+              newData: {
+                subtotal: Number(subtotal) || 0,
+                tax_rate: 8.75,
+                tax_amount: Number(tax_amount) || 0,
+                total: Number(total) || 0,
+                notes: formData.notes,
+                valid_until: formData.valid_until,
+                customer_id: customerId,
+                deposit_required: depositRequired,
+                deposit_amount: depositType === 'fixed' ? Number(depositValue) || null : null,
+                deposit_percentage: depositType === 'percentage' ? Number(depositValue) || null : null,
+              },
+              oldItems,
+              newItems,
+            }),
+          })
+        } catch {
+          // Audit logging is best-effort, don't block the save
+          console.log('Quote edit audit log skipped')
+        }
       }
     } else {
       // Create new quote via server-side API (bypasses RLS issues)

--- a/src/app/quote/[id]/QuoteViewClient.tsx
+++ b/src/app/quote/[id]/QuoteViewClient.tsx
@@ -386,16 +386,23 @@ export default function CustomerQuoteView({ quoteId }: { quoteId: string }) {
             <div className="text-right">
               <LanguageSwitcher />
               <div className="text-sm text-gray-500 mt-2">{t('quoteNumber')}{quote.quote_number || quote.id.slice(0, 8)}</div>
-              <div className={`inline-block px-3 py-1 rounded-full text-sm font-medium mt-1 ${
-                quoteStatus === 'approved'
-                  ? 'bg-green-100 text-green-700'
-                  : quoteStatus === 'rejected'
-                  ? 'bg-red-100 text-red-700'
-                  : isExpired
-                  ? 'bg-gray-100 text-gray-700'
-                  : 'bg-gold-100 text-gold-700'
-              }`}>
-                {quoteStatus === 'approved' ? `✓ ${t('approved')}` : quoteStatus === 'rejected' ? t('declined') : isExpired ? t('expired') : t('awaitingResponse')}
+              <div className="flex items-center gap-2 justify-end mt-1">
+                <div className={`inline-block px-3 py-1 rounded-full text-sm font-medium ${
+                  quoteStatus === 'approved'
+                    ? 'bg-green-100 text-green-700'
+                    : quoteStatus === 'rejected'
+                    ? 'bg-red-100 text-red-700'
+                    : isExpired
+                    ? 'bg-gray-100 text-gray-700'
+                    : 'bg-gold-100 text-gold-700'
+                }`}>
+                  {quoteStatus === 'approved' ? `✓ ${t('approved')}` : quoteStatus === 'rejected' ? t('declined') : isExpired ? t('expired') : t('awaitingResponse')}
+                </div>
+                {((quote as unknown as Record<string, unknown>).revision_number as number) > 0 && (
+                  <div className="inline-block px-3 py-1 rounded-full text-sm font-medium bg-amber-100 text-amber-700">
+                    Revised (Rev. {(quote as unknown as Record<string, unknown>).revision_number as number})
+                  </div>
+                )}
               </div>
             </div>
           </div>
@@ -508,6 +515,21 @@ export default function CustomerQuoteView({ quoteId }: { quoteId: string }) {
           </div>
         )}
 
+        {/* Revision Notice */}
+        {((quote as unknown as Record<string, unknown>).revision_number as number) > 0 && quoteStatus === 'viewing' && (
+          <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 flex items-start gap-3">
+            <div className="text-amber-500 text-lg mt-0.5">&#9888;</div>
+            <div>
+              <h3 className="font-semibold text-amber-800">This quote has been revised</h3>
+              <p className="text-sm text-amber-700 mt-1">
+                This is revision {(quote as unknown as Record<string, unknown>).revision_number as number} of quote {quote.quote_number || quote.id.slice(0, 8)}.
+                It was last updated on {formatDate(quote.updated_at)}.
+                Please review the updated details below before approving.
+              </p>
+            </div>
+          </div>
+        )}
+
         {/* Quote Details Card */}
         <div className="bg-white rounded-xl shadow-sm overflow-hidden mb-6">
           {/* Customer Info */}
@@ -521,6 +543,12 @@ export default function CustomerQuoteView({ quoteId }: { quoteId: string }) {
               <div className="md:text-right">
                 <div className="text-sm text-gray-500 mb-1">{t('quoteDate')}</div>
                 <div className="font-medium text-navy-500">{formatDate(quote.created_at)}</div>
+                {((quote as unknown as Record<string, unknown>).revision_number as number) > 0 && (
+                  <div className="mt-1">
+                    <div className="text-sm text-gray-500">Last Updated</div>
+                    <div className="font-medium text-amber-600">{formatDate(quote.updated_at)}</div>
+                  </div>
+                )}
                 <div className="text-sm text-gray-500 mt-2">{t('validUntil')}</div>
                 <div className={`font-medium ${isExpired ? 'text-red-500' : 'text-navy-500'}`}>
                   {formatDate(quote.valid_until)}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -540,6 +540,7 @@ export interface Database {
           deposit_paid: boolean
           deposit_paid_at: string | null
           deposit_stripe_payment_id: string | null
+          revision_number: number
           created_at: string
           updated_at: string
         }
@@ -571,6 +572,7 @@ export interface Database {
           deposit_paid?: boolean
           deposit_paid_at?: string | null
           deposit_stripe_payment_id?: string | null
+          revision_number?: number
           created_at?: string
           updated_at?: string
         }
@@ -602,8 +604,41 @@ export interface Database {
           deposit_paid?: boolean
           deposit_paid_at?: string | null
           deposit_stripe_payment_id?: string | null
+          revision_number?: number
           created_at?: string
           updated_at?: string
+        }
+      }
+      quote_edit_history: {
+        Row: {
+          id: string
+          quote_id: string
+          company_id: string
+          edited_by: string | null
+          revision_number: number
+          change_summary: string
+          changes: Record<string, { old: unknown; new: unknown }>
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          quote_id: string
+          company_id: string
+          edited_by?: string | null
+          revision_number?: number
+          change_summary: string
+          changes?: Record<string, { old: unknown; new: unknown }>
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          quote_id?: string
+          company_id?: string
+          edited_by?: string | null
+          revision_number?: number
+          change_summary?: string
+          changes?: Record<string, { old: unknown; new: unknown }>
+          created_at?: string
         }
       }
       invoices: {
@@ -1226,6 +1261,7 @@ export type JobInsert = Database['public']['Tables']['jobs']['Insert']
 export type TimeEntryInsert = Database['public']['Tables']['time_entries']['Insert']
 export type BreakInsert = Database['public']['Tables']['breaks']['Insert']
 export type QuoteInsert = Database['public']['Tables']['quotes']['Insert']
+export type QuoteEditHistory = Database['public']['Tables']['quote_edit_history']['Row']
 export type InvoiceInsert = Database['public']['Tables']['invoices']['Insert']
 export type IncidentInsert = Database['public']['Tables']['incidents']['Insert']
 export type ComplianceAlertInsert = Database['public']['Tables']['compliance_alerts']['Insert']


### PR DESCRIPTION
## Summary
Implements comprehensive audit logging for quote edits after quotes have been sent to customers. This provides accountability on the business side and revision transparency for customers by tracking all changes made to sent quotes.

## Key Changes

### Backend
- **New API endpoint** (`/api/quote/edit-history`):
  - `GET` - Retrieves edit history for a quote with editor names and detailed change information
  - `POST` - Logs quote edits, compares old vs new values, and bumps revision numbers
  - Includes authorization checks to ensure users can only access quotes from their company

- **Database schema updates**:
  - Added `revision_number` column to `quotes` table (incremented on each edit after send)
  - Created new `quote_edit_history` table to store audit trail with structured diffs
  - Added indexes and RLS policies for security

### Frontend
- **Quotes dashboard** (`/app/dashboard/quotes/page.tsx`):
  - Added "History" button for sent/viewed/approved/rejected quotes
  - New modal displaying edit history with revision numbers, editor names, timestamps, and detailed change summaries
  - Shows before/after values for all tracked fields including line items

- **Quote editor** (`QuoteModal`):
  - Captures old quote data before updates
  - Automatically logs edits to audit trail when saving sent quotes
  - Includes old and new line items in audit log

- **Customer quote view** (`QuoteViewClient.tsx`):
  - Displays revision badge showing current revision number
  - Shows revision notice when customer views a revised quote
  - Displays last updated date alongside creation date

### Data Tracking
Audit logs capture changes to:
- Financial fields: subtotal, tax rate, tax amount, total
- Deposit settings: required flag, amount, percentage
- Quote metadata: notes, valid until date, customer
- Line items: additions, removals, and modifications with quantities and prices

## Implementation Details
- Audit logging is best-effort and non-blocking (failures don't prevent quote saves)
- Edit history only tracked for quotes in sent/viewed/approved/rejected states
- Changes are stored as structured JSON diffs for detailed analysis
- Human-readable summaries generated for each edit (e.g., "Total: $500 → $650")
- Line items compared by normalized JSON to detect any modifications

https://claude.ai/code/session_01U6wK7BAvDhkC51V2h78uC2