### PR TITLE
Add anchor link to Jenny AI section on pricing page

### DIFF
--- a/src/app/dashboard/jenny-lite/page.tsx
+++ b/src/app/dashboard/jenny-lite/page.tsx
@@ -597,7 +597,7 @@ export default function JennyLitePage() {
               </p>
             </div>
             <Link
-              href="/pricing"
+              href="/pricing#jenny-ai"
               className="px-6 py-3 bg-orange-500 text-white font-bold rounded-lg hover:bg-orange-600 transition-colors no-underline text-sm whitespace-nowrap"
             >
               Upgrade to Jenny Pro →

--- a/src/app/pricing/page.jsx
+++ b/src/app/pricing/page.jsx
@@ -463,7 +463,7 @@ export default function PricingPage() {
         </section>
 
         {/* Jenny AI Add-on */}
-        <section className="section jenny-section">
+        <section id="jenny-ai" className="section jenny-section">
           <div className="jenny-banner">
             <div className="jenny-banner-content">
               <div className="jenny-avatar">🎧</div>


### PR DESCRIPTION
## Summary
This PR adds an anchor link to the Jenny AI section on the pricing page, allowing users to navigate directly to that section when clicking the "Upgrade to Jenny Pro" button from the Jenny Lite dashboard.

## Key Changes
- Added `id="jenny-ai"` to the Jenny AI section in the pricing page to create an anchor point
- Updated the "Upgrade to Jenny Pro" button link from `/pricing` to `/pricing#jenny-ai` to direct users to the specific section

## Implementation Details
This change improves user experience by ensuring that when users click the upgrade button on the Jenny Lite page, they are scrolled directly to the Jenny AI add-on section on the pricing page, rather than landing at the top of the page.

https://claude.ai/code/session_019HrbTkgZnCTd7cxPZJVZi4