### PR TITLE
Refactor Google Calendar API routes to use consistent URL handling

### DIFF
--- a/src/app/api/google-calendar/callback/route.js
+++ b/src/app/api/google-calendar/callback/route.js
@@ -5,19 +5,9 @@ export const dynamic = 'force-dynamic'
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || ''
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || ''
-
-function getAppUrl(request) {
-  if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL
-  const proto = request.headers.get('x-forwarded-proto') || 'https'
-  const host = request.headers.get('host')
-  if (host) return `${proto}://${host}`
-  return 'https://app.tooltimepro.com'
-}
+const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.tooltimepro.com'
 
 export async function GET(request) {
-  const APP_URL = getAppUrl(request)
-  const REDIRECT_URI = `${APP_URL}/api/google-calendar/callback`
-
   try {
     const { searchParams } = new URL(request.url)
     const code = searchParams.get('code')
@@ -27,13 +17,13 @@ export async function GET(request) {
     if (error) {
       console.error('Google OAuth error:', error)
       return NextResponse.redirect(
-        new URL('/dashboard/settings?gcal=error&reason=oauth_denied', APP_URL)
+        new URL('/dashboard/settings?gcal=error&reason=oauth_denied', SITE_URL)
       )
     }
 
     if (!code || !state) {
       return NextResponse.redirect(
-        new URL('/dashboard/settings?gcal=error&reason=missing_params', APP_URL)
+        new URL('/dashboard/settings?gcal=error&reason=missing_params', SITE_URL)
       )
     }
 
@@ -43,7 +33,7 @@ export async function GET(request) {
       stateData = JSON.parse(Buffer.from(state, 'base64url').toString())
     } catch {
       return NextResponse.redirect(
-        new URL('/dashboard/settings?gcal=error&reason=invalid_state', APP_URL)
+        new URL('/dashboard/settings?gcal=error&reason=invalid_state', SITE_URL)
       )
     }
 
@@ -52,15 +42,17 @@ export async function GET(request) {
     // Reject stale OAuth state (older than 10 minutes) to prevent replay attacks
     if (!timestamp || Date.now() - timestamp > 10 * 60 * 1000) {
       return NextResponse.redirect(
-        new URL('/dashboard/settings?gcal=error&reason=expired_state', APP_URL)
+        new URL('/dashboard/settings?gcal=error&reason=expired_state', SITE_URL)
       )
     }
 
     if (!userId) {
       return NextResponse.redirect(
-        new URL('/dashboard/settings?gcal=error&reason=no_user', APP_URL)
+        new URL('/dashboard/settings?gcal=error&reason=no_user', SITE_URL)
       )
     }
+
+    const REDIRECT_URI = `${SITE_URL}/api/google-calendar/callback`
 
     // Exchange authorization code for tokens
     const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
@@ -79,7 +71,7 @@ export async function GET(request) {
       const errBody = await tokenResponse.text()
       console.error('Google token exchange failed:', errBody)
       return NextResponse.redirect(
-        new URL('/dashboard/settings?gcal=error&reason=token_exchange', APP_URL)
+        new URL('/dashboard/settings?gcal=error&reason=token_exchange', SITE_URL)
       )
     }
 
@@ -89,10 +81,17 @@ export async function GET(request) {
     const expiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString()
 
     // Get user's company_id from the database
-    const supabaseAdmin = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL,
-      process.env.SUPABASE_SERVICE_ROLE_KEY
-    )
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      console.error('Supabase not configured')
+      return NextResponse.redirect(
+        new URL('/dashboard/settings?gcal=error&reason=db_not_configured', SITE_URL)
+      )
+    }
+
+    const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey)
 
     const { data: dbUser, error: userError } = await supabaseAdmin
       .from('users')
@@ -103,7 +102,7 @@ export async function GET(request) {
     if (userError || !dbUser?.company_id) {
       console.error('Failed to get user company:', userError)
       return NextResponse.redirect(
-        new URL('/dashboard/settings?gcal=error&reason=no_company', APP_URL)
+        new URL('/dashboard/settings?gcal=error&reason=no_company', SITE_URL)
       )
     }
 
@@ -126,17 +125,17 @@ export async function GET(request) {
     if (upsertError) {
       console.error('Failed to store Google Calendar connection:', upsertError)
       return NextResponse.redirect(
-        new URL('/dashboard/settings?gcal=error&reason=db_error', APP_URL)
+        new URL('/dashboard/settings?gcal=error&reason=db_error', SITE_URL)
       )
     }
 
     return NextResponse.redirect(
-      new URL('/dashboard/settings?gcal=connected', APP_URL)
+      new URL('/dashboard/settings?gcal=connected', SITE_URL)
     )
   } catch (error) {
     console.error('Google Calendar callback error:', error)
     return NextResponse.redirect(
-      new URL('/dashboard/settings?gcal=error', APP_URL)
+      new URL('/dashboard/settings?gcal=error', SITE_URL)
     )
   }
 }

--- a/src/app/api/google-calendar/connect/route.js
+++ b/src/app/api/google-calendar/connect/route.js
@@ -1,71 +1,45 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
 
 export const dynamic = 'force-dynamic'
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || ''
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || ''
+const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.tooltimepro.com'
 
-function getAppUrl(request) {
-  if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL
-  const proto = request.headers.get('x-forwarded-proto') || 'https'
-  const host = request.headers.get('host')
-  if (host) return `${proto}://${host}`
-  return 'https://app.tooltimepro.com'
-}
-
-export async function GET(request) {
-  const APP_URL = getAppUrl(request)
-  const REDIRECT_URI = `${APP_URL}/api/google-calendar/callback`
-
+export async function GET() {
   try {
     if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET) {
       console.error('Google Calendar environment variables not configured')
       return NextResponse.redirect(
-        new URL('/dashboard/settings?gcal=error&reason=not_configured', APP_URL)
+        new URL('/dashboard/settings?gcal=error&reason=not_configured', SITE_URL)
       )
     }
 
-    // Get user from Authorization header Bearer token
-    const authHeader = request.headers.get('authorization')
-    let userId = null
+    // Get the current user from Supabase using SSR client
+    const supabase = await createSupabaseServerClient()
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
 
-    if (authHeader && authHeader.startsWith('Bearer ')) {
-      const token = authHeader.slice(7)
-      const supabaseAdmin = createClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL,
-        process.env.SUPABASE_SERVICE_ROLE_KEY
-      )
-      const { data: { user }, error } = await supabaseAdmin.auth.getUser(token)
-      if (!error && user) {
-        userId = user.id
-      }
+    if (userError) {
+      console.error('Error getting user:', userError)
     }
 
-    // Fallback: try cookie-based auth
-    if (!userId) {
-      const { createSupabaseServerClient } = await import('@/lib/supabase-server')
-      const supabase = await createSupabaseServerClient()
-      const { data: { user } } = await supabase.auth.getUser()
-      if (user) {
-        userId = user.id
-      }
-    }
-
-    if (!userId) {
+    if (!user) {
       return NextResponse.redirect(
-        new URL('/auth/login?redirect=/dashboard/settings', APP_URL)
+        new URL('/auth/login?redirect=/dashboard/settings', SITE_URL)
       )
     }
 
     // Encode user ID in state param for CSRF protection
     const state = Buffer.from(
       JSON.stringify({
-        userId,
+        userId: user.id,
         timestamp: Date.now(),
         nonce: Math.random().toString(36).substring(7),
       })
     ).toString('base64url')
+
+    const REDIRECT_URI = `${SITE_URL}/api/google-calendar/callback`
 
     const params = new URLSearchParams({
       client_id: GOOGLE_CLIENT_ID,
@@ -83,7 +57,7 @@ export async function GET(request) {
   } catch (error) {
     console.error('Google Calendar connect error:', error)
     return NextResponse.redirect(
-      new URL('/dashboard/settings?gcal=error', APP_URL)
+      new URL('/dashboard/settings?gcal=error', SITE_URL)
     )
   }
 }

--- a/src/app/api/google-calendar/disconnect/route.js
+++ b/src/app/api/google-calendar/disconnect/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
 
 export const dynamic = 'force-dynamic'
 
@@ -23,7 +24,6 @@ export async function POST(request) {
     }
 
     if (!userId) {
-      const { createSupabaseServerClient } = await import('@/lib/supabase-server')
       const supabase = await createSupabaseServerClient()
       const { data: { user } } = await supabase.auth.getUser()
       if (user) {

--- a/src/app/api/google-calendar/sync/route.js
+++ b/src/app/api/google-calendar/sync/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
 
 export const dynamic = 'force-dynamic'
 
@@ -156,7 +157,6 @@ export async function POST(request) {
     }
 
     if (!userId) {
-      const { createSupabaseServerClient } = await import('@/lib/supabase-server')
       const supabase = await createSupabaseServerClient()
       const { data: { user } } = await supabase.auth.getUser()
       if (user) {


### PR DESCRIPTION
## Summary
Refactored Google Calendar API routes to simplify URL handling and improve authentication consistency by removing dynamic URL construction in favor of a static `SITE_URL` environment variable.

## Key Changes

- **Removed dynamic URL construction**: Eliminated the `getAppUrl()` function that attempted to derive the app URL from request headers. Now uses a single `SITE_URL` constant derived from `NEXT_PUBLIC_APP_URL` environment variable with a fallback to `https://app.tooltimepro.com`.

- **Simplified authentication in connect route**: 
  - Removed Bearer token authentication logic from the Authorization header
  - Now exclusively uses the Supabase server client for cookie-based authentication
  - Removed the `request` parameter from the GET handler since it's no longer needed

- **Improved error handling in callback route**:
  - Added explicit validation for Supabase configuration variables before use
  - Returns a specific error when Supabase is not properly configured

- **Consolidated imports**: Moved `createSupabaseServerClient` import to the top of files in `disconnect` and `sync` routes instead of using dynamic imports, improving code clarity and consistency.

## Implementation Details

- The `SITE_URL` is now computed once at module load time rather than on every request, reducing overhead
- All redirect URLs throughout the Google Calendar flow now consistently use the same `SITE_URL` constant
- Authentication now relies solely on Supabase's built-in cookie handling via the server client, simplifying the auth flow
- Added validation for required Supabase environment variables to fail fast with clear error messages

https://claude.ai/code/session_013iuUF84JhFhuq8R3pVEPNK