### PR TITLE
Add ON DELETE CASCADE to company foreign keys

### DIFF
--- a/database/migrations/023_recurring_jobs.sql
+++ b/database/migrations/023_recurring_jobs.sql
@@ -1,7 +1,7 @@
 -- Recurring job templates
 CREATE TABLE IF NOT EXISTS recurring_jobs (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  company_id UUID NOT NULL REFERENCES companies(id),
+  company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
   title VARCHAR(255) NOT NULL,
   description TEXT,
   address VARCHAR(500),

--- a/database/migrations/024_notifications.sql
+++ b/database/migrations/024_notifications.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS notifications (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  company_id UUID NOT NULL REFERENCES companies(id),
+  company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
   user_id UUID NOT NULL,
   type VARCHAR(50) NOT NULL, -- 'new_lead', 'job_assigned', 'invoice_paid', 'invoice_overdue', 'compliance_alert', 'review_received', 'booking_received', 'worker_clock_in', 'quote_accepted', 'quote_expired'
   title VARCHAR(255) NOT NULL,

--- a/database/migrations/025_google_calendar.sql
+++ b/database/migrations/025_google_calendar.sql
@@ -2,7 +2,7 @@
 CREATE TABLE IF NOT EXISTS google_calendar_connections (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL UNIQUE,
-  company_id UUID NOT NULL REFERENCES companies(id),
+  company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
   access_token TEXT NOT NULL,
   refresh_token TEXT NOT NULL,
   token_expires_at TIMESTAMP WITH TIME ZONE,

--- a/database/migrations/026_payment_plans.sql
+++ b/database/migrations/026_payment_plans.sql
@@ -1,7 +1,7 @@
 -- Payment plans for installment payments on invoices
 CREATE TABLE IF NOT EXISTS payment_plans (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  company_id UUID NOT NULL REFERENCES companies(id),
+  company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
   invoice_id UUID NOT NULL REFERENCES invoices(id),
   customer_id UUID REFERENCES customers(id),
   total_amount DECIMAL(10,2) NOT NULL,

--- a/database/migrations/027_webhooks.sql
+++ b/database/migrations/027_webhooks.sql
@@ -1,7 +1,7 @@
 -- Outbound webhook subscriptions for Zapier/integration support
 CREATE TABLE IF NOT EXISTS webhooks (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  company_id UUID NOT NULL REFERENCES companies(id),
+  company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
   url VARCHAR(2000) NOT NULL,
   secret VARCHAR(255), -- HMAC secret for signature verification
   events TEXT[] NOT NULL DEFAULT '{}', -- array of event types to subscribe to

--- a/database/migrations/033_cascade_delete_company_fks.sql
+++ b/database/migrations/033_cascade_delete_company_fks.sql
@@ -1,0 +1,39 @@
+-- Mirror of supabase/migrations/20260416000000_cascade_delete_company_fks.sql
+-- See that file for rationale.
+
+DO $$
+DECLARE
+  fk RECORD;
+BEGIN
+  FOR fk IN
+    SELECT
+      c.conname     AS constraint_name,
+      n.nspname     AS schema_name,
+      t.relname     AS table_name,
+      a.attname     AS column_name
+    FROM pg_constraint c
+    JOIN pg_class      t  ON t.oid  = c.conrelid
+    JOIN pg_namespace  n  ON n.oid  = t.relnamespace
+    JOIN pg_class      r  ON r.oid  = c.confrelid
+    JOIN pg_namespace  rn ON rn.oid = r.relnamespace
+    JOIN pg_attribute  a  ON a.attrelid = c.conrelid AND a.attnum = c.conkey[1]
+    WHERE c.contype = 'f'
+      AND rn.nspname = 'public'
+      AND r.relname  = 'companies'
+      AND c.confdeltype IN ('a', 'r')
+      AND array_length(c.conkey, 1) = 1
+  LOOP
+    RAISE NOTICE 'Rewriting FK % on %.%(%) to ON DELETE CASCADE',
+      fk.constraint_name, fk.schema_name, fk.table_name, fk.column_name;
+
+    EXECUTE format(
+      'ALTER TABLE %I.%I DROP CONSTRAINT %I',
+      fk.schema_name, fk.table_name, fk.constraint_name
+    );
+
+    EXECUTE format(
+      'ALTER TABLE %I.%I ADD CONSTRAINT %I FOREIGN KEY (%I) REFERENCES public.companies(id) ON DELETE CASCADE',
+      fk.schema_name, fk.table_name, fk.constraint_name, fk.column_name
+    );
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260416000000_cascade_delete_company_fks.sql
+++ b/supabase/migrations/20260416000000_cascade_delete_company_fks.sql
@@ -1,0 +1,46 @@
+-- Ensure every foreign key pointing at public.companies(id) cascades on delete.
+-- Several older migrations (recurring_jobs, notifications, google_calendar_connections,
+-- payment_plans, webhooks) omitted ON DELETE CASCADE, which blocks deletion of a
+-- company row for account resets and tenant offboarding.
+--
+-- This block rewrites any single-column FK referencing companies whose delete rule
+-- is NO ACTION ('a') or RESTRICT ('r'). SET NULL ('n') and SET DEFAULT ('d') are
+-- left alone — those are intentional design choices (e.g. website_leads preserves
+-- lead history after a company is removed).
+
+DO $$
+DECLARE
+  fk RECORD;
+BEGIN
+  FOR fk IN
+    SELECT
+      c.conname     AS constraint_name,
+      n.nspname     AS schema_name,
+      t.relname     AS table_name,
+      a.attname     AS column_name
+    FROM pg_constraint c
+    JOIN pg_class      t  ON t.oid  = c.conrelid
+    JOIN pg_namespace  n  ON n.oid  = t.relnamespace
+    JOIN pg_class      r  ON r.oid  = c.confrelid
+    JOIN pg_namespace  rn ON rn.oid = r.relnamespace
+    JOIN pg_attribute  a  ON a.attrelid = c.conrelid AND a.attnum = c.conkey[1]
+    WHERE c.contype = 'f'
+      AND rn.nspname = 'public'
+      AND r.relname  = 'companies'
+      AND c.confdeltype IN ('a', 'r')
+      AND array_length(c.conkey, 1) = 1
+  LOOP
+    RAISE NOTICE 'Rewriting FK % on %.%(%) to ON DELETE CASCADE',
+      fk.constraint_name, fk.schema_name, fk.table_name, fk.column_name;
+
+    EXECUTE format(
+      'ALTER TABLE %I.%I DROP CONSTRAINT %I',
+      fk.schema_name, fk.table_name, fk.constraint_name
+    );
+
+    EXECUTE format(
+      'ALTER TABLE %I.%I ADD CONSTRAINT %I FOREIGN KEY (%I) REFERENCES public.companies(id) ON DELETE CASCADE',
+      fk.schema_name, fk.table_name, fk.constraint_name, fk.column_name
+    );
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary
This PR ensures all foreign key constraints referencing `public.companies(id)` properly cascade on delete, enabling company deletion for account resets and tenant offboarding.

## Key Changes
- Added migration `20260416000000_cascade_delete_company_fks.sql` (Supabase) and `033_cascade_delete_company_fks.sql` (local database) that automatically rewrites single-column foreign keys with NO ACTION or RESTRICT delete rules to use ON DELETE CASCADE
- Updated five existing table definitions to explicitly include `ON DELETE CASCADE`:
  - `recurring_jobs.company_id`
  - `notifications.company_id`
  - `google_calendar_connections.company_id`
  - `payment_plans.company_id`
  - `webhooks.company_id`

## Implementation Details
- The migration uses a PL/pgSQL block to query `pg_constraint` and identify all foreign keys pointing to companies with restrictive delete rules (`confdeltype IN ('a', 'r')`)
- Only single-column foreign keys are modified; composite keys are skipped
- Intentional design choices like SET NULL and SET DEFAULT rules (e.g., in `website_leads`) are preserved
- The migration is idempotent and includes RAISE NOTICE statements for visibility
- Both Supabase and local database migrations are kept in sync

https://claude.ai/code/session_01Vqz1skyJSyy3TNmKdaCpad