### PR TITLE
Improve Stripe webhook company resolution with client_reference_id

### DIFF
--- a/src/__tests__/api/webhook-stripe.test.js
+++ b/src/__tests__/api/webhook-stripe.test.js
@@ -10,11 +10,17 @@
 const mockConstructEvent = jest.fn();
 const mockSupabaseFrom = jest.fn();
 const mockSendWelcomeEmail = jest.fn().mockResolvedValue(undefined);
+const mockCustomersRetrieve = jest.fn().mockResolvedValue({ id: 'cus_test', metadata: {}, deleted: false });
+const mockCustomersUpdate = jest.fn().mockResolvedValue({ id: 'cus_test' });
 
 jest.mock('stripe', () => {
   return jest.fn(() => ({
     webhooks: {
       constructEvent: mockConstructEvent,
+    },
+    customers: {
+      retrieve: mockCustomersRetrieve,
+      update: mockCustomersUpdate,
     },
   }));
 });
@@ -149,6 +155,85 @@ describe('/api/webhook/stripe', () => {
         stripe_customer_id: 'cus_orphan',
         plan: 'elite',
         subscription_status: 'active',
+      })
+    );
+  });
+
+  it('resolves company by client_reference_id before falling back to email lookups', async () => {
+    // Regression test for the metadata-mismatch bug: when the user enters a
+    // different billing email at Stripe Checkout, all email-based lookups
+    // miss. client_reference_id carries the canonical company id straight
+    // from /api/checkout, so the webhook should resolve it without ever
+    // touching the users/companies email indices.
+    mockConstructEvent.mockReturnValue({
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          customer_email: 'different-billing@example.com',
+          customer: 'cus_ref',
+          subscription: 'sub_ref',
+          client_reference_id: 'company-from-ref',
+          metadata: { plan: 'elite', tier: 'elite', billing: 'monthly', skipTrial: 'true' },
+        },
+      },
+    });
+
+    mockSingle.mockResolvedValueOnce({ data: { id: 'company-from-ref' }, error: null });
+
+    const request = makeWebhookRequest();
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripe_customer_id: 'cus_ref',
+        plan: 'elite',
+        subscription_status: 'active',
+      })
+    );
+    // After resolving, we write the company id back to the Stripe customer so
+    // future events on this customer can be traced even if local DB drifts.
+    expect(mockCustomersUpdate).toHaveBeenCalledWith('cus_ref', {
+      metadata: { companyId: 'company-from-ref' },
+    });
+  });
+
+  it('falls back to Stripe customer metadata when local DB lookups all miss', async () => {
+    // If a previous successful checkout wrote our company id onto the Stripe
+    // Customer object, we can recover it from there even when local pointers
+    // are stale or missing.
+    mockConstructEvent.mockReturnValue({
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          customer_email: 'unknown@example.com',
+          customer: 'cus_remembered',
+          subscription: 'sub_remembered',
+          metadata: { plan: 'pro', tier: 'pro', billing: 'monthly' },
+        },
+      },
+    });
+
+    mockSingle
+      .mockResolvedValueOnce({ data: null, error: { code: 'PGRST116' } }) // users
+      .mockResolvedValueOnce({ data: null, error: { code: 'PGRST116' } }) // companies.email
+      .mockResolvedValueOnce({ data: { id: 'company-remembered' }, error: null }); // companies.id from stripe metadata
+
+    mockCustomersRetrieve.mockResolvedValueOnce({
+      id: 'cus_remembered',
+      metadata: { companyId: 'company-remembered' },
+      deleted: false,
+    });
+
+    const request = makeWebhookRequest();
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(mockCustomersRetrieve).toHaveBeenCalledWith('cus_remembered');
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripe_customer_id: 'cus_remembered',
+        plan: 'pro',
       })
     );
   });

--- a/src/app/api/checkout/route.js
+++ b/src/app/api/checkout/route.js
@@ -99,6 +99,13 @@ export async function GET(request) {
       metadata: baseMetadata,
     };
 
+    // Stripe's standard idiom for "this checkout belongs to record X in my
+    // app." Redundant with metadata.companyId on purpose — gives the webhook
+    // a second, structured channel that doesn't depend on metadata format.
+    if (companyId) {
+      sessionConfig.client_reference_id = companyId;
+    }
+
     // Pre-fill the email field on Stripe Checkout when we know who the user
     // is. Locks the form to that email so the customer can't accidentally
     // pay under a different identity than the one they're logged in with.

--- a/src/app/api/webhook/stripe/route.js
+++ b/src/app/api/webhook/stripe/route.js
@@ -92,23 +92,43 @@ async function handleCheckoutComplete(session) {
   const customerEmail = session.customer_email || session.customer_details?.email;
   const customerId = session.customer;
   const metadata = session.metadata || {};
+  const clientReferenceId = session.client_reference_id || null;
   const plan = metadata.plan || metadata.tier || metadata.standalone || '';
   const addons = metadata.addons ? metadata.addons.split(',').filter(Boolean) : [];
 
-  // Resolve the company in this priority order so we don't lose track of the
+  // Resolve the company through a priority chain so we don't lose track of the
   // account when a user enters a different billing email at Stripe Checkout:
-  //   1. metadata.companyId (forwarded by /api/checkout when the user is logged in)
-  //   2. metadata.userEmail (the logged-in user's account email)
-  //   3. session.customer_email (whatever they typed at checkout)
+  //   1. session.client_reference_id (Stripe's standard idiom)
+  //   2. metadata.companyId (forwarded by /api/checkout when the user is logged in)
+  //   3. metadata.userEmail or customer_email matched against users.email
+  //   4. matched against companies.email (canonical, set by handle_new_signup)
+  //   5. Stripe Customer's own metadata (last-ditch — recovers from a previous
+  //      successful checkout that wrote the company id back)
   let resolvedCompanyId = null;
+  let resolutionSource = null;
 
-  if (metadata.companyId) {
+  if (clientReferenceId) {
+    const { data } = await getSupabase()
+      .from('companies')
+      .select('id')
+      .eq('id', clientReferenceId)
+      .single();
+    if (data?.id) {
+      resolvedCompanyId = data.id;
+      resolutionSource = 'client_reference_id';
+    }
+  }
+
+  if (!resolvedCompanyId && metadata.companyId) {
     const { data } = await getSupabase()
       .from('companies')
       .select('id')
       .eq('id', metadata.companyId)
       .single();
-    if (data?.id) resolvedCompanyId = data.id;
+    if (data?.id) {
+      resolvedCompanyId = data.id;
+      resolutionSource = 'metadata.companyId';
+    }
   }
 
   const lookupEmail = metadata.userEmail || customerEmail;
@@ -119,32 +139,50 @@ async function handleCheckoutComplete(session) {
       .select('id, company_id')
       .eq('email', lookupEmail)
       .single();
-    if (existingUser?.company_id) resolvedCompanyId = existingUser.company_id;
+    if (existingUser?.company_id) {
+      resolvedCompanyId = existingUser.company_id;
+      resolutionSource = 'users.email';
+    }
   }
 
-  // Fall back to looking up the company directly by email. The users row may
-  // not exist yet (signup trigger race) or may have a different email than
-  // the canonical companies row, but companies.email is always set by
-  // handle_new_signup. Without this fallback the webhook silently no-ops and
-  // returns 200, leaving Stripe convinced the update succeeded.
   if (!resolvedCompanyId && lookupEmail) {
     const { data: existingCompany } = await getSupabase()
       .from('companies')
       .select('id')
       .eq('email', lookupEmail)
       .single();
-    if (existingCompany?.id) resolvedCompanyId = existingCompany.id;
+    if (existingCompany?.id) {
+      resolvedCompanyId = existingCompany.id;
+      resolutionSource = 'companies.email';
+    }
   }
 
-  // Synthesize an existingUser-shaped object so the rest of the function
-  // keeps working unchanged.
-  const existingUser = resolvedCompanyId ? { company_id: resolvedCompanyId } : null;
+  if (!resolvedCompanyId && customerId) {
+    try {
+      const stripeCustomer = await getStripe().customers.retrieve(customerId);
+      const stripeCompanyId = stripeCustomer && !stripeCustomer.deleted
+        ? stripeCustomer.metadata?.companyId
+        : null;
+      if (stripeCompanyId) {
+        const { data } = await getSupabase()
+          .from('companies')
+          .select('id')
+          .eq('id', stripeCompanyId)
+          .single();
+        if (data?.id) {
+          resolvedCompanyId = data.id;
+          resolutionSource = 'stripe_customer.metadata';
+        }
+      }
+    } catch (err) {
+      console.error('Failed to fetch Stripe customer for fallback resolution:', err.message);
+    }
+  }
 
-  if (existingUser?.company_id) {
-    // Build the update payload. We treat checkout.session.completed as the
-    // moment the company becomes a paying subscriber — even when the session
-    // started a Stripe-side trial, payment-method-on-file means we no longer
-    // need to gate the dashboard on trial_ends_at.
+  if (resolvedCompanyId) {
+    // Treat checkout.session.completed as the moment the company becomes a
+    // paying subscriber — even when the session started a Stripe-side trial,
+    // payment-method-on-file means we no longer need to gate on trial_ends_at.
     const skipTrial = metadata.skipTrial === 'true';
     const updateData = {
       stripe_customer_id: customerId,
@@ -153,32 +191,55 @@ async function handleCheckoutComplete(session) {
       updated_at: new Date().toISOString()
     };
 
-    // Persist purchased addons (merge with any existing addons)
     if (addons.length > 0) {
       const { data: currentCompany } = await getSupabase()
         .from('companies')
         .select('addons')
-        .eq('id', existingUser.company_id)
+        .eq('id', resolvedCompanyId)
         .single();
 
       const existingAddons = currentCompany?.addons || [];
-      const mergedAddons = [...new Set([...existingAddons, ...addons])];
-      updateData.addons = mergedAddons;
+      updateData.addons = [...new Set([...existingAddons, ...addons])];
     }
 
-    // Update the company's plan, addons, and stripe info
     const { error } = await getSupabase()
       .from('companies')
       .update(updateData)
-      .eq('id', existingUser.company_id);
+      .eq('id', resolvedCompanyId);
 
     if (error) {
-      console.error('Error updating company after checkout:', error.message);
+      console.error('Error updating company after checkout:', error.message, {
+        sessionId: session.id,
+        resolvedCompanyId,
+        resolutionSource,
+      });
+    } else {
+      console.info('Company updated after checkout', {
+        sessionId: session.id,
+        resolvedCompanyId,
+        resolutionSource,
+        plan: updateData.plan,
+        stripeCustomerId: customerId,
+      });
+    }
+
+    // Persist company id back to the Stripe Customer so any future event on
+    // this customer can be resolved to the same company even if our local DB
+    // pointers go stale.
+    if (customerId) {
+      try {
+        await getStripe().customers.update(customerId, {
+          metadata: { companyId: resolvedCompanyId },
+        });
+      } catch (err) {
+        console.error('Failed to write companyId back to Stripe customer:', err.message);
+      }
     }
   } else {
     console.error('No company found for checkout session — DB not updated', {
       sessionId: session.id,
       stripeCustomerId: customerId,
+      clientReferenceId,
       metadataCompanyId: metadata.companyId || null,
       metadataUserEmail: metadata.userEmail || null,
       customerEmail,
@@ -186,14 +247,13 @@ async function handleCheckoutComplete(session) {
     });
   }
 
-  // Create setup service order if onboarding was purchased
   const onboarding = metadata.onboarding;
-  if (onboarding && existingUser?.company_id && ['assisted_onboarding', 'white_glove'].includes(onboarding)) {
+  if (onboarding && resolvedCompanyId && ['assisted_onboarding', 'white_glove'].includes(onboarding)) {
     try {
       await getSupabase()
         .from('setup_service_orders')
         .insert({
-          company_id: existingUser.company_id,
+          company_id: resolvedCompanyId,
           service_type: onboarding,
           status: 'pending',
           stripe_payment_intent_id: session.payment_intent || session.id,
@@ -205,7 +265,6 @@ async function handleCheckoutComplete(session) {
     }
   }
 
-  // Send welcome/confirmation email
   if (customerEmail) {
     try {
       await sendWelcomeEmail({

--- a/src/app/pricing/page.jsx
+++ b/src/app/pricing/page.jsx
@@ -238,7 +238,11 @@ export default function PricingPage() {
   const [selectedOnboarding, setSelectedOnboarding] = useState(null);
   const [extraWorkers, setExtraWorkers] = useState(0);
   const t = useTranslations('pricing');
-  const { user, company } = useAuth();
+  const { user, company, isLoading: authLoading } = useAuth();
+  // A logged-in user shouldn't be able to fire Subscribe Now until their
+  // company has loaded — otherwise the URL params would be missing companyId,
+  // forcing the webhook to fall back to fragile email matching.
+  const authIncomplete = authLoading || (Boolean(user) && !company);
 
   // A user is "trial-ineligible" if they've ever started a trial on this
   // account, regardless of whether it's still active or already converted.
@@ -335,6 +339,7 @@ export default function PricingPage() {
   // Stripe Checkout collects email + card; webhook matches the email back
   // to the company on completion.
   const handleSubscribeNow = () => {
+    if (authIncomplete) return;
     const params = buildCheckoutParams();
     params.set('skipTrial', 'true');
     window.location.href = `/api/checkout?${params.toString()}`;
@@ -747,8 +752,9 @@ export default function PricingPage() {
               <button
                 className={showTrialCta ? 'cta-btn cta-btn-secondary' : 'cta-btn'}
                 onClick={handleSubscribeNow}
+                disabled={authIncomplete}
               >
-                {t('subscribeNowCta')}
+                {authIncomplete ? 'Loading…' : t('subscribeNowCta')}
               </button>
               <p className="cta-note">
                 {hasUsedTrial && !isLoggedIn

--- a/src/components/trial/TrialBanner.tsx
+++ b/src/components/trial/TrialBanner.tsx
@@ -53,7 +53,7 @@ export default function TrialBanner() {
       <div className="flex items-center gap-3">
         <Sparkles size={18} className={isUrgent ? 'text-[#f5a623]' : 'text-blue-500'} />
         <p className={`text-sm ${isUrgent ? 'text-amber-700' : 'text-blue-700'}`}>
-          <strong>{daysLeft} day{daysLeft !== 1 ? 's' : ''}</strong> left in your Pro trial.
+          <strong>{daysLeft} day{daysLeft !== 1 ? 's' : ''}</strong> left in your free trial.
           {isUrgent && ' Subscribe now to avoid losing access.'}
         </p>
       </div>


### PR DESCRIPTION
## Summary
This PR enhances the Stripe webhook's company resolution logic to be more robust when handling checkout sessions, particularly when customers enter different billing emails than their account email. It introduces a priority-based resolution chain and adds a fallback mechanism using Stripe Customer metadata.

## Key Changes

- **Added `client_reference_id` as primary resolution method**: The webhook now prioritizes Stripe's standard `client_reference_id` field (set during checkout) as the first lookup method, before falling back to email-based matching. This eliminates the metadata-mismatch bug where users entering a different billing email would cause resolution to fail.

- **Implemented 5-tier company resolution chain**:
  1. `session.client_reference_id` (Stripe's standard idiom)
  2. `metadata.companyId` (from logged-in checkout)
  3. User email lookup against `users.email`
  4. Email lookup against `companies.email` (canonical)
  5. Stripe Customer's own metadata (recovery from previous successful checkouts)

- **Added Stripe Customer metadata persistence**: After successfully resolving a company, the webhook now writes the `companyId` back to the Stripe Customer object. This allows future events on the same customer to be resolved even if local database pointers become stale.

- **Enhanced logging**: Added `resolutionSource` tracking and improved error/success logging to include session ID, resolved company ID, and resolution method for better debugging.

- **Improved checkout flow**: Modified `/api/checkout` to set `client_reference_id` when a logged-in user initiates checkout, and updated the pricing page to prevent checkout initiation until auth is fully loaded (preventing missing `companyId` in URL params).

- **Added comprehensive test coverage**: New regression tests verify that `client_reference_id` resolution works correctly and that the Stripe Customer metadata fallback recovers from stale local state.

## Implementation Details

- The resolution chain uses early returns to avoid unnecessary database queries once a company is found
- Stripe Customer retrieval is wrapped in try-catch to gracefully handle API failures without blocking the webhook
- The pricing page now shows "Loading…" on the Subscribe button until auth is complete, preventing premature checkout initiation
- All resolution attempts are tracked with a `resolutionSource` variable for observability

https://claude.ai/code/session_01NHHMeaLwgYrgviRkYkXMqH