### PR TITLE
Fix Supabase migrations to be idempotent for db push

### DIFF
--- a/supabase/migrations/20260128000000_add_quickbooks_tables.sql
+++ b/supabase/migrations/20260128000000_add_quickbooks_tables.sql
@@ -54,25 +54,31 @@ ALTER TABLE qbo_connections ENABLE ROW LEVEL SECURITY;
 ALTER TABLE qbo_sync_log ENABLE ROW LEVEL SECURITY;
 
 -- Policy: Users can view their own connections
+DROP POLICY IF EXISTS "Users can view own qbo_connections" ON qbo_connections;
 CREATE POLICY "Users can view own qbo_connections" ON qbo_connections
   FOR SELECT USING (auth.uid() = user_id);
 
 -- Policy: Users can insert their own connections
+DROP POLICY IF EXISTS "Users can insert own qbo_connections" ON qbo_connections;
 CREATE POLICY "Users can insert own qbo_connections" ON qbo_connections
   FOR INSERT WITH CHECK (auth.uid() = user_id);
 
 -- Policy: Users can update their own connections
+DROP POLICY IF EXISTS "Users can update own qbo_connections" ON qbo_connections;
 CREATE POLICY "Users can update own qbo_connections" ON qbo_connections
   FOR UPDATE USING (auth.uid() = user_id);
 
 -- Policy: Users can delete their own connections
+DROP POLICY IF EXISTS "Users can delete own qbo_connections" ON qbo_connections;
 CREATE POLICY "Users can delete own qbo_connections" ON qbo_connections
   FOR DELETE USING (auth.uid() = user_id);
 
 -- Policy: Users can view their own sync logs
+DROP POLICY IF EXISTS "Users can view own qbo_sync_log" ON qbo_sync_log;
 CREATE POLICY "Users can view own qbo_sync_log" ON qbo_sync_log
   FOR SELECT USING (auth.uid() = user_id);
 
 -- Policy: Users can insert their own sync logs
+DROP POLICY IF EXISTS "Users can insert own qbo_sync_log" ON qbo_sync_log;
 CREATE POLICY "Users can insert own qbo_sync_log" ON qbo_sync_log
   FOR INSERT WITH CHECK (auth.uid() = user_id);

--- a/supabase/migrations/20260201000000_add_worker_notes_table.sql
+++ b/supabase/migrations/20260201000000_add_worker_notes_table.sql
@@ -38,6 +38,7 @@ CREATE INDEX IF NOT EXISTS idx_worker_notes_created_at ON worker_notes(created_a
 ALTER TABLE worker_notes ENABLE ROW LEVEL SECURITY;
 
 -- Policy: Users can view notes for workers in their company
+DROP POLICY IF EXISTS "Users can view company worker notes" ON worker_notes;
 CREATE POLICY "Users can view company worker notes" ON worker_notes
     FOR SELECT USING (
         company_id IN (
@@ -46,6 +47,7 @@ CREATE POLICY "Users can view company worker notes" ON worker_notes
     );
 
 -- Policy: Admins and owners can insert notes
+DROP POLICY IF EXISTS "Admins can insert worker notes" ON worker_notes;
 CREATE POLICY "Admins can insert worker notes" ON worker_notes
     FOR INSERT WITH CHECK (
         company_id IN (
@@ -57,6 +59,7 @@ CREATE POLICY "Admins can insert worker notes" ON worker_notes
     );
 
 -- Policy: Admins and owners can update notes in their company
+DROP POLICY IF EXISTS "Admins can update worker notes" ON worker_notes;
 CREATE POLICY "Admins can update worker notes" ON worker_notes
     FOR UPDATE USING (
         company_id IN (
@@ -68,6 +71,7 @@ CREATE POLICY "Admins can update worker notes" ON worker_notes
     );
 
 -- Policy: Owners can delete notes in their company
+DROP POLICY IF EXISTS "Owners can delete worker notes" ON worker_notes;
 CREATE POLICY "Owners can delete worker notes" ON worker_notes
     FOR DELETE USING (
         company_id IN (
@@ -83,6 +87,7 @@ CREATE POLICY "Owners can delete worker notes" ON worker_notes
 -- ============================================
 
 -- Auto-update updated_at timestamp
+DROP TRIGGER IF EXISTS update_worker_notes_updated_at ON worker_notes;
 CREATE TRIGGER update_worker_notes_updated_at
     BEFORE UPDATE ON worker_notes
     FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/supabase/migrations/20260201000001_add_worker_certifications_table.sql
+++ b/supabase/migrations/20260201000001_add_worker_certifications_table.sql
@@ -54,6 +54,7 @@ CREATE INDEX IF NOT EXISTS idx_worker_certs_active ON worker_certifications(is_a
 ALTER TABLE worker_certifications ENABLE ROW LEVEL SECURITY;
 
 -- Policy: Users can view certifications for workers in their company
+DROP POLICY IF EXISTS "Users can view company worker certifications" ON worker_certifications;
 CREATE POLICY "Users can view company worker certifications" ON worker_certifications
     FOR SELECT USING (
         company_id IN (
@@ -62,6 +63,7 @@ CREATE POLICY "Users can view company worker certifications" ON worker_certifica
     );
 
 -- Policy: Admins and owners can insert certifications
+DROP POLICY IF EXISTS "Admins can insert worker certifications" ON worker_certifications;
 CREATE POLICY "Admins can insert worker certifications" ON worker_certifications
     FOR INSERT WITH CHECK (
         company_id IN (
@@ -73,6 +75,7 @@ CREATE POLICY "Admins can insert worker certifications" ON worker_certifications
     );
 
 -- Policy: Admins and owners can update certifications
+DROP POLICY IF EXISTS "Admins can update worker certifications" ON worker_certifications;
 CREATE POLICY "Admins can update worker certifications" ON worker_certifications
     FOR UPDATE USING (
         company_id IN (
@@ -84,6 +87,7 @@ CREATE POLICY "Admins can update worker certifications" ON worker_certifications
     );
 
 -- Policy: Owners can delete certifications
+DROP POLICY IF EXISTS "Owners can delete worker certifications" ON worker_certifications;
 CREATE POLICY "Owners can delete worker certifications" ON worker_certifications
     FOR DELETE USING (
         company_id IN (
@@ -97,6 +101,7 @@ CREATE POLICY "Owners can delete worker certifications" ON worker_certifications
 -- ============================================
 -- TRIGGERS
 -- ============================================
+DROP TRIGGER IF EXISTS update_worker_certifications_updated_at ON worker_certifications;
 CREATE TRIGGER update_worker_certifications_updated_at
     BEFORE UPDATE ON worker_certifications
     FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/supabase/migrations/20260201000003_add_admin_update_users_policy.sql
+++ b/supabase/migrations/20260201000003_add_admin_update_users_policy.sql
@@ -1,6 +1,7 @@
 -- Allow admins and owners to update team members in their company
 -- Fixes: toggleMemberStatus was silently failing because the only UPDATE
 -- policy on users was "Users can update own profile" (id = auth.uid()).
+DROP POLICY IF EXISTS "Admins can update team members" ON users;
 CREATE POLICY "Admins can update team members" ON users
     FOR UPDATE USING (
         company_id IN (

--- a/supabase/migrations/20260201000005_allow_admin_insert_users.sql
+++ b/supabase/migrations/20260201000005_allow_admin_insert_users.sql
@@ -1,6 +1,7 @@
 -- Allow admins and owners to create new team members in their company
 -- This fixes the RLS error when creating team members from the dashboard
 
+DROP POLICY IF EXISTS "Admins can insert team members" ON users;
 CREATE POLICY "Admins can insert team members" ON users
     FOR INSERT WITH CHECK (
         -- Allow if the inserting user is an admin or owner in the same company

--- a/supabase/migrations/20260404000000_add_route_optimization_tables.sql
+++ b/supabase/migrations/20260404000000_add_route_optimization_tables.sql
@@ -24,18 +24,22 @@ CREATE INDEX idx_saved_routes_company_date ON saved_routes(company_id, route_dat
 -- RLS for saved_routes
 ALTER TABLE saved_routes ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can view saved routes for their company" ON saved_routes;
 CREATE POLICY "Users can view saved routes for their company"
   ON saved_routes FOR SELECT
   USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
 
+DROP POLICY IF EXISTS "Users can insert saved routes for their company" ON saved_routes;
 CREATE POLICY "Users can insert saved routes for their company"
   ON saved_routes FOR INSERT
   WITH CHECK (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
 
+DROP POLICY IF EXISTS "Users can update saved routes for their company" ON saved_routes;
 CREATE POLICY "Users can update saved routes for their company"
   ON saved_routes FOR UPDATE
   USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
 
+DROP POLICY IF EXISTS "Users can delete saved routes for their company" ON saved_routes;
 CREATE POLICY "Users can delete saved routes for their company"
   ON saved_routes FOR DELETE
   USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
@@ -58,14 +62,17 @@ CREATE TABLE IF NOT EXISTS route_settings (
 -- RLS for route_settings
 ALTER TABLE route_settings ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can view route settings for their company" ON route_settings;
 CREATE POLICY "Users can view route settings for their company"
   ON route_settings FOR SELECT
   USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
 
+DROP POLICY IF EXISTS "Users can insert route settings for their company" ON route_settings;
 CREATE POLICY "Users can insert route settings for their company"
   ON route_settings FOR INSERT
   WITH CHECK (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
 
+DROP POLICY IF EXISTS "Users can update route settings for their company" ON route_settings;
 CREATE POLICY "Users can update route settings for their company"
   ON route_settings FOR UPDATE
   USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
@@ -85,6 +92,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS set_saved_routes_updated_at ON saved_routes;
 CREATE TRIGGER set_saved_routes_updated_at
   BEFORE UPDATE ON saved_routes
   FOR EACH ROW
@@ -99,6 +107,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS set_route_settings_updated_at ON route_settings;
 CREATE TRIGGER set_route_settings_updated_at
   BEFORE UPDATE ON route_settings
   FOR EACH ROW

--- a/supabase/migrations/20260411000000_fix_quickbooks_schema.sql
+++ b/supabase/migrations/20260411000000_fix_quickbooks_schema.sql
@@ -8,8 +8,16 @@
 -- Add company_id column (references companies table)
 ALTER TABLE qbo_connections ADD COLUMN IF NOT EXISTS company_id UUID REFERENCES companies(id) ON DELETE CASCADE;
 
--- Rename qbo_realm_id → realm_id to match API code
-ALTER TABLE qbo_connections RENAME COLUMN qbo_realm_id TO realm_id;
+-- Rename qbo_realm_id → realm_id to match API code (idempotent)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'qbo_connections' AND column_name = 'qbo_realm_id'
+  ) THEN
+    ALTER TABLE qbo_connections RENAME COLUMN qbo_realm_id TO realm_id;
+  END IF;
+END $$;
 
 -- Backfill company_id from the user's company for any existing rows
 UPDATE qbo_connections qc
@@ -20,7 +28,14 @@ WHERE qc.user_id = u.id
 
 -- Drop old unique constraint on user_id and add one on company_id
 ALTER TABLE qbo_connections DROP CONSTRAINT IF EXISTS qbo_connections_user_id_key;
-ALTER TABLE qbo_connections ADD CONSTRAINT qbo_connections_company_id_key UNIQUE (company_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'qbo_connections_company_id_key'
+  ) THEN
+    ALTER TABLE qbo_connections ADD CONSTRAINT qbo_connections_company_id_key UNIQUE (company_id);
+  END IF;
+END $$;
 
 -- Add index on company_id
 CREATE INDEX IF NOT EXISTS idx_qbo_connections_company_id ON qbo_connections(company_id);


### PR DESCRIPTION
## Summary
- The `migrate.yml` workflow fails because `supabase db push` tries to re-apply migrations that were originally run manually via the SQL Editor — they aren't tracked in Supabase's `schema_migrations` table, so the CLI treats them as pending
- Added `DROP POLICY IF EXISTS` before all 22 `CREATE POLICY` statements across 6 migration files
- Added `DROP TRIGGER IF EXISTS` before all 4 `CREATE TRIGGER` statements
- Wrapped the non-idempotent `RENAME COLUMN` and `ADD CONSTRAINT` in `20260411000000_fix_quickbooks_schema.sql` in `DO $$ ... END $$` blocks with existence checks

## Test plan
- [ ] Merge to main and verify the "Run Supabase Migrations" workflow passes
- [ ] Confirm existing RLS policies and triggers are unchanged in Supabase dashboard
- [ ] Verify app functionality (invoices, QuickBooks settings, team management) is unaffected

https://claude.ai/code/session_01L86VgymSfokoHm7LfXMJHf