### PR TITLE
Add production screenshot to 2FA SMS consent documentation

### DIFF
--- a/src/app/sms/page.tsx
+++ b/src/app/sms/page.tsx
@@ -107,9 +107,26 @@ export default function SmsPage() {
               <li>You will then receive a 6-digit code by SMS the next time you log in from an unrecognized device.</li>
             </ol>
 
-            {/* Visual representation of the 2FA opt-in CTA */}
-            <div className="border-2 border-dashed border-[#f5a623] rounded-xl p-6 bg-[#fef3d6]/50">
-              <p className="text-sm font-bold text-[#5c5c70] mb-3 uppercase tracking-wide">2FA Opt-In Example (shown in Account Settings)</p>
+            {/* Actual screenshot of the production 2FA consent UI */}
+            <figure className="border border-gray-200 rounded-xl p-4 bg-white">
+              <p className="text-sm font-bold text-[#5c5c70] mb-3 uppercase tracking-wide">
+                Screenshot &mdash; 2FA SMS consent checkbox in Account Settings
+              </p>
+              <img
+                src="/sms-2fa-consent.png"
+                alt="Screenshot of the ToolTime Pro Two-Factor Authentication settings page showing an unchecked SMS consent checkbox with the label: 'I agree to receive SMS text messages containing verification codes for two-factor authentication at the phone number provided above. Msg & data rates may apply. Frequency varies based on login activity. Reply STOP to opt out or HELP for help at any time.'"
+                className="w-full max-w-[720px] mx-auto rounded-lg border border-gray-200 shadow-sm"
+                loading="lazy"
+              />
+              <figcaption className="text-xs text-[#5c5c70] mt-3 text-center">
+                Captured from app.tooltimepro.com &rarr; Dashboard &rarr; Settings &rarr; Two-Factor Authentication.
+                The consent checkbox is unchecked by default; users must affirmatively check it before 2FA SMS can be enabled.
+              </figcaption>
+            </figure>
+
+            {/* Interactive example of the same opt-in CTA */}
+            <div className="border-2 border-dashed border-[#f5a623] rounded-xl p-6 bg-[#fef3d6]/50 mt-4">
+              <p className="text-sm font-bold text-[#5c5c70] mb-3 uppercase tracking-wide">Interactive example &mdash; same consent label as shown above</p>
               <div className="bg-[#fef3d6] rounded-xl p-4">
                 <label className="flex items-start gap-3 cursor-pointer">
                   <input


### PR DESCRIPTION
## Summary
Updated the SMS 2FA documentation page to include an actual screenshot of the production consent UI alongside the existing interactive example, improving clarity and authenticity of the documentation.

## Key Changes
- Replaced the visual mockup with an actual screenshot of the 2FA SMS consent checkbox from the production app
- Changed the container from a dashed border box to a semantic `<figure>` element with proper `<figcaption>`
- Added an image element (`/sms-2fa-consent.png`) with comprehensive alt text describing the consent checkbox and its label
- Included breadcrumb navigation in the figcaption showing where users can find this setting in the app
- Clarified that the consent checkbox is unchecked by default and requires affirmative user action
- Kept the interactive example as a secondary reference, now labeled as such and separated with margin spacing
- Updated comment text to distinguish between the screenshot and the interactive example

## Implementation Details
- Used semantic HTML5 `<figure>` and `<figcaption>` elements for better accessibility and document structure
- Added `loading="lazy"` attribute for performance optimization
- Included detailed alt text for screen readers explaining the checkbox state and full consent message
- Maintained consistent styling with existing design system (gray borders, rounded corners, shadow effects)
- Preserved the interactive checkbox example for users who want to see the component in action

https://claude.ai/code/session_01Vata9Ccd4x4uduWEuGyhWc