### PR TITLE
Fix checkout flow for logged-out users on marketing site

### DIFF
--- a/src/app/auth/set-password/page.tsx
+++ b/src/app/auth/set-password/page.tsx
@@ -157,8 +157,26 @@ export default function SetPasswordPage() {
     // Fire the welcome email in the background (non-blocking)
     triggerWelcomeEmail();
 
-    // Redirect based on user role
+    // If the user came here via the "Subscribe Now" path on /pricing, finish
+    // their checkout instead of dropping them on /onboarding. The pricing page
+    // stashed the params in localStorage right before sending them to /auth/signup.
+    let pendingCheckoutParams: string | null = null;
+    try {
+      const raw = localStorage.getItem('pendingCheckout');
+      if (raw) {
+        const parsed = JSON.parse(raw) as { params?: string; savedAt?: number };
+        // Discard intents older than 24h to avoid resurrecting stale carts.
+        const fresh = parsed.savedAt && Date.now() - parsed.savedAt < 24 * 60 * 60 * 1000;
+        if (fresh && parsed.params) pendingCheckoutParams = parsed.params;
+        localStorage.removeItem('pendingCheckout');
+      }
+    } catch {}
+
     setTimeout(() => {
+      if (pendingCheckoutParams) {
+        window.location.href = `/api/checkout?${pendingCheckoutParams}`;
+        return;
+      }
       if (dbUser?.role === 'worker') {
         router.push('/worker');
       } else if (company?.onboarding_completed) {

--- a/src/app/pricing/page.jsx
+++ b/src/app/pricing/page.jsx
@@ -336,12 +336,26 @@ export default function PricingPage() {
   };
 
   // Subscribe-now path: skip the trial and go straight to Stripe Checkout.
-  // Stripe Checkout collects email + card; webhook matches the email back
-  // to the company on completion.
+  // Logged-out visitors must sign up first — otherwise the webhook has no
+  // company to attach the subscription to and the post-payment email link
+  // dead-ends at /dashboard with no auth session. Stash the checkout intent
+  // in localStorage so /auth/set-password can resume it after password setup.
   const handleSubscribeNow = () => {
     if (authIncomplete) return;
     const params = buildCheckoutParams();
     params.set('skipTrial', 'true');
+
+    if (!isLoggedIn) {
+      try {
+        localStorage.setItem(
+          'pendingCheckout',
+          JSON.stringify({ params: params.toString(), savedAt: Date.now() })
+        );
+      } catch {}
+      window.location.href = '/auth/signup';
+      return;
+    }
+
     window.location.href = `/api/checkout?${params.toString()}`;
   };
 

--- a/tooltimepro/index.html
+++ b/tooltimepro/index.html
@@ -1318,28 +1318,20 @@
             return addOns;
         }
 
-        async function startCheckout(plan) {
-            try {
-                const addOns = getAddOns(plan);
-                const response = await fetch('/api/checkout', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        plan: plan,
-                        billing: currentBilling,
-                        addOns: addOns
-                    })
-                });
-                const data = await response.json();
-                if (data.url) {
-                    window.location.href = data.url;
-                } else {
-                    alert('Unable to start checkout. Please try again.');
-                }
-            } catch (error) {
-                console.error('Checkout error:', error);
-                alert('Unable to start checkout. Please try again.');
-            }
+        function startCheckout(plan) {
+            // The static marketing site has no auth context, so it can't drive
+            // /api/checkout directly — the webhook would have no company to
+            // attach the subscription to. Send visitors to the app's signup
+            // page, which creates the account, starts the 14-day trial, and
+            // (once they confirm + set a password) lands them in onboarding.
+            const addOns = getAddOns(plan);
+            const params = new URLSearchParams({
+                plan: plan,
+                billing: currentBilling,
+            });
+            if (addOns.length) params.set('addons', addOns.join(','));
+            window.location.href =
+                'https://app.tooltimepro.com/auth/signup?' + params.toString();
         }
 
         document.querySelectorAll('a[href^="#"]').forEach(a=>{a.addEventListener('click',function(e){e.preventDefault();const t=document.querySelector(this.getAttribute('href'));t&&(t.scrollIntoView({behavior:'smooth',block:'start'}),document.getElementById('navLinks').classList.remove('active'))})});


### PR DESCRIPTION
## Summary
Updated the checkout flow to properly handle logged-out users on the marketing site by routing them through account creation before payment, ensuring the webhook has a valid company context to attach subscriptions to.

## Key Changes

- **Marketing site (index.html)**: Replaced async `/api/checkout` call with direct redirect to app signup page, passing plan/billing/addons as URL parameters instead of making an API request
- **Auth set-password page**: Added logic to detect and resume pending checkout intents stored in localStorage after password setup, redirecting to `/api/checkout` with the original parameters
- **Pricing page**: Updated `handleSubscribeNow()` to stash checkout parameters in localStorage and redirect logged-out users to `/auth/signup` before attempting checkout

## Implementation Details

- Checkout intent is stored in localStorage with a 24-hour TTL to prevent resurrecting stale carts
- Parameters are serialized as URL query strings (plan, billing, addons, skipTrial) for transport through the signup flow
- The flow ensures the webhook receives a valid company context by requiring account creation first
- Error handling includes try-catch blocks around localStorage operations to gracefully degrade if storage is unavailable
- Logged-in users on the pricing page continue to hit `/api/checkout` directly, bypassing the signup redirect

https://claude.ai/code/session_01A1gFKHD2ApjD8CXYTwhBG8