### PR TITLE
fix(webhook): resolve company by companies.email when users row missing

### DIFF
--- a/src/__tests__/api/webhook-stripe.test.js
+++ b/src/__tests__/api/webhook-stripe.test.js
@@ -101,12 +101,56 @@ describe('/api/webhook/stripe', () => {
 
     expect(response.status).toBe(200);
     expect(mockSupabaseFrom).toHaveBeenCalledWith('users');
+    expect(mockSupabaseFrom).toHaveBeenCalledWith('companies');
     expect(consoleSpy).toHaveBeenCalledWith(
-      'No company found for checkout session',
-      expect.objectContaining({ customerEmail: 'test@example.com' })
+      'No company found for checkout session — DB not updated',
+      expect.objectContaining({
+        customerEmail: 'test@example.com',
+        lookupEmailUsed: 'test@example.com',
+        stripeCustomerId: 'cus_123',
+      })
     );
 
     consoleSpy.mockRestore();
+  });
+
+  it('falls back to companies.email lookup when users row is missing', async () => {
+    // Regression test for silent-failure bug: webhook used to only look up
+    // companies via the users table. If a checkout completed before the users
+    // row existed (signup race) or with a different email, the webhook
+    // returned 200 OK without ever updating the company. This test ensures
+    // the companies.email fallback resolves the company and the update fires.
+    mockConstructEvent.mockReturnValue({
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          customer_email: 'orphan@example.com',
+          customer: 'cus_orphan',
+          subscription: 'sub_orphan',
+          metadata: { plan: 'elite', tier: 'elite', billing: 'monthly', skipTrial: 'true' },
+        },
+      },
+    });
+
+    // First .single() call = users lookup, returns null (no users row).
+    // Second .single() call = companies fallback, returns the company id.
+    mockSingle
+      .mockResolvedValueOnce({ data: null, error: { code: 'PGRST116' } })
+      .mockResolvedValueOnce({ data: { id: 'company-orphan' }, error: null });
+
+    const request = makeWebhookRequest();
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(mockSupabaseFrom).toHaveBeenCalledWith('users');
+    expect(mockSupabaseFrom).toHaveBeenCalledWith('companies');
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripe_customer_id: 'cus_orphan',
+        plan: 'elite',
+        subscription_status: 'active',
+      })
+    );
   });
 
   it('handles checkout.session.completed for existing users', async () => {

--- a/src/app/api/webhook/stripe/route.js
+++ b/src/app/api/webhook/stripe/route.js
@@ -111,16 +111,29 @@ async function handleCheckoutComplete(session) {
     if (data?.id) resolvedCompanyId = data.id;
   }
 
-  if (!resolvedCompanyId) {
-    const lookupEmail = metadata.userEmail || customerEmail;
-    if (lookupEmail) {
-      const { data: existingUser } = await getSupabase()
-        .from('users')
-        .select('id, company_id')
-        .eq('email', lookupEmail)
-        .single();
-      if (existingUser?.company_id) resolvedCompanyId = existingUser.company_id;
-    }
+  const lookupEmail = metadata.userEmail || customerEmail;
+
+  if (!resolvedCompanyId && lookupEmail) {
+    const { data: existingUser } = await getSupabase()
+      .from('users')
+      .select('id, company_id')
+      .eq('email', lookupEmail)
+      .single();
+    if (existingUser?.company_id) resolvedCompanyId = existingUser.company_id;
+  }
+
+  // Fall back to looking up the company directly by email. The users row may
+  // not exist yet (signup trigger race) or may have a different email than
+  // the canonical companies row, but companies.email is always set by
+  // handle_new_signup. Without this fallback the webhook silently no-ops and
+  // returns 200, leaving Stripe convinced the update succeeded.
+  if (!resolvedCompanyId && lookupEmail) {
+    const { data: existingCompany } = await getSupabase()
+      .from('companies')
+      .select('id')
+      .eq('email', lookupEmail)
+      .single();
+    if (existingCompany?.id) resolvedCompanyId = existingCompany.id;
   }
 
   // Synthesize an existingUser-shaped object so the rest of the function
@@ -163,11 +176,13 @@ async function handleCheckoutComplete(session) {
       console.error('Error updating company after checkout:', error.message);
     }
   } else {
-    console.error('No company found for checkout session', {
+    console.error('No company found for checkout session — DB not updated', {
       sessionId: session.id,
+      stripeCustomerId: customerId,
       metadataCompanyId: metadata.companyId || null,
       metadataUserEmail: metadata.userEmail || null,
       customerEmail,
+      lookupEmailUsed: lookupEmail || null,
     });
   }
 


### PR DESCRIPTION
## Summary
Fixes the silent-failure pattern where the Stripe `checkout.session.completed` webhook returned `200 OK` but never updated the company's `plan`, `stripe_customer_id`, or `subscription_status`.

## Root cause
`handleCheckoutComplete` in `src/app/api/webhook/stripe/route.js` resolved the company through two tiers only:
1. `metadata.companyId` → `companies.id`
2. `metadata.userEmail` / `customer_email` → **`users.email`**

If the `users` row didn't exist yet (signup trigger race) or used a slightly different email than the canonical `companies` row, resolution returned `null`. The handler then logged "No company found" and returned 200, so Stripe stopped retrying and the DB was never updated.

## Fix
- Added a third resolution tier that queries `companies.email` directly. The `companies` row is the canonical record (set by `handle_new_signup`), so it's the most reliable fallback.
- Expanded the silent-failure error log to include `stripeCustomerId` and `lookupEmailUsed` to make any future failure mode faster to diagnose.
- Added a regression test asserting the fallback fires when the `users` lookup misses but a `companies.email` match exists.

## Test plan
- [x] `npm test` — 420/420 passing (8/8 in the affected webhook test file, including new regression case)
- [x] `npm run build` — clean
- [x] `npm run lint` — no new warnings
- [ ] Re-run the sandbox checkout that originally exposed the bug; confirm `subscription_status`, `stripe_customer_id`, and `plan` all populate this time
- [ ] Manually exercise the TrialExpiredGate (separate from this PR)

https://claude.ai/code/session_01PoA2sSzhdViAPE9Y3XqiXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoA2sSzhdViAPE9Y3XqiXc)_