### PR TITLE
Sanitize and validate message content to prevent API errors

### DIFF
--- a/src/app/api/jenny-exec/chat/route.ts
+++ b/src/app/api/jenny-exec/chat/route.ts
@@ -447,7 +447,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const lastUserMessage = messages[messages.length - 1]?.content || '';
+    const lastUserMessage = (messages[messages.length - 1]?.content || '').trim();
+    if (!lastUserMessage) {
+      return NextResponse.json(
+        { error: 'Message content cannot be empty' },
+        { status: 400 },
+      );
+    }
 
     // Build system prompt with context
     let systemPrompt = getSystemPrompt(mode, language);
@@ -484,11 +490,15 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // Build message history
-    const apiMessages = messages.slice(-10).map((m) => ({
-      role: m.role as 'user' | 'assistant',
-      content: m.content,
-    }));
+    // Build message history — drop any turn that has empty content so the
+    // Anthropic API doesn't 400 on "text content blocks must be non-empty".
+    const apiMessages = messages
+      .slice(-10)
+      .map((m) => ({
+        role: m.role as 'user' | 'assistant',
+        content: typeof m.content === 'string' ? m.content.trim() : m.content,
+      }))
+      .filter((m) => (typeof m.content === 'string' ? m.content.length > 0 : !!m.content));
 
     try {
       const aiResult = await aiComplete({

--- a/src/lib/ai-client.js
+++ b/src/lib/ai-client.js
@@ -39,45 +39,61 @@ async function callClaude({ systemPrompt, messages, maxTokens = 1024, temperatur
 
   // Convert messages to Anthropic format
   // Anthropic uses system as a top-level param, not in messages array
-  const apiMessages = messages.map((m) => {
-    // Handle vision messages (content as array with image_url)
-    if (Array.isArray(m.content)) {
-      return {
-        role: m.role === 'system' ? 'user' : m.role,
-        content: m.content.map((part) => {
-          if (part.type === 'text') return part;
-          if (part.type === 'image_url') {
-            // Convert OpenAI image format to Anthropic format
-            const url = part.image_url.url;
-            const base64Match = url.match(/^data:(image\/\w+);base64,(.+)$/);
-            if (base64Match) {
+  const apiMessages = messages
+    .map((m) => {
+      // Handle vision messages (content as array with image_url)
+      if (Array.isArray(m.content)) {
+        const parts = m.content
+          .map((part) => {
+            if (part.type === 'text') {
+              const text = typeof part.text === 'string' ? part.text.trim() : '';
+              return text ? { type: 'text', text } : null;
+            }
+            if (part.type === 'image_url') {
+              // Convert OpenAI image format to Anthropic format
+              const url = part.image_url?.url;
+              if (!url) return null;
+              const base64Match = url.match(/^data:(image\/\w+);base64,(.+)$/);
+              if (base64Match) {
+                return {
+                  type: 'image',
+                  source: {
+                    type: 'base64',
+                    media_type: base64Match[1],
+                    data: base64Match[2],
+                  },
+                };
+              }
+              // URL-based image
               return {
                 type: 'image',
                 source: {
-                  type: 'base64',
-                  media_type: base64Match[1],
-                  data: base64Match[2],
+                  type: 'url',
+                  url: url,
                 },
               };
             }
-            // URL-based image
-            return {
-              type: 'image',
-              source: {
-                type: 'url',
-                url: url,
-              },
-            };
-          }
-          return part;
-        }),
+            return part;
+          })
+          .filter(Boolean);
+        if (parts.length === 0) return null;
+        return {
+          role: m.role === 'system' ? 'user' : m.role,
+          content: parts,
+        };
+      }
+      const text = typeof m.content === 'string' ? m.content.trim() : '';
+      if (!text) return null;
+      return {
+        role: m.role === 'system' ? 'user' : m.role,
+        content: text,
       };
-    }
-    return {
-      role: m.role === 'system' ? 'user' : m.role,
-      content: m.content,
-    };
-  });
+    })
+    .filter(Boolean);
+
+  if (apiMessages.length === 0) {
+    return { error: 'Claude API error 400: messages array is empty after stripping blank content' };
+  }
 
   try {
     const response = await fetch('https://api.anthropic.com/v1/messages', {
@@ -130,9 +146,28 @@ async function callOpenAI({ systemPrompt, messages, maxTokens = 1024, temperatur
 
   const model = OPENAI_MODELS[tier] || OPENAI_MODELS.high;
 
+  const cleaned = messages
+    .map((m) => {
+      if (Array.isArray(m.content)) {
+        const parts = m.content.filter((p) => {
+          if (p.type === 'text') return typeof p.text === 'string' && p.text.trim().length > 0;
+          if (p.type === 'image_url') return !!p.image_url?.url;
+          return true;
+        });
+        return parts.length ? { role: m.role, content: parts } : null;
+      }
+      const text = typeof m.content === 'string' ? m.content.trim() : '';
+      return text ? { role: m.role, content: text } : null;
+    })
+    .filter(Boolean);
+
+  if (cleaned.length === 0) {
+    return { error: 'OpenAI API error 400: messages array is empty after stripping blank content' };
+  }
+
   const apiMessages = [
     { role: 'system', content: systemPrompt },
-    ...messages,
+    ...cleaned,
   ];
 
   try {


### PR DESCRIPTION
## Summary
This PR adds robust validation and sanitization of message content across the AI client and chat API to prevent empty or whitespace-only messages from being sent to Claude and OpenAI APIs, which reject such requests with 400 errors.

## Key Changes

- **Claude API client (`callClaude`)**: 
  - Added trimming of text content in both array-based (vision) and string-based messages
  - Filter out null/empty parts after processing to remove blank text blocks
  - Return early with error if all messages are stripped, preventing API 400 errors
  - Improved null-safety checks for image URL extraction

- **OpenAI API client (`callOpenAI`)**:
  - Added message cleaning pipeline that filters out empty text content and invalid image URLs
  - Return early with error if all messages are stripped
  - Ensures only valid, non-empty messages are sent to the API

- **Chat API endpoint (`route.ts`)**:
  - Added validation to reject requests with empty last user message
  - Sanitize message content by trimming whitespace before sending to AI clients
  - Filter out turns with empty content from message history to prevent downstream API errors
  - Added explanatory comment about why empty content is filtered

## Implementation Details

- All text content is trimmed using `.trim()` to remove leading/trailing whitespace
- Empty strings and null values are filtered out using `.filter(Boolean)` 
- Validation happens at multiple layers: endpoint level, client level, and message preparation level
- Error messages clearly indicate when messages are rejected due to empty content
- Vision message parts (images and text) are individually validated and filtered

https://claude.ai/code/session_01WpobxrMdok4jfQYY3eX9fF