### PR TITLE
fix: wiki-gen path + standalone Crisp sync workflow

### DIFF
--- a/.github/workflows/sync-crisp.yml
+++ b/.github/workflows/sync-crisp.yml
@@ -1,0 +1,52 @@
+name: Sync Crisp Helpdesk
+
+# Manual-only: pushes wiki/*.md into Crisp's knowledge base.
+# Does NOT regenerate wiki content or push commits — pure one-way sync.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview what would sync without calling the Crisp API'
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Verify Crisp secrets are configured
+        env:
+          CRISP_API_IDENTIFIER: ${{ secrets.CRISP_API_IDENTIFIER }}
+          CRISP_API_KEY: ${{ secrets.CRISP_API_KEY }}
+          CRISP_WEBSITE_ID: ${{ secrets.CRISP_WEBSITE_ID }}
+        run: |
+          missing=()
+          [ -z "$CRISP_API_IDENTIFIER" ] && missing+=("CRISP_API_IDENTIFIER")
+          [ -z "$CRISP_API_KEY" ] && missing+=("CRISP_API_KEY")
+          [ -z "$CRISP_WEBSITE_ID" ] && missing+=("CRISP_WEBSITE_ID")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required GitHub repo secrets: ${missing[*]}"
+            echo "Add them at: Settings → Secrets and variables → Actions"
+            exit 1
+          fi
+          echo "All Crisp secrets are configured."
+
+      - name: Sync wiki to Crisp
+        env:
+          CRISP_API_IDENTIFIER: ${{ secrets.CRISP_API_IDENTIFIER }}
+          CRISP_API_KEY: ${{ secrets.CRISP_API_KEY }}
+          CRISP_WEBSITE_ID: ${{ secrets.CRISP_WEBSITE_ID }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            node scripts/sync-to-crisp.js --dry-run
+          else
+            node scripts/sync-to-crisp.js
+          fi

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       # Pricing / product catalog changes
+      - 'scripts/stripe-products.js'
       - 'scripts/setup-stripe-products.js'
       - 'src/lib/stripe-prices.js'
       # API route changes

--- a/scripts/generate-wiki.js
+++ b/scripts/generate-wiki.js
@@ -43,17 +43,17 @@ function formatDollars(cents) {
 }
 
 // ============================================================
-// 1. Pricing & Plans — parsed from setup-stripe-products.js
+// 1. Pricing & Plans — parsed from stripe-products.js
 // ============================================================
 
 function extractProducts() {
-  const scriptPath = path.join(ROOT, 'scripts', 'setup-stripe-products.js');
+  const scriptPath = path.join(ROOT, 'scripts', 'stripe-products.js');
   const src = fs.readFileSync(scriptPath, 'utf8');
 
   // Extract the PRODUCTS array using a regex that captures the array content
   const match = src.match(/const PRODUCTS\s*=\s*\[([\s\S]*?)\n\];/);
   if (!match) {
-    console.error('Could not parse PRODUCTS array from setup-stripe-products.js');
+    console.error('Could not parse PRODUCTS array from stripe-products.js');
     process.exit(1);
   }
 


### PR DESCRIPTION
Follow-up to #547 — these two commits were pushed after #547 was merged, so they didn't make it onto main. Without them, the wiki/Crisp sync still fails.

## What's in here

**1. Fix `generate-wiki.js` — points at relocated `stripe-products.js`**

PRODUCTS was extracted from `scripts/setup-stripe-products.js` into a shared module (`scripts/stripe-products.js`) in commit `7dd3ee7`. The wiki generator's regex still pointed at the old file, so every Auto-Update Wiki run since then has failed at step 3 with `Could not parse PRODUCTS array`.

Verified locally: dry-run finds all 16 products.

**2. Watch the new file in `update-wiki.yml`**

Adds `scripts/stripe-products.js` to the workflow's path filters so wiki regen also triggers when prices change in the new location.

**3. New `sync-crisp.yml` — standalone Crisp helpdesk sync**

The existing `update-wiki.yml` bundles Crisp sync with a git push back to main, which fails on protected branches before the Crisp step ever runs. This new workflow is manual-only (`workflow_dispatch`), depends on nothing but the three Crisp secrets, and supports a dry-run input for preview.

Trigger from Actions tab → **Sync Crisp Helpdesk** → Run workflow.

## Test plan

- [ ] Merge this PR
- [ ] Re-run **Auto-Update Wiki & Crisp Helpdesk** — step 3 (`Generate wiki content from source code`) should now succeed
- [ ] Trigger **Sync Crisp Helpdesk** from Actions tab — should populate the Crisp knowledge base with the 23 wiki articles
- [ ] Refresh dashboard, open chat widget → Articles tab should show content

---
_Generated by [Claude Code](https://claude.ai/code/session_012Xf1r3kmd3GAHmAh1GB3uQ)_