### PR TITLE
Refresh auth context after company data updates

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -52,7 +52,7 @@ const PLAN_CONFIG: Record<string, { name: string; price: string; period: string 
 }
 
 function SettingsContent() {
-  const { user, dbUser, company } = useAuth()
+  const { user, dbUser, company, refreshUserData } = useAuth()
   const router = useRouter()
   const searchParams = useSearchParams()
   const tabParam = searchParams.get('tab')
@@ -252,6 +252,8 @@ function SettingsContent() {
       if (error) {
         setSaveMessage({ type: 'error', text: 'Error saving: ' + error.message })
       } else {
+        // Refresh AuthContext so dashboard checklist sees updated company data
+        await refreshUserData()
         setSaveMessage({ type: 'success', text: 'Company info saved!' })
         setTimeout(() => setSaveMessage(null), 3000)
       }

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -154,6 +154,8 @@ export default function OnboardingPage() {
       setError(updateError.message)
       return false
     }
+    // Refresh AuthContext so dashboard checklist sees updated company data
+    await refreshUserData()
     return true
   }
 


### PR DESCRIPTION
## Summary
This PR ensures that the AuthContext is refreshed after company information is updated, allowing dependent features like the dashboard checklist to immediately reflect the latest company data.

## Key Changes
- Added `refreshUserData` to the `useAuth()` hook destructuring in the settings page
- Call `refreshUserData()` after successfully saving company info in the settings page
- Call `refreshUserData()` after successfully updating company data during onboarding
- Added clarifying comments explaining why the refresh is necessary for dashboard checklist updates

## Implementation Details
The changes ensure that when users update their company information through either the settings page or onboarding flow, the AuthContext is refreshed to sync the updated data. This prevents stale data from being displayed in dependent UI components like the dashboard checklist, which relies on current company information to display accurate status.

https://claude.ai/code/session_018pktdE1S2iPR6unK8FcfdP