### PR TITLE
Add self-healing for inactive Stripe prices via metadata lookup

### DIFF
--- a/src/__tests__/api/checkout.test.js
+++ b/src/__tests__/api/checkout.test.js
@@ -8,6 +8,7 @@
  */
 
 const mockSessionCreate = jest.fn();
+const mockPricesList = jest.fn();
 
 jest.mock('stripe', () => {
   return jest.fn(() => ({
@@ -15,6 +16,9 @@ jest.mock('stripe', () => {
       sessions: {
         create: mockSessionCreate,
       },
+    },
+    prices: {
+      list: mockPricesList,
     },
   }));
 });
@@ -47,6 +51,7 @@ describe('/api/checkout', () => {
     mockSessionCreate.mockResolvedValue({
       url: 'https://checkout.stripe.com/test-session',
     });
+    mockPricesList.mockResolvedValue({ data: [], has_more: false });
   });
 
   it('creates a subscription session for a tier plan', async () => {
@@ -166,6 +171,72 @@ describe('/api/checkout', () => {
     const config = mockSessionCreate.mock.calls[0][0];
     expect(config.subscription_data.trial_period_days).toBe(14);
     expect(config.metadata.skipTrial).toBe('false');
+  });
+
+  describe('inactive-price self-heal', () => {
+    // The route caches the active-prices map at module scope. Reset modules
+    // between tests so each test starts with an empty cache.
+    let isolatedGET;
+    beforeEach(() => {
+      jest.resetModules();
+      isolatedGET = require('@/app/api/checkout/route').GET;
+    });
+
+    it('retries with a metadata-resolved active price when Stripe rejects the configured price as inactive', async () => {
+      mockSessionCreate
+        .mockRejectedValueOnce(Object.assign(new Error('The price specified is inactive. This field only accepts active prices.'), { type: 'StripeInvalidRequestError' }))
+        .mockResolvedValueOnce({ url: 'https://checkout.stripe.com/recovered-session' });
+
+      mockPricesList.mockResolvedValueOnce({
+        data: [
+          { id: 'price_elite_m_NEW', metadata: { tooltime_id: 'elite', tooltime_key: 'monthly' } },
+        ],
+        has_more: false,
+      });
+
+      const request = makeRequest({ tier: 'elite', billing: 'monthly', skipTrial: 'true' });
+      const response = await isolatedGET(request);
+
+      expect(mockSessionCreate).toHaveBeenCalledTimes(2);
+      expect(mockPricesList).toHaveBeenCalled();
+
+      const firstCall = mockSessionCreate.mock.calls[0][0];
+      expect(firstCall.line_items[0].price).toBe('price_elite_m');
+
+      const secondCall = mockSessionCreate.mock.calls[1][0];
+      expect(secondCall.line_items[0].price).toBe('price_elite_m_NEW');
+
+      expect(response.status).toBe(303);
+    });
+
+    it('returns a clear error with attempted price details when no active replacement exists', async () => {
+      mockSessionCreate.mockRejectedValueOnce(
+        Object.assign(new Error('The price specified is inactive. This field only accepts active prices.'), { type: 'StripeInvalidRequestError' })
+      );
+      mockPricesList.mockResolvedValueOnce({ data: [], has_more: false });
+
+      const request = makeRequest({ tier: 'elite', billing: 'monthly' });
+      const response = await isolatedGET(request);
+
+      expect(response.status).toBe(500);
+      const body = await response.json();
+      expect(body.error).toBe('Failed to create checkout session');
+      expect(body.details).toMatch(/inactive/i);
+      expect(body.attempted).toEqual([
+        { tooltimeId: 'elite', tooltimeKey: 'monthly', priceId: 'price_elite_m' },
+      ]);
+      expect(body.hint).toMatch(/setup-products/);
+    });
+
+    it('does not retry when the error is unrelated to inactive prices', async () => {
+      mockSessionCreate.mockRejectedValueOnce(new Error('Network down'));
+      const request = makeRequest({ tier: 'pro', billing: 'monthly' });
+      const response = await isolatedGET(request);
+
+      expect(mockSessionCreate).toHaveBeenCalledTimes(1);
+      expect(mockPricesList).not.toHaveBeenCalled();
+      expect(response.status).toBe(500);
+    });
   });
 
   it('forwards userEmail and companyId so the webhook can match an existing trial user', async () => {

--- a/src/app/api/checkout/route.js
+++ b/src/app/api/checkout/route.js
@@ -17,6 +17,68 @@ function getStripe() {
   return stripeClient;
 }
 
+// Cached map of tooltime_id -> { tooltime_key -> active stripe price id }.
+// setup-products writes these metadata fields on every price it creates, so
+// we can recover when the configured PRICE_IDS env var points at a price
+// that's been archived in the connected Stripe account (common on sandbox
+// deploys that re-seed Stripe but don't update Netlify env vars).
+let activePriceCache = null;
+let activePriceCachedAt = 0;
+const ACTIVE_PRICE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+async function loadActivePricesByMetadata(stripe) {
+  if (activePriceCache && Date.now() - activePriceCachedAt < ACTIVE_PRICE_CACHE_TTL_MS) {
+    return activePriceCache;
+  }
+  const map = {};
+  let hasMore = true;
+  let startingAfter;
+  while (hasMore) {
+    const list = await stripe.prices.list({ limit: 100, active: true, starting_after: startingAfter });
+    for (const price of list.data) {
+      const ttId = price.metadata?.tooltime_id;
+      const ttKey = price.metadata?.tooltime_key;
+      if (ttId && ttKey) {
+        if (!map[ttId]) map[ttId] = {};
+        map[ttId][ttKey] = price.id;
+      }
+    }
+    hasMore = list.has_more;
+    if (list.data.length > 0) startingAfter = list.data[list.data.length - 1].id;
+  }
+  activePriceCache = map;
+  activePriceCachedAt = Date.now();
+  return map;
+}
+
+function isInactivePriceError(err) {
+  const msg = String(err?.message || '');
+  return /inactive/i.test(msg) || err?.code === 'resource_missing';
+}
+
+// Each line item carries the (tooltime_id, tooltime_key) it was built from
+// so we can look up an active replacement if Stripe rejects the configured
+// price as inactive. Returns the new line_items array and a list of swaps
+// that happened (for logging).
+async function resolveLineItemsByMetadata(stripe, lineItems) {
+  const map = await loadActivePricesByMetadata(stripe);
+  const swaps = [];
+  const resolved = lineItems.map((item) => {
+    const ctx = item._context;
+    const replacement = ctx ? map[ctx.tooltimeId]?.[ctx.tooltimeKey] : null;
+    if (!replacement) return item;
+    if (replacement !== item.price) {
+      swaps.push({ tooltimeId: ctx.tooltimeId, tooltimeKey: ctx.tooltimeKey, from: item.price, to: replacement });
+    }
+    return { ...item, price: replacement };
+  });
+  return { resolved, swaps };
+}
+
+function stripContext(lineItems) {
+  return lineItems.map(({ _context, ...rest }) => rest);
+}
+
 
 export async function GET(request) {
   try {
@@ -39,28 +101,37 @@ export async function GET(request) {
     const lineItems = [];
 
     if (tier && PRICE_IDS[tier]) {
-      const priceId = PRICE_IDS[tier][billing] || PRICE_IDS[tier].monthly;
-      lineItems.push({ price: priceId, quantity: 1 });
+      const key = PRICE_IDS[tier][billing] ? billing : 'monthly';
+      const priceId = PRICE_IDS[tier][key];
+      lineItems.push({ price: priceId, quantity: 1, _context: { tooltimeId: tier, tooltimeKey: key } });
     } else if (standalone && PRICE_IDS[standalone]) {
-      const priceId = PRICE_IDS[standalone][billing] || PRICE_IDS[standalone].monthly;
-      lineItems.push({ price: priceId, quantity: 1 });
+      const key = PRICE_IDS[standalone][billing] ? billing : 'monthly';
+      const priceId = PRICE_IDS[standalone][key];
+      lineItems.push({ price: priceId, quantity: 1, _context: { tooltimeId: standalone, tooltimeKey: key } });
     }
 
     for (const addonId of addons) {
       if (PRICE_IDS[addonId]) {
-        const priceId = billing === 'annual' && PRICE_IDS[addonId].annual
-          ? PRICE_IDS[addonId].annual
-          : PRICE_IDS[addonId].monthly;
-        if (priceId) lineItems.push({ price: priceId, quantity: 1 });
+        const key = billing === 'annual' && PRICE_IDS[addonId].annual ? 'annual' : 'monthly';
+        const priceId = PRICE_IDS[addonId][key];
+        if (priceId) lineItems.push({ price: priceId, quantity: 1, _context: { tooltimeId: addonId, tooltimeKey: key } });
       }
     }
 
     if (extraWorkers > 0 && PRICE_IDS.extra_worker?.monthly) {
-      lineItems.push({ price: PRICE_IDS.extra_worker.monthly, quantity: extraWorkers });
+      lineItems.push({
+        price: PRICE_IDS.extra_worker.monthly,
+        quantity: extraWorkers,
+        _context: { tooltimeId: 'extra_worker', tooltimeKey: 'monthly' },
+      });
     }
 
     if (onboarding && PRICE_IDS[onboarding]) {
-      lineItems.push({ price: PRICE_IDS[onboarding], quantity: 1 });
+      lineItems.push({
+        price: PRICE_IDS[onboarding],
+        quantity: 1,
+        _context: { tooltimeId: onboarding, tooltimeKey: 'one_time' },
+      });
     }
 
     if (lineItems.length === 0) {
@@ -91,7 +162,7 @@ export async function GET(request) {
 
     let sessionConfig = {
       payment_method_types: ['card'],
-      line_items: lineItems,
+      line_items: stripContext(lineItems),
       success_url: `${baseUrl}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${baseUrl}/pricing`,
       allow_promotion_codes: true,
@@ -126,7 +197,37 @@ export async function GET(request) {
     }
 
     const stripe = getStripe();
-    const session = await stripe.checkout.sessions.create(sessionConfig);
+
+    let session;
+    try {
+      session = await stripe.checkout.sessions.create(sessionConfig);
+    } catch (firstErr) {
+      if (!isInactivePriceError(firstErr)) throw firstErr;
+
+      // The configured PRICE_IDS env var is pointing at archived prices.
+      // Resolve fresh active price IDs by metadata and retry once.
+      const { resolved, swaps } = await resolveLineItemsByMetadata(stripe, lineItems);
+      if (swaps.length === 0) {
+        // Nothing to swap — surface a clear error so the operator knows
+        // exactly which (tier, billing, priceId) Stripe rejected.
+        const attempted = lineItems.map((it) => ({
+          tooltimeId: it._context?.tooltimeId,
+          tooltimeKey: it._context?.tooltimeKey,
+          priceId: it.price,
+        }));
+        return NextResponse.json({
+          error: 'Failed to create checkout session',
+          details: firstErr.message,
+          hint: 'No active replacement price found in Stripe. POST /api/stripe/setup-products to (re)create the catalog, then update NEXT_PUBLIC_STRIPE_PRICES.',
+          attempted,
+        }, { status: 500 });
+      }
+
+      console.warn('Stripe price(s) inactive — retrying with metadata-resolved active prices:', swaps);
+      const retryConfig = { ...sessionConfig, line_items: stripContext(resolved) };
+      session = await stripe.checkout.sessions.create(retryConfig);
+    }
+
     return NextResponse.redirect(session.url, 303);
 
   } catch (error) {


### PR DESCRIPTION
## Summary
This PR adds resilience to the checkout flow when configured Stripe price IDs become inactive (e.g., after re-seeding a sandbox environment). The system now automatically recovers by looking up active replacement prices using metadata stored by the product setup process, with a single retry attempt before surfacing a clear error to operators.

## Key Changes
- **Active price metadata caching**: Added `loadActivePricesByMetadata()` function that fetches all active Stripe prices and builds a map indexed by `tooltime_id` and `tooltime_key`. Results are cached for 5 minutes to minimize API calls.
- **Line item context tracking**: Modified all line item construction to include a `_context` field containing the `tooltimeId` and `tooltimeKey`, enabling price resolution if the configured price ID fails.
- **Automatic retry logic**: Wrapped `stripe.checkout.sessions.create()` in a try-catch that:
  - Detects inactive price errors via message pattern matching or `resource_missing` error code
  - Resolves fresh active price IDs from the metadata cache
  - Retries the session creation with swapped prices if replacements exist
  - Returns a detailed error response (with attempted prices and recovery hint) if no active replacements are found
- **Context stripping**: Added `stripContext()` helper to remove internal `_context` fields before sending line items to Stripe API.
- **Comprehensive test coverage**: Added three new test cases covering successful recovery, graceful failure when no replacement exists, and non-retry behavior for unrelated errors.

## Implementation Details
- The metadata cache is stored at module scope with a TTL, so it persists across multiple requests within the same serverless function invocation.
- Line items are built with context before being stripped, allowing the retry logic to access the original product identifiers.
- Error detection is defensive: checks both error message content and error code to identify inactive price scenarios.
- Operators receive actionable guidance in error responses, including which prices failed and how to recover (via `/api/stripe/setup-products`).

https://claude.ai/code/session_01TXwz5g93dho7McSMWhmc1M