### PR TITLE
Fix Supabase keep-alive to use real DB queries instead of API pings

### DIFF
--- a/netlify/functions/supabase-keepalive-cron.ts
+++ b/netlify/functions/supabase-keepalive-cron.ts
@@ -1,6 +1,12 @@
 // Netlify Scheduled Function: Supabase Keep-Alive
-// Pings the Supabase REST API every 3 days to prevent the free-tier project
+// Runs an actual database query every 3 days to prevent the free-tier project
 // from being paused due to inactivity (Supabase pauses after 7 days).
+//
+// IMPORTANT: Supabase determines inactivity based on real database queries,
+// not API-gateway hits. A HEAD request to /rest/v1/ touches PostgREST but
+// never executes SQL, so it does NOT reset the pause timer. This function
+// performs a lightweight SELECT against a real table to generate genuine
+// database activity.
 
 export default async function handler() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -15,16 +21,32 @@ export default async function handler() {
   }
 
   try {
-    // Simple health check query against the Supabase REST API
-    const response = await fetch(`${supabaseUrl}/rest/v1/`, {
-      method: 'HEAD',
-      headers: {
-        'apikey': supabaseAnonKey,
-        'Authorization': `Bearer ${supabaseAnonKey}`,
-      },
-    });
+    // Lightweight SELECT against a core table. This forces PostgREST to
+    // execute real SQL against the database, which counts as activity.
+    const response = await fetch(
+      `${supabaseUrl}/rest/v1/companies?select=id&limit=1`,
+      {
+        method: 'GET',
+        headers: {
+          'apikey': supabaseAnonKey,
+          'Authorization': `Bearer ${supabaseAnonKey}`,
+          'Accept': 'application/json',
+        },
+      }
+    );
 
-    console.log(`[Supabase Keep-Alive] Ping status: ${response.status}`);
+    if (!response.ok) {
+      const body = await response.text();
+      console.error(
+        `[Supabase Keep-Alive] Query failed: ${response.status} ${body}`
+      );
+      return new Response(
+        JSON.stringify({ error: 'Keep-alive query failed', status: response.status }),
+        { status: 502, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    console.log(`[Supabase Keep-Alive] DB query OK: ${response.status}`);
 
     return new Response(JSON.stringify({ success: true, status: response.status }), {
       status: 200,


### PR DESCRIPTION
## Summary
The Supabase keep-alive cron function was using a HEAD request to the REST API gateway, which does not trigger actual database activity. Supabase's inactivity timer is based on real SQL execution, not API hits. This change switches to a lightweight SELECT query against the `companies` table to ensure genuine database activity is recorded.

## Key Changes
- **Changed request method** from `HEAD` to `GET` with a real SELECT query (`/rest/v1/companies?select=id&limit=1`)
- **Added proper error handling** to check response status and log failures with response body
- **Updated headers** to include `Accept: application/json` for proper REST API communication
- **Improved logging** to clarify that a database query (not just a ping) is being executed
- **Added documentation** explaining why real queries are required (Supabase pause timer is based on SQL execution, not API gateway hits)

## Implementation Details
- The query selects only the `id` column with a limit of 1 to minimize database load while still forcing SQL execution
- Error responses now return a 502 status with descriptive JSON to aid debugging
- Console logging distinguishes between a "ping" and an actual "DB query" for clarity in Netlify logs

https://claude.ai/code/session_01JKxQ2vJ3ExFWg4uv2excnL