### PR TITLE
fix: refresh Supabase session before integration API calls

### DIFF
--- a/src/components/settings/GoogleCalendarConnect.tsx
+++ b/src/components/settings/GoogleCalendarConnect.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation'
 import { Calendar, RefreshCw, CheckCircle, Link2, Unlink } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
+import { getFreshAccessToken, redirectToLogin, SESSION_EXPIRED_MESSAGE } from '@/lib/auth-refresh'
 
 export default function GoogleCalendarConnect() {
   const { user } = useAuth()
@@ -57,17 +58,25 @@ export default function GoogleCalendarConnect() {
     setMessage(null)
 
     try {
-      const { data: { session } } = await supabase.auth.getSession()
-      if (!session?.access_token) {
-        setMessage({ type: 'error', text: 'Please log in again to connect Google Calendar.' })
+      const token = await getFreshAccessToken(supabase)
+      if (!token) {
+        setMessage({ type: 'error', text: SESSION_EXPIRED_MESSAGE })
         setConnecting(false)
+        redirectToLogin()
         return
       }
 
       const response = await fetch('/api/google-calendar/connect', {
         method: 'POST',
-        headers: { Authorization: `Bearer ${session.access_token}` },
+        headers: { Authorization: `Bearer ${token}` },
       })
+
+      if (response.status === 401) {
+        setMessage({ type: 'error', text: SESSION_EXPIRED_MESSAGE })
+        setConnecting(false)
+        redirectToLogin()
+        return
+      }
 
       if (!response.ok) {
         const errData = await response.json().catch(() => ({}))
@@ -91,16 +100,28 @@ export default function GoogleCalendarConnect() {
     setMessage(null)
 
     try {
-      const { data: { session } } = await supabase.auth.getSession()
+      const token = await getFreshAccessToken(supabase)
+      if (!token) {
+        setMessage({ type: 'error', text: SESSION_EXPIRED_MESSAGE })
+        setSyncing(false)
+        redirectToLogin()
+        return
+      }
+
       const response = await fetch('/api/google-calendar/sync', {
         method: 'POST',
-        headers: session?.access_token
-          ? { Authorization: `Bearer ${session.access_token}` }
-          : {},
+        headers: { Authorization: `Bearer ${token}` },
       })
 
+      if (response.status === 401) {
+        setMessage({ type: 'error', text: SESSION_EXPIRED_MESSAGE })
+        setSyncing(false)
+        redirectToLogin()
+        return
+      }
+
       if (!response.ok) {
-        const errData = await response.json()
+        const errData = await response.json().catch(() => ({}))
         throw new Error(errData.error || 'Sync failed')
       }
 
@@ -126,13 +147,23 @@ export default function GoogleCalendarConnect() {
     if (!confirm('Are you sure you want to disconnect Google Calendar?')) return
 
     try {
-      const { data: { session } } = await supabase.auth.getSession()
+      const token = await getFreshAccessToken(supabase)
+      if (!token) {
+        setMessage({ type: 'error', text: SESSION_EXPIRED_MESSAGE })
+        redirectToLogin()
+        return
+      }
+
       const response = await fetch('/api/google-calendar/disconnect', {
         method: 'POST',
-        headers: session?.access_token
-          ? { Authorization: `Bearer ${session.access_token}` }
-          : {},
+        headers: { Authorization: `Bearer ${token}` },
       })
+
+      if (response.status === 401) {
+        setMessage({ type: 'error', text: SESSION_EXPIRED_MESSAGE })
+        redirectToLogin()
+        return
+      }
 
       if (!response.ok) {
         throw new Error('Failed to disconnect')

--- a/src/components/settings/QuickBooksConnect.tsx
+++ b/src/components/settings/QuickBooksConnect.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { supabase } from '@/lib/supabase'
+import { getFreshAccessToken, redirectToLogin, SESSION_EXPIRED_MESSAGE } from '@/lib/auth-refresh'
 
 interface QuickBooksConnectProps {
   isConnected: boolean
@@ -25,17 +26,25 @@ export default function QuickBooksConnect({
     setMessage(null)
 
     try {
-      const { data: { session } } = await supabase.auth.getSession()
-      if (!session?.access_token) {
-        setMessage({ type: 'error', text: 'Please log in again to connect QuickBooks.' })
+      const token = await getFreshAccessToken(supabase)
+      if (!token) {
+        setMessage({ type: 'error', text: SESSION_EXPIRED_MESSAGE })
         setConnecting(false)
+        redirectToLogin()
         return
       }
 
       const response = await fetch('/api/quickbooks/connect', {
         method: 'POST',
-        headers: { Authorization: `Bearer ${session.access_token}` },
+        headers: { Authorization: `Bearer ${token}` },
       })
+
+      if (response.status === 401) {
+        setMessage({ type: 'error', text: SESSION_EXPIRED_MESSAGE })
+        setConnecting(false)
+        redirectToLogin()
+        return
+      }
 
       if (!response.ok) {
         const errData = await response.json().catch(() => ({}))

--- a/src/lib/auth-refresh.ts
+++ b/src/lib/auth-refresh.ts
@@ -1,0 +1,34 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export const SESSION_EXPIRED_MESSAGE =
+  'Your session expired. Redirecting to the login page…'
+
+export async function getFreshAccessToken(
+  supabase: SupabaseClient
+): Promise<string | null> {
+  try {
+    const { data: refreshed } = await supabase.auth.refreshSession()
+    if (refreshed?.session?.access_token) {
+      return refreshed.session.access_token
+    }
+  } catch {
+    // fall through to getSession
+  }
+
+  try {
+    const { data } = await supabase.auth.getSession()
+    return data.session?.access_token ?? null
+  } catch {
+    return null
+  }
+}
+
+export function redirectToLogin(delayMs = 1500): void {
+  if (typeof window === 'undefined') return
+  const redirect = encodeURIComponent(
+    window.location.pathname + window.location.search
+  )
+  setTimeout(() => {
+    window.location.href = `/auth/login?redirect=${redirect}`
+  }, delayMs)
+}


### PR DESCRIPTION
Stale access tokens were reaching /api/quickbooks/connect and /api/google-calendar/{connect,sync,disconnect}, producing unhelpful "Session expired" and "Unauthorized" toasts on the Integrations settings page. Now each handler refreshes the session first and, on 401, shows a friendly message and redirects to /auth/login with a redirect back to the current page.

https://claude.ai/code/session_01KUJgEAgRPXhcGMyEbWtA37