### PR TITLE
Fix subscription plan downgrade during trial and dunning states

### DIFF
--- a/src/__tests__/api/premium-purchase-all.test.js
+++ b/src/__tests__/api/premium-purchase-all.test.js
@@ -492,7 +492,7 @@ describe('Premium Purchase Flow — Buy Everything', () => {
       expect(updatePayload.plan).toBe('starter');
     });
 
-    it('downgrades to starter when subscription becomes past_due', async () => {
+    it('marks subscription past_due without downgrading plan', async () => {
       const { mockUpdate } = setupSupabaseMocks();
 
       mockConstructEvent.mockReturnValue({
@@ -511,7 +511,12 @@ describe('Premium Purchase Flow — Buy Everything', () => {
 
       expect(response.status).toBe(200);
       const updatePayload = mockUpdate.mock.calls[0][0];
-      expect(updatePayload.plan).toBe('starter');
+      // past_due is dunning, not cancellation. Stripe will eventually emit
+      // subscription.deleted if the account never recovers — that's where the
+      // plan downgrade belongs (handleSubscriptionCanceled). Resetting plan
+      // here would knock paid customers down to Starter mid-retry.
+      expect(updatePayload.plan).toBeUndefined();
+      expect(updatePayload.subscription_status).toBe('past_due');
     });
   });
 

--- a/src/__tests__/api/purchase-plans-and-upsells.test.js
+++ b/src/__tests__/api/purchase-plans-and-upsells.test.js
@@ -610,7 +610,7 @@ describe('Webhook — subscription lifecycle events', () => {
     expect(updatePayload.updated_at).toBeDefined();
   });
 
-  it('subscription.updated with trialing status downgrades to starter', async () => {
+  it('subscription.updated with trialing status syncs status without touching plan', async () => {
     const { mockUpdate } = setupSupabaseMocks();
 
     mockConstructEvent.mockReturnValue({
@@ -623,12 +623,16 @@ describe('Webhook — subscription lifecycle events', () => {
     const response = await webhookPOST(makeWebhookRequest());
     expect(response.status).toBe(200);
 
-    // trialing !== 'active', so plan gets set to starter
+    // Trial subscriptions arrive as status='trialing' immediately after
+    // checkout.session.completed sets the chosen plan. The handler must NOT
+    // reset plan here, or every Elite/Pro purchase silently downgrades to
+    // Starter mid-flow.
     const updatePayload = mockUpdate.mock.calls[0][0];
-    expect(updatePayload.plan).toBe('starter');
+    expect(updatePayload.plan).toBeUndefined();
+    expect(updatePayload.subscription_status).toBe('trialing');
   });
 
-  it('subscription.updated with incomplete status downgrades to starter', async () => {
+  it('subscription.updated with incomplete status syncs status without touching plan', async () => {
     const { mockUpdate } = setupSupabaseMocks();
 
     mockConstructEvent.mockReturnValue({
@@ -639,7 +643,9 @@ describe('Webhook — subscription lifecycle events', () => {
     });
 
     await webhookPOST(makeWebhookRequest());
-    expect(mockUpdate.mock.calls[0][0].plan).toBe('starter');
+    const updatePayload = mockUpdate.mock.calls[0][0];
+    expect(updatePayload.plan).toBeUndefined();
+    expect(updatePayload.subscription_status).toBe('incomplete');
   });
 
   it('subscription.deleted always downgrades regardless of previous plan', async () => {

--- a/src/__tests__/api/webhook-stripe.test.js
+++ b/src/__tests__/api/webhook-stripe.test.js
@@ -285,6 +285,30 @@ describe('/api/webhook/stripe', () => {
     });
   });
 
+  it('does not downgrade plan on customer.subscription.updated for trialing status', async () => {
+    // Regression test: trial subscriptions arrive with status='trialing', not
+    // 'active'. The handler used to reset plan to 'starter' for any non-active
+    // status, clobbering 'elite'/'pro' set moments earlier by
+    // checkout.session.completed.
+    mockConstructEvent.mockReturnValue({
+      type: 'customer.subscription.updated',
+      data: {
+        object: { id: 'sub_123', customer: 'cus_123', status: 'trialing' },
+      },
+    });
+
+    const request = makeWebhookRequest();
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.not.objectContaining({ plan: expect.anything() })
+    );
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ subscription_status: 'trialing' })
+    );
+  });
+
   it('handles subscription canceled', async () => {
     mockConstructEvent.mockReturnValue({
       type: 'customer.subscription.deleted',

--- a/src/app/api/webhook/stripe/route.js
+++ b/src/app/api/webhook/stripe/route.js
@@ -282,13 +282,13 @@ async function handleSubscriptionUpdate(subscription) {
   const customerId = subscription.customer;
   if (!customerId) return;
 
-  // Map Stripe subscription status to plan — active means keep plan, else downgrade
-  const planUpdate = subscription.status === 'active' ? {} : { plan: 'starter' };
-
+  // Only sync subscription_status here. The plan is set by checkout.session.completed
+  // and cleared by customer.subscription.deleted (handleSubscriptionCanceled).
+  // Resetting plan on any non-active status would clobber 'elite'/'pro' to 'starter'
+  // during the normal trialing/past_due/incomplete states.
   const { error } = await getSupabase()
     .from('companies')
     .update({
-      ...planUpdate,
       subscription_status: subscription.status,
       updated_at: new Date().toISOString()
     })


### PR DESCRIPTION
## Summary
Fixed a critical bug where trial and dunning subscription states were incorrectly downgrading customer plans from Elite/Pro to Starter. The webhook handler was resetting the plan whenever subscription status wasn't 'active', which interfered with the normal subscription lifecycle.

## Key Changes
- **Modified `handleSubscriptionUpdate()`** in `src/app/api/webhook/stripe/route.js`:
  - Removed automatic plan downgrade logic that triggered on non-active statuses
  - Now only syncs `subscription_status` without modifying the `plan` field
  - Plan changes are now exclusively handled by `checkout.session.completed` (upgrades) and `customer.subscription.deleted` (downgrades)

- **Updated test expectations** across three test files to reflect the corrected behavior:
  - `webhook-stripe.test.js`: Added regression test for trialing status
  - `purchase-plans-and-upsells.test.js`: Updated two tests to verify status sync without plan modification
  - `premium-purchase-all.test.js`: Updated past_due test to verify dunning state handling

## Implementation Details
The root cause was that Stripe emits `customer.subscription.updated` events with status='trialing' immediately after `checkout.session.completed` sets the chosen plan. The old logic would then reset the plan to 'starter' because 'trialing' !== 'active', silently downgrading every Elite/Pro purchase mid-flow.

The fix establishes a clear separation of concerns:
- **Plan upgrades**: Handled by `checkout.session.completed` webhook
- **Plan downgrades**: Handled by `customer.subscription.deleted` webhook  
- **Status syncing**: Handled by `customer.subscription.updated` webhook (no plan changes)

This prevents plan downgrades during normal transient states like 'trialing', 'incomplete', and 'past_due' (dunning).

https://claude.ai/code/session_01BJNDuY49WaebZA6JuLBmdb