### PR TITLE
Fix Jenny ToolTime Assistant link navigation path

### DIFF
--- a/src/app/dashboard/website-builder/components/Step6ReviewLaunch.js
+++ b/src/app/dashboard/website-builder/components/Step6ReviewLaunch.js
@@ -329,7 +329,7 @@ export default function Step6ReviewLaunch({ wizardData, setWizardData, onGoToSte
         <div className="card bg-gold-50 border border-gold-200">
           <h3 className="font-semibold text-navy-500 mb-2">While you wait...</h3>
           <p className="text-sm text-gray-600 mb-4">Set up Jenny ToolTime Assistant to capture leads from your website 24/7.</p>
-          <a href="/jenny" className="btn-primary inline-flex items-center gap-2 text-sm">
+          <a href="/dashboard/jenny-lite" className="btn-primary inline-flex items-center gap-2 text-sm">
             Set up Jenny ToolTime Assistant
             <ArrowRight size={16} />
           </a>


### PR DESCRIPTION
## Summary
Updated the navigation link for the Jenny ToolTime Assistant setup in the Step 6 Review & Launch component to use the correct dashboard route.

## Changes
- Changed the href from `/jenny` to `/dashboard/jenny-lite` in the "Set up Jenny ToolTime Assistant" link on the Step 6 Review & Launch page

## Details
This fix ensures users are directed to the correct dashboard route when clicking the "Set up Jenny ToolTime Assistant" call-to-action button. The updated path `/dashboard/jenny-lite` aligns with the proper application routing structure for accessing the Jenny ToolTime Assistant feature from within the dashboard context.

https://claude.ai/code/session_016EMLBSTQNw3RzRNx8nJHdy