### PR TITLE
Add "Save and Send" invoice functionality with RLS fix

### DIFF
--- a/database/migrations/031_fix_invoice_items_rls.sql
+++ b/database/migrations/031_fix_invoice_items_rls.sql
@@ -1,0 +1,21 @@
+-- Migration: Fix invoice_items RLS policy for INSERT operations
+-- The existing FOR ALL USING(...) policy fails on INSERT because
+-- it lacks an explicit WITH CHECK clause. Adding WITH CHECK ensures
+-- new rows are validated against the same company ownership check.
+
+DROP POLICY IF EXISTS "Invoice items for company invoices" ON invoice_items;
+
+CREATE POLICY "Invoice items for company invoices" ON invoice_items
+    FOR ALL
+    USING (
+        invoice_id IN (
+            SELECT i.id FROM invoices i
+            WHERE i.company_id = (SELECT company_id FROM users WHERE id = auth.uid())
+        )
+    )
+    WITH CHECK (
+        invoice_id IN (
+            SELECT i.id FROM invoices i
+            WHERE i.company_id = (SELECT company_id FROM users WHERE id = auth.uid())
+        )
+    );

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -707,7 +707,14 @@ CREATE POLICY "Quote items for company quotes" ON quote_items
 
 -- Invoice items: users can manage items for invoices in their company
 CREATE POLICY "Invoice items for company invoices" ON invoice_items
-    FOR ALL USING (
+    FOR ALL
+    USING (
+        invoice_id IN (
+            SELECT i.id FROM invoices i
+            WHERE i.company_id = (SELECT company_id FROM users WHERE id = auth.uid())
+        )
+    )
+    WITH CHECK (
         invoice_id IN (
             SELECT i.id FROM invoices i
             WHERE i.company_id = (SELECT company_id FROM users WHERE id = auth.uid())

--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -531,6 +531,21 @@ export default function InvoicesPage() {
             setShowModal(false)
             if (companyId) fetchInvoices(companyId)
           }}
+          onSaveAndSend={async (invoiceId: string) => {
+            setShowModal(false)
+            if (companyId) {
+              await fetchInvoices(companyId)
+              // Fetch the just-saved invoice with full customer/items data to send it
+              const { data } = await supabase
+                .from('invoices')
+                .select('*, customer:customers(id, name, email, phone, address, city, state, zip, sms_consent), items:invoice_items(*)')
+                .eq('id', invoiceId)
+                .single()
+              if (data) {
+                await sendInvoice(data as Invoice)
+              }
+            }
+          }}
         />
       )}
     </div>
@@ -548,12 +563,13 @@ const STATE_TAX_RATES: Record<string, number> = {
   WA: 6.5, WV: 6, WI: 5, WY: 4,
 }
 
-function InvoiceModal({ invoice, companyId, customers, onClose, onSave }: {
+function InvoiceModal({ invoice, companyId, customers, onClose, onSave, onSaveAndSend }: {
   invoice: Invoice | null
   companyId: string
   customers: { id: string; name: string; email: string; phone?: string; address?: string; city?: string; state?: string; zip?: string }[]
   onClose: () => void
   onSave: () => void
+  onSaveAndSend?: (invoiceId: string) => void
 }) {
   const [formData, setFormData] = useState({
     customer_id: invoice?.customer_id || '',
@@ -568,6 +584,7 @@ function InvoiceModal({ invoice, companyId, customers, onClose, onSave }: {
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [customerError, setCustomerError] = useState<string | null>(null)
+  const [sendAfterSave, setSendAfterSave] = useState(false)
 
   const selectedCustomer = customers.find(c => c.id === formData.customer_id) || null
 
@@ -646,11 +663,16 @@ function InvoiceModal({ invoice, companyId, customers, onClose, onSave }: {
         }
       }
 
-      onSave()
+      if (sendAfterSave && invoiceId && onSaveAndSend) {
+        onSaveAndSend(invoiceId)
+      } else {
+        onSave()
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'An unexpected error occurred while saving the invoice.'
       console.error('Error saving invoice:', err)
       setSaveError(message)
+      setSendAfterSave(false)
     } finally {
       setSaving(false)
     }
@@ -806,10 +828,21 @@ function InvoiceModal({ invoice, companyId, customers, onClose, onSave }: {
             <button
               type="submit"
               disabled={saving}
+              onClick={() => setSendAfterSave(false)}
               className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
             >
-              {saving ? 'Saving...' : 'Save Invoice'}
+              {saving && !sendAfterSave ? 'Saving...' : 'Save Invoice'}
             </button>
+            {onSaveAndSend && (
+              <button
+                type="submit"
+                disabled={saving}
+                onClick={() => setSendAfterSave(true)}
+                className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+              >
+                {saving && sendAfterSave ? 'Sending...' : 'Send Invoice'}
+              </button>
+            )}
           </div>
         </form>
       </div>

--- a/supabase/migrations/20260411000001_fix_invoice_items_rls.sql
+++ b/supabase/migrations/20260411000001_fix_invoice_items_rls.sql
@@ -1,0 +1,21 @@
+-- Migration: Fix invoice_items RLS policy for INSERT operations
+-- The existing FOR ALL USING(...) policy fails on INSERT because
+-- it lacks an explicit WITH CHECK clause. Adding WITH CHECK ensures
+-- new rows are validated against the same company ownership check.
+
+DROP POLICY IF EXISTS "Invoice items for company invoices" ON invoice_items;
+
+CREATE POLICY "Invoice items for company invoices" ON invoice_items
+    FOR ALL
+    USING (
+        invoice_id IN (
+            SELECT i.id FROM invoices i
+            WHERE i.company_id = (SELECT company_id FROM users WHERE id = auth.uid())
+        )
+    )
+    WITH CHECK (
+        invoice_id IN (
+            SELECT i.id FROM invoices i
+            WHERE i.company_id = (SELECT company_id FROM users WHERE id = auth.uid())
+        )
+    );


### PR DESCRIPTION
## Summary
This PR adds a "Save and Send" feature to the invoice modal, allowing users to save an invoice and immediately send it in one action. It also fixes a critical Row-Level Security (RLS) policy issue that was preventing invoice items from being inserted.

## Key Changes

- **Invoice Modal Enhancement**: Added `onSaveAndSend` callback and a new "Send Invoice" button alongside the existing "Save Invoice" button
  - New `sendAfterSave` state tracks whether the user clicked "Send" vs "Save"
  - After successful save, if send was requested, the invoice is fetched with full customer and items data, then sent via `sendInvoice()`
  - Button text updates to show "Sending..." during the send operation

- **RLS Policy Fix**: Fixed the `invoice_items` table RLS policy by adding an explicit `WITH CHECK` clause
  - The previous `FOR ALL USING(...)` policy lacked a `WITH CHECK` clause, causing INSERT operations to fail
  - Now both `USING` and `WITH CHECK` clauses validate that the invoice belongs to the user's company
  - Updated in three locations: `database/schema.sql`, `database/migrations/031_fix_invoice_items_rls.sql`, and `supabase/migrations/20260411000001_fix_invoice_items_rls.sql`

## Implementation Details

- The "Send Invoice" button is conditionally rendered only when `onSaveAndSend` callback is provided
- Error handling resets `sendAfterSave` flag if the save operation fails
- The invoice fetch after save includes customer details and line items needed for sending
- Both save buttons use the same form submission, with the `sendAfterSave` flag determining the post-save action

https://claude.ai/code/session_011ATqbBmV1o84zNN3sHvXa2