### PR TITLE
Refactor Google Calendar API auth to use Bearer tokens

### DIFF
--- a/src/app/api/google-calendar/connect/route.js
+++ b/src/app/api/google-calendar/connect/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { createClient } from '@supabase/supabase-js'
 
 export const dynamic = 'force-dynamic'
 
@@ -7,27 +7,41 @@ const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || ''
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || ''
 const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.tooltimepro.com'
 
-export async function GET() {
+export async function POST(request) {
   try {
     if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET) {
-      console.error('Google Calendar environment variables not configured')
-      return NextResponse.redirect(
-        new URL('/dashboard/settings?gcal=error&reason=not_configured', SITE_URL)
+      return NextResponse.json(
+        { error: 'Google Calendar is not configured' },
+        { status: 503 }
       )
     }
 
-    // Get the current user from Supabase using SSR client
-    const supabase = await createSupabaseServerClient()
+    // Authenticate via Bearer token (the app uses localStorage-based auth,
+    // so cookies are not available in API routes)
+    const authHeader = request.headers.get('authorization')
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    }
+
+    const token = authHeader.slice(7)
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return NextResponse.json(
+        { error: 'Database not configured' },
+        { status: 503 }
+      )
+    }
+
+    // Validate the token by creating a Supabase client with it
+    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: `Bearer ${token}` } },
+    })
     const { data: { user }, error: userError } = await supabase.auth.getUser()
 
-    if (userError) {
-      console.error('Error getting user:', userError)
-    }
-
-    if (!user) {
-      return NextResponse.redirect(
-        new URL('/auth/login?redirect=/dashboard/settings', SITE_URL)
-      )
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
     }
 
     // Encode user ID in state param for CSRF protection
@@ -53,11 +67,12 @@ export async function GET() {
 
     const authUrl = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`
 
-    return NextResponse.redirect(authUrl)
+    return NextResponse.json({ url: authUrl })
   } catch (error) {
     console.error('Google Calendar connect error:', error)
-    return NextResponse.redirect(
-      new URL('/dashboard/settings?gcal=error', SITE_URL)
+    return NextResponse.json(
+      { error: 'Failed to initiate Google Calendar connection' },
+      { status: 500 }
     )
   }
 }

--- a/src/app/api/google-calendar/disconnect/route.js
+++ b/src/app/api/google-calendar/disconnect/route.js
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
-import { createSupabaseServerClient } from '@/lib/supabase-server'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,29 +10,19 @@ export async function POST(request) {
       process.env.SUPABASE_SERVICE_ROLE_KEY
     )
 
-    // Get user from Authorization header or cookie
-    let userId = null
+    // Authenticate via Bearer token (the app uses localStorage-based auth)
     const authHeader = request.headers.get('authorization')
-
-    if (authHeader && authHeader.startsWith('Bearer ')) {
-      const token = authHeader.slice(7)
-      const { data: { user }, error } = await supabaseAdmin.auth.getUser(token)
-      if (!error && user) {
-        userId = user.id
-      }
-    }
-
-    if (!userId) {
-      const supabase = await createSupabaseServerClient()
-      const { data: { user } } = await supabase.auth.getUser()
-      if (user) {
-        userId = user.id
-      }
-    }
-
-    if (!userId) {
+    if (!authHeader?.startsWith('Bearer ')) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const token = authHeader.slice(7)
+    const { data: { user }, error: userError } = await supabaseAdmin.auth.getUser(token)
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const userId = user.id
 
     // Optionally revoke the Google token before deleting
     const { data: connection } = await supabaseAdmin

--- a/src/app/api/google-calendar/sync/route.js
+++ b/src/app/api/google-calendar/sync/route.js
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
-import { createSupabaseServerClient } from '@/lib/supabase-server'
 
 export const dynamic = 'force-dynamic'
 
@@ -144,29 +143,19 @@ export async function POST(request) {
       process.env.SUPABASE_SERVICE_ROLE_KEY
     )
 
-    // Get user from Authorization header or cookie
-    let userId = null
+    // Authenticate via Bearer token (the app uses localStorage-based auth)
     const authHeader = request.headers.get('authorization')
-
-    if (authHeader && authHeader.startsWith('Bearer ')) {
-      const token = authHeader.slice(7)
-      const { data: { user }, error } = await supabaseAdmin.auth.getUser(token)
-      if (!error && user) {
-        userId = user.id
-      }
-    }
-
-    if (!userId) {
-      const supabase = await createSupabaseServerClient()
-      const { data: { user } } = await supabase.auth.getUser()
-      if (user) {
-        userId = user.id
-      }
-    }
-
-    if (!userId) {
+    if (!authHeader?.startsWith('Bearer ')) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const token = authHeader.slice(7)
+    const { data: { user }, error: userError } = await supabaseAdmin.auth.getUser(token)
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const userId = user.id
 
     // Get Google Calendar connection for this user
     const { data: connection, error: connError } = await supabaseAdmin

--- a/src/components/settings/GoogleCalendarConnect.tsx
+++ b/src/components/settings/GoogleCalendarConnect.tsx
@@ -52,9 +52,38 @@ export default function GoogleCalendarConnect() {
     }
   }, [searchParams])
 
-  const handleConnect = () => {
+  const handleConnect = async () => {
     setConnecting(true)
-    window.location.href = '/api/google-calendar/connect'
+    setMessage(null)
+
+    try {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (!session?.access_token) {
+        setMessage({ type: 'error', text: 'Please log in again to connect Google Calendar.' })
+        setConnecting(false)
+        return
+      }
+
+      const response = await fetch('/api/google-calendar/connect', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}))
+        throw new Error(errData.error || 'Failed to start Google Calendar connection')
+      }
+
+      const { url } = await response.json()
+      window.location.href = url
+    } catch (error) {
+      console.error('Connect failed:', error)
+      setMessage({
+        type: 'error',
+        text: error instanceof Error ? error.message : 'Failed to connect. Please try again.',
+      })
+      setConnecting(false)
+    }
   }
 
   const handleSync = async () => {
@@ -62,8 +91,12 @@ export default function GoogleCalendarConnect() {
     setMessage(null)
 
     try {
+      const { data: { session } } = await supabase.auth.getSession()
       const response = await fetch('/api/google-calendar/sync', {
         method: 'POST',
+        headers: session?.access_token
+          ? { Authorization: `Bearer ${session.access_token}` }
+          : {},
       })
 
       if (!response.ok) {
@@ -93,8 +126,12 @@ export default function GoogleCalendarConnect() {
     if (!confirm('Are you sure you want to disconnect Google Calendar?')) return
 
     try {
+      const { data: { session } } = await supabase.auth.getSession()
       const response = await fetch('/api/google-calendar/disconnect', {
         method: 'POST',
+        headers: session?.access_token
+          ? { Authorization: `Bearer ${session.access_token}` }
+          : {},
       })
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
Refactored Google Calendar API routes to use Bearer token authentication instead of relying on server-side session cookies. This change aligns with the app's localStorage-based authentication model and improves compatibility with client-side API calls.

## Key Changes
- **Connect endpoint** (`/api/google-calendar/connect`):
  - Changed from GET to POST method
  - Replaced server-side session retrieval with Bearer token validation
  - Changed response from redirect to JSON with auth URL
  - Updated to use `createClient` directly instead of `createSupabaseServerClient`

- **Sync endpoint** (`/api/google-calendar/sync`):
  - Simplified authentication to only accept Bearer tokens
  - Removed fallback to cookie-based session retrieval
  - Removed dependency on `createSupabaseServerClient`

- **Disconnect endpoint** (`/api/google-calendar/disconnect`):
  - Simplified authentication to only accept Bearer tokens
  - Removed fallback to cookie-based session retrieval
  - Removed dependency on `createSupabaseServerClient`

- **GoogleCalendarConnect component**:
  - Updated `handleConnect` to be async and fetch the auth URL via POST
  - Added Bearer token extraction from session and passed in Authorization header
  - Updated `handleSync` and `handleDisconnect` to include Bearer token in requests
  - Improved error handling with user-friendly error messages

## Implementation Details
- All three API routes now consistently use Bearer token authentication via the `Authorization` header
- Tokens are validated using `supabaseAdmin.auth.getUser(token)` 
- Client-side component retrieves the access token from `supabase.auth.getSession()` and includes it in all API requests
- Error responses are now JSON instead of redirects, providing better error context to the client

https://claude.ai/code/session_0154dUPUhmBwTNJcWKsauHzu