### PR TITLE
Refactor OAuth connect endpoints to use Bearer token auth

### DIFF
--- a/src/app/api/google-calendar/connect/route.js
+++ b/src/app/api/google-calendar/connect/route.js
@@ -7,11 +7,18 @@ const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || ''
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || ''
 const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.tooltimepro.com'
 
+function getSupabaseAdmin() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) return null
+  return createClient(url, key)
+}
+
 export async function POST(request) {
   try {
     if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET) {
       return NextResponse.json(
-        { error: 'Google Calendar is not configured' },
+        { error: 'Google Calendar is not configured. Please contact support.' },
         { status: 503 }
       )
     }
@@ -19,29 +26,24 @@ export async function POST(request) {
     // Authenticate via Bearer token (the app uses localStorage-based auth,
     // so cookies are not available in API routes)
     const authHeader = request.headers.get('authorization')
-    if (!authHeader?.startsWith('Bearer ')) {
+    const token = authHeader?.replace('Bearer ', '')
+    if (!token) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
     }
 
-    const token = authHeader.slice(7)
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
-    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
-
-    if (!supabaseUrl || !supabaseAnonKey) {
+    const supabase = getSupabaseAdmin()
+    if (!supabase) {
       return NextResponse.json(
-        { error: 'Database not configured' },
-        { status: 503 }
+        { error: 'Server configuration error. Please contact support.' },
+        { status: 500 }
       )
     }
 
-    // Validate the token by creating a Supabase client with it
-    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-      global: { headers: { Authorization: `Bearer ${token}` } },
-    })
-    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    // Validate the token explicitly (matching Stripe Connect pattern)
+    const { data: { user }, error: userError } = await supabase.auth.getUser(token)
 
     if (userError || !user) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+      return NextResponse.json({ error: 'Session expired. Please log in again.' }, { status: 401 })
     }
 
     // Encode user ID in state param for CSRF protection

--- a/src/app/api/quickbooks/connect/route.ts
+++ b/src/app/api/quickbooks/connect/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
-import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
 
 export const dynamic = 'force-dynamic'
 
@@ -9,31 +9,49 @@ const QUICKBOOKS_REDIRECT_URI = process.env.QUICKBOOKS_REDIRECT_URI || ''
 
 const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.tooltimepro.com'
 
-export async function GET() {
+function getSupabaseAdmin() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) return null
+  return createClient(url, key)
+}
+
+export async function POST(request: NextRequest) {
   try {
     // Check if QuickBooks is configured
     if (!QUICKBOOKS_CLIENT_ID || !QUICKBOOKS_REDIRECT_URI) {
       console.error('QuickBooks environment variables not configured')
-      return NextResponse.redirect(
-        new URL('/dashboard/settings?tab=integrations&qbo=error&reason=not_configured', SITE_URL)
+      return NextResponse.json(
+        { error: 'QuickBooks is not configured. Please contact support.' },
+        { status: 503 }
       )
     }
 
-    // Get the current user from Supabase using SSR client
-    const supabase = await createSupabaseServerClient()
+    // Authenticate via Bearer token (the app uses localStorage-based auth,
+    // so cookies are not available in API routes)
+    const authHeader = request.headers.get('authorization')
+    const token = authHeader?.replace('Bearer ', '')
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    }
+
+    const supabase = getSupabaseAdmin()
+    if (!supabase) {
+      return NextResponse.json(
+        { error: 'Server configuration error. Please contact support.' },
+        { status: 500 }
+      )
+    }
 
     const {
       data: { user },
       error: userError,
-    } = await supabase.auth.getUser()
+    } = await supabase.auth.getUser(token)
 
-    if (userError) {
-      console.error('Error getting user:', userError)
-    }
-
-    if (!user) {
-      return NextResponse.redirect(
-        new URL('/auth/login?redirect=/dashboard/settings', SITE_URL)
+    if (userError || !user) {
+      return NextResponse.json(
+        { error: 'Session expired. Please log in again.' },
+        { status: 401 }
       )
     }
 
@@ -46,8 +64,9 @@ export async function GET() {
 
     if (!dbUser?.company_id) {
       console.error('No company found for user before QuickBooks OAuth')
-      return NextResponse.redirect(
-        new URL('/dashboard/settings?tab=integrations&qbo=error&reason=no_company', SITE_URL)
+      return NextResponse.json(
+        { error: 'No company found. Please complete your account setup first.' },
+        { status: 400 }
       )
     }
 
@@ -73,12 +92,12 @@ export async function GET() {
 
     const authUrl = `https://appcenter.intuit.com/connect/oauth2?${params.toString()}`
 
-    // Redirect to QuickBooks OAuth
-    return NextResponse.redirect(authUrl)
+    return NextResponse.json({ url: authUrl })
   } catch (error) {
     console.error('Error initiating QuickBooks OAuth:', error)
-    return NextResponse.redirect(
-      new URL('/dashboard/settings?tab=integrations&qbo=error', SITE_URL)
+    return NextResponse.json(
+      { error: 'Failed to initiate QuickBooks connection. Please try again.' },
+      { status: 500 }
     )
   }
 }

--- a/src/components/settings/QuickBooksConnect.tsx
+++ b/src/components/settings/QuickBooksConnect.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { supabase } from '@/lib/supabase'
 
 interface QuickBooksConnectProps {
   isConnected: boolean
@@ -17,14 +18,38 @@ export default function QuickBooksConnect({
 }: QuickBooksConnectProps) {
   const [syncing, setSyncing] = useState(false)
   const [connecting, setConnecting] = useState(false)
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
 
   const handleConnect = async () => {
     setConnecting(true)
+    setMessage(null)
+
     try {
-      // Redirect to QuickBooks OAuth flow
-      window.location.href = '/api/quickbooks/connect'
+      const { data: { session } } = await supabase.auth.getSession()
+      if (!session?.access_token) {
+        setMessage({ type: 'error', text: 'Please log in again to connect QuickBooks.' })
+        setConnecting(false)
+        return
+      }
+
+      const response = await fetch('/api/quickbooks/connect', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}))
+        throw new Error(errData.error || 'Failed to start QuickBooks connection')
+      }
+
+      const { url } = await response.json()
+      window.location.href = url
     } catch (error) {
       console.error('Failed to initiate QuickBooks connection:', error)
+      setMessage({
+        type: 'error',
+        text: error instanceof Error ? error.message : 'Failed to connect. Please try again.',
+      })
       setConnecting(false)
     }
   }
@@ -68,6 +93,19 @@ export default function QuickBooksConnect({
 
   return (
     <div className="border rounded-lg p-4 bg-white">
+      {/* Toast message */}
+      {message && (
+        <div
+          className={`mb-3 p-3 rounded-lg text-sm ${
+            message.type === 'success'
+              ? 'bg-green-50 text-green-700 border border-green-200'
+              : 'bg-red-50 text-red-700 border border-red-200'
+          }`}
+        >
+          {message.text}
+        </div>
+      )}
+
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-4">
           {/* QuickBooks Logo */}


### PR DESCRIPTION
## Summary
Refactored QuickBooks and Google Calendar OAuth connection endpoints to use Bearer token authentication instead of server-side session cookies, and changed them from GET/redirect-based to POST/JSON-based responses. This aligns with the app's localStorage-based authentication pattern.

## Key Changes

- **QuickBooks Connect (`/api/quickbooks/connect`)**
  - Changed from GET to POST request handler
  - Replaced `createSupabaseServerClient()` with admin client using service role key
  - Added Bearer token extraction from Authorization header for authentication
  - Changed response from `NextResponse.redirect()` to `NextResponse.json()` returning OAuth URL
  - Updated error responses to return JSON with descriptive error messages and appropriate HTTP status codes

- **Google Calendar Connect (`/api/google-calendar/connect`)**
  - Extracted `getSupabaseAdmin()` helper function for consistent admin client initialization
  - Refactored token extraction to use `authHeader?.replace('Bearer ', '')` pattern
  - Changed from creating anon-key client with Authorization header to using admin client with explicit `getUser(token)` call
  - Updated error messages for consistency and clarity

- **QuickBooksConnect Component (`src/components/settings/QuickBooksConnect.tsx`)**
  - Updated `handleConnect()` to fetch session access token from Supabase
  - Changed from direct redirect to POST request with Bearer token in Authorization header
  - Added error handling and user-facing toast messages for success/error states
  - Added message state management to display connection status to users

## Implementation Details

- Both endpoints now use the same authentication pattern: Bearer token validation via `supabase.auth.getUser(token)`
- Admin client is initialized with service role key for server-side operations
- All error responses now return consistent JSON format with descriptive messages
- HTTP status codes properly reflect error types (401 for auth, 503 for config, 500 for server errors)
- Client-side component now handles async OAuth flow initiation and provides user feedback

https://claude.ai/code/session_0181nALZwKU7NrRJdWJtcL8y