### PR TITLE
Improve Stripe key matching and rename portal_pro addon ID

### DIFF
--- a/src/app/api/checkout/session/route.js
+++ b/src/app/api/checkout/session/route.js
@@ -29,7 +29,12 @@ export async function GET(request) {
     });
 
   } catch (error) {
-    console.error('Error fetching session:', error);
+    console.error('Error fetching session:', {
+      sessionId,
+      message: error.message,
+      type: error.type,
+      code: error.code,
+    });
     return NextResponse.json(
       { error: error.message },
       { status: 500 }

--- a/src/app/api/portal/route.ts
+++ b/src/app/api/portal/route.ts
@@ -463,7 +463,10 @@ export async function GET(request: NextRequest) {
       .single();
 
     const addons = (company?.addons || []) as string[];
-    const hasPro = addons.includes('portal_pro') || company?.plan === 'elite';
+    const hasPro =
+      addons.includes('customer_portal_pro') ||
+      addons.includes('portal_pro') ||
+      company?.plan === 'elite';
 
     return NextResponse.json({ hasPortalPro: hasPro });
   }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -352,6 +352,7 @@ export default function DashboardPage() {
 
       {/* Customer Portal Pro Upsell — show for non-Elite users who don't have it */}
       {company && company.plan !== 'elite' && !company.is_beta_tester &&
+       !(company.addons as string[] || []).includes('customer_portal_pro') &&
        !(company.addons as string[] || []).includes('portal_pro') && (
         <div className="bg-gradient-to-r from-indigo-600 to-purple-600 rounded-xl p-4 sm:p-6 text-white mb-6 sm:mb-8">
           <div className="flex items-center justify-between">

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1025,6 +1025,7 @@ function SettingsContent() {
           website_builder: { name: 'Website Builder', description: 'Custom business website' },
           keep_me_legal: { name: 'Compliance Autopilot', description: 'Automated compliance monitoring, law-change alerts & cert reminders' },
           quickbooks_sync: { name: 'QuickBooks Sync', description: 'Two-way QuickBooks integration' },
+          customer_portal_pro: { name: 'Customer Portal Pro', description: 'Branded customer portal with job tracker, photos, messaging & documents' },
           portal_pro: { name: 'Customer Portal Pro', description: 'Branded customer portal with job tracker, photos, messaging & documents' },
         }
 

--- a/src/app/pricing/page.jsx
+++ b/src/app/pricing/page.jsx
@@ -81,14 +81,14 @@ const TIERS = [
 // Add-ons shown inline inside each plan card
 const PLAN_INLINE_ADDONS = {
   starter: [
-    { id: 'portal_pro', name: 'Customer Portal Pro', price: 24 },
+    { id: 'customer_portal_pro', name: 'Customer Portal Pro', price: 24 },
     { id: 'keep_me_legal', name: 'Compliance Autopilot', price: 29 },
     { id: 'quickbooks_sync', name: 'QuickBooks Sync', price: 12 },
     { id: 'website_builder', name: 'Website Builder', price: 25 },
     { id: 'extra_page', name: 'Extra Website Page', price: 10 },
   ],
   pro: [
-    { id: 'portal_pro', name: 'Customer Portal Pro', price: 24 },
+    { id: 'customer_portal_pro', name: 'Customer Portal Pro', price: 24 },
     { id: 'keep_me_legal', name: 'Compliance Autopilot', price: 29 },
     { id: 'quickbooks_sync', name: 'QuickBooks Sync', price: 12 },
     { id: 'website_builder', name: 'Website Builder', price: 25 },
@@ -192,7 +192,7 @@ const ADDONS = [
     hasAnnual: true,
   },
   {
-    id: 'portal_pro',
+    id: 'customer_portal_pro',
     name: 'Customer Portal Pro',
     monthlyPrice: 24,
     annualPrice: 240,

--- a/src/lib/plan-features.ts
+++ b/src/lib/plan-features.ts
@@ -101,6 +101,7 @@ const ADDON_FEATURE_MAP: Record<string, FeatureKey> = {
   jenny_exec_admin: 'jenny_exec_admin',
   keep_me_legal: 'compliance',
   quickbooks_sync: 'quickbooks_sync',
+  customer_portal_pro: 'customer_portal',
   portal_pro: 'customer_portal',
 };
 

--- a/src/lib/stripe-server.js
+++ b/src/lib/stripe-server.js
@@ -12,17 +12,37 @@ function clientFor(key) {
   return clientsByKey.get(key);
 }
 
-// Stripe session/event IDs prefixed `cs_test_` belong to sandbox/test mode and
-// can only be retrieved with a test secret. Calling retrieve() with the wrong
-// mode's key fails with `resource_missing`, which silently breaks the
-// success page when the deploy is configured for live but a tester pays in
-// the sandbox.
+// Stripe session IDs prefixed `cs_test_` belong to sandbox mode; `cs_live_`
+// are live. Calling retrieve() with the wrong mode's key fails with
+// `resource_missing`, which surfaces as a confusing 500 on the success page.
+// Pick a key whose mode matches the session, and refuse to fall back to a
+// wrong-mode key — surface a clear config error instead.
 export function getStripeForSession(sessionId) {
-  const isTest =
-    typeof sessionId === 'string' && sessionId.startsWith('cs_test_');
+  const id = typeof sessionId === 'string' ? sessionId : '';
+  const isTest = id.startsWith('cs_test_');
+  const isLive = id.startsWith('cs_live_');
   const liveKey = process.env.STRIPE_SECRET_KEY;
   const testKey = process.env.STRIPE_SECRET_KEY_TEST;
-  return clientFor(isTest ? testKey || liveKey : liveKey || testKey);
+
+  // Unrecognized prefix (test fixtures, future formats): fall back to whatever
+  // is configured rather than blocking. Prefer live, then test.
+  if (!isTest && !isLive) {
+    return clientFor(liveKey || testKey);
+  }
+
+  const expectedPrefix = isTest ? 'sk_test_' : 'sk_live_';
+  const candidates = isTest ? [testKey, liveKey] : [liveKey, testKey];
+  const matched = candidates.find(
+    (k) => typeof k === 'string' && k.startsWith(expectedPrefix)
+  );
+  if (!matched) {
+    throw new Error(
+      `No Stripe ${isTest ? 'test' : 'live'} secret key configured for session ` +
+        `${id.slice(0, 12)}…. Set ` +
+        `${isTest ? 'STRIPE_SECRET_KEY_TEST (or STRIPE_SECRET_KEY=sk_test_…)' : 'STRIPE_SECRET_KEY=sk_live_…'} in your environment.`
+    );
+  }
+  return clientFor(matched);
 }
 
 export function getStripe() {


### PR DESCRIPTION
## Summary
This PR makes two key improvements: (1) enhances Stripe session key matching to prevent silent failures and provide clear configuration errors, and (2) renames the `portal_pro` addon ID to `customer_portal_pro` for consistency while maintaining backward compatibility.

## Key Changes

**Stripe Key Matching (`src/lib/stripe-server.js`)**
- Replaced lenient fallback logic with strict mode matching that validates the Stripe secret key mode matches the session ID prefix
- Now throws a clear, actionable error when the required key is missing instead of silently failing with a 500 error
- Handles unrecognized session ID prefixes (test fixtures, future formats) by falling back to configured keys
- Improved error messages to guide users on which environment variable to set

**Addon ID Rename (`portal_pro` → `customer_portal_pro`)**
- Renamed addon ID across all references: pricing page, portal route, dashboard, and settings
- Added backward compatibility checks to support both old and new IDs during transition
- Updated feature mapping to recognize the new ID

**Error Logging Enhancement (`src/app/api/checkout/session/route.js`)**
- Improved error logging to include session ID and error details for better debugging

## Notable Implementation Details
- The Stripe key matching logic prioritizes keys in order: live first (unless test session), then test as fallback for unrecognized prefixes
- Backward compatibility maintained by checking for both `customer_portal_pro` and `portal_pro` addon IDs in multiple locations
- Error messages are user-friendly and include the session ID prefix to help identify which environment is being used

https://claude.ai/code/session_014R4qreyksf4WUe8MwmsFF5