### PR TITLE
Add subscription management fields to companies table

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -21,6 +21,10 @@ CREATE TABLE companies (
     plan VARCHAR(50) DEFAULT 'starter', -- starter, pro, elite
     addons TEXT[] DEFAULT '{}', -- purchased add-on IDs (jenny_exec_admin, jenny_pro, etc.)
     stripe_customer_id VARCHAR(255),
+    subscription_status TEXT, -- trialing, active, past_due, canceled, expired (set by Stripe webhook)
+    trial_starts_at TIMESTAMP WITH TIME ZONE,
+    trial_ends_at TIMESTAMP WITH TIME ZONE,
+    onboarding_completed BOOLEAN DEFAULT false,
     -- Professional details (compliance & invoicing)
     license_number VARCHAR(100),          -- Contractor license # (auto-prints on quotes/invoices)
     insurance_policy_number VARCHAR(100),  -- Insurance policy for commercial proposals
@@ -533,6 +537,7 @@ CREATE TABLE website_domain_log (
 -- ============================================
 -- INDEXES (Performance)
 -- ============================================
+CREATE INDEX idx_companies_subscription_status ON companies(subscription_status);
 CREATE INDEX idx_users_company ON users(company_id);
 CREATE INDEX idx_customers_company ON customers(company_id);
 CREATE INDEX idx_leads_company ON leads(company_id);


### PR DESCRIPTION
## Summary
This PR adds subscription lifecycle tracking to the companies table to support Stripe webhook integration and trial period management.

## Key Changes
- Added `subscription_status` field to track subscription state (trialing, active, past_due, canceled, expired) as set by Stripe webhooks
- Added `trial_starts_at` and `trial_ends_at` timestamp fields to manage trial periods
- Added `onboarding_completed` boolean flag to track onboarding progress (defaults to false)
- Created index on `subscription_status` for efficient filtering and querying of companies by subscription state

## Implementation Details
- All new fields are nullable except `onboarding_completed` which defaults to false
- Timestamps use `TIMESTAMP WITH TIME ZONE` for proper timezone handling
- The `subscription_status` field is designed to be updated by Stripe webhook events
- Index on `subscription_status` will improve query performance for subscription-related operations (e.g., finding active vs. past-due accounts)

https://claude.ai/code/session_01PoA2sSzhdViAPE9Y3XqiXc