### PR TITLE
Add Crisp integration for live chat and knowledge base sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,14 @@ CRON_SECRET=your-random-secret-here
 
 # Platform Admin
 PLATFORM_ADMIN_EMAILS=admin@yourcompany.com
+
+# Crisp (live chat widget + helpdesk article sync)
+# NEXT_PUBLIC_CRISP_WEBSITE_ID is what the dashboard widget loads.
+# CRISP_API_IDENTIFIER / CRISP_API_KEY are required by scripts/sync-to-crisp.js
+# to push wiki/*.md into the Crisp knowledge base. Create a Personal Plugin at
+# https://marketplace.crisp.chat to get the identifier + key.
+# These belong in GitHub Actions repo secrets (the sync runs in CI), not Netlify.
+NEXT_PUBLIC_CRISP_WEBSITE_ID=
+CRISP_WEBSITE_ID=
+CRISP_API_IDENTIFIER=
+CRISP_API_KEY=

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test:coverage": "jest --coverage",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
-    "test:e2e": "cypress run"
+    "test:e2e": "cypress run",
+    "sync:crisp": "node scripts/sync-to-crisp.js",
+    "sync:crisp:dry": "node scripts/sync-to-crisp.js --dry-run"
   },
   "dependencies": {
     "@prisma/client": "^5.15.0",


### PR DESCRIPTION
## Summary
This PR adds integration with Crisp, a live chat and helpdesk platform, enabling the application to display a live chat widget and automatically sync wiki documentation to the Crisp knowledge base.

## Key Changes
- **Environment Configuration**: Added Crisp-related environment variables to `.env.example`:
  - `NEXT_PUBLIC_CRISP_WEBSITE_ID`: Public identifier for the chat widget
  - `CRISP_WEBSITE_ID`: Internal website ID reference
  - `CRISP_API_IDENTIFIER` and `CRISP_API_KEY`: Credentials for the knowledge base sync API
  
- **NPM Scripts**: Added two new scripts to `package.json`:
  - `sync:crisp`: Runs the Crisp sync script to push wiki documentation to the knowledge base
  - `sync:crisp:dry`: Runs the sync script in dry-run mode for testing without making changes

## Implementation Details
- The Crisp API credentials are intended for use in GitHub Actions CI/CD workflows (not Netlify), as indicated in the environment variable comments
- A Personal Plugin must be created in the Crisp marketplace to obtain the API identifier and key
- The sync script (`scripts/sync-to-crisp.js`) will automatically push markdown files from the `wiki/` directory to the Crisp knowledge base

https://claude.ai/code/session_012Xf1r3kmd3GAHmAh1GB3uQ