### PR TITLE
fix(stripe): pick secret key by session-ID prefix on retrieve

### DIFF
--- a/src/app/api/checkout/session/route.js
+++ b/src/app/api/checkout/session/route.js
@@ -1,20 +1,7 @@
-import Stripe from 'stripe';
 import { NextResponse } from 'next/server';
+import { getStripeForSession } from '@/lib/stripe-server';
 
 export const dynamic = 'force-dynamic';
-
-// Lazy initialization to prevent build-time errors when env vars aren't available
-let stripeClient = null;
-
-function getStripe() {
-  if (!stripeClient) {
-    if (!process.env.STRIPE_SECRET_KEY) {
-      throw new Error('STRIPE_SECRET_KEY is not configured');
-    }
-    stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY);
-  }
-  return stripeClient;
-}
 
 export async function GET(request) {
   const { searchParams } = new URL(request.url);
@@ -28,7 +15,7 @@ export async function GET(request) {
   }
 
   try {
-    const stripe = getStripe();
+    const stripe = getStripeForSession(sessionId);
     const session = await stripe.checkout.sessions.retrieve(sessionId);
 
     return NextResponse.json({

--- a/src/lib/stripe-server.js
+++ b/src/lib/stripe-server.js
@@ -1,0 +1,33 @@
+import Stripe from 'stripe';
+
+const clientsByKey = new Map();
+
+function clientFor(key) {
+  if (!key) {
+    throw new Error('Stripe secret key is not configured');
+  }
+  if (!clientsByKey.has(key)) {
+    clientsByKey.set(key, new Stripe(key));
+  }
+  return clientsByKey.get(key);
+}
+
+// Stripe session/event IDs prefixed `cs_test_` belong to sandbox/test mode and
+// can only be retrieved with a test secret. Calling retrieve() with the wrong
+// mode's key fails with `resource_missing`, which silently breaks the
+// success page when the deploy is configured for live but a tester pays in
+// the sandbox.
+export function getStripeForSession(sessionId) {
+  const isTest =
+    typeof sessionId === 'string' && sessionId.startsWith('cs_test_');
+  const liveKey = process.env.STRIPE_SECRET_KEY;
+  const testKey = process.env.STRIPE_SECRET_KEY_TEST;
+  return clientFor(isTest ? testKey || liveKey : liveKey || testKey);
+}
+
+export function getStripe() {
+  const mode = (process.env.STRIPE_MODE || '').toLowerCase();
+  const liveKey = process.env.STRIPE_SECRET_KEY;
+  const testKey = process.env.STRIPE_SECRET_KEY_TEST;
+  return clientFor(mode === 'test' ? testKey || liveKey : liveKey || testKey);
+}


### PR DESCRIPTION
## Summary
- Fixes the `No such checkout.session: cs_test_...` 500 error on `/api/checkout/session` after a sandbox-mode checkout
- Adds `src/lib/stripe-server.js` exporting `getStripeForSession(sessionId)` that picks the right Stripe secret based on the `cs_test_` vs `cs_live_` prefix
- Updates `src/app/api/checkout/session/route.js` to use it

## Why
Production env has `STRIPE_SECRET_KEY=sk_live_...` and Branch deploys have `sk_test_...`. A test-mode checkout created on a branch deploy redirected its success URL to production, where the live key tried (and failed) to retrieve the test session — `resource_missing` from Stripe.

The new helper looks up `STRIPE_SECRET_KEY_TEST` for `cs_test_` sessions and falls back gracefully when only one key is configured, so live-only deploys behave unchanged.

## Required env var (already added)
- `STRIPE_SECRET_KEY_TEST` = your `sk_test_...` secret, all scopes

## Test plan
- [ ] Wait for Netlify Deploy Preview to publish
- [ ] On the preview URL, log in and start an Elite checkout in sandbox mode
- [ ] Pay with `4242 4242 4242 4242`
- [ ] Confirm the success page loads cleanly (no 500, no "Error fetching session" in Function logs)
- [ ] Confirm the company row in Supabase has `subscription_status` updated and `stripe_customer_id` set

## Quality gates
- `npm run build` — passes
- `npm test` — 420/420 passing
- `npm run lint` — no new warnings introduced

https://claude.ai/code/session_01ENZfgYsmKC8UddRqfkoxbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENZfgYsmKC8UddRqfkoxbQ)_