### PR TITLE
fix(crisp-sync): support workspace API token instead of marketplace plugin

### DIFF
--- a/scripts/sync-to-crisp.js
+++ b/scripts/sync-to-crisp.js
@@ -6,9 +6,13 @@
  * Each wiki/*.md file becomes a Crisp helpdesk article, organized into categories.
  *
  * Required env vars:
- *   CRISP_API_IDENTIFIER  — Crisp API plugin identifier (from marketplace.crisp.chat)
- *   CRISP_API_KEY         — Crisp API plugin secret key
+ *   CRISP_API_IDENTIFIER  — Crisp API token identifier
+ *   CRISP_API_KEY         — Crisp API token secret key
  *   CRISP_WEBSITE_ID      — Your Crisp website ID
+ *
+ * Get the token from: Crisp app > Settings > Workspace Settings >
+ * Advanced Configuration > API Token (tier defaults to 'user').
+ * For a legacy marketplace plugin token, set CRISP_API_TIER=plugin.
  *
  * Usage:
  *   CRISP_API_IDENTIFIER=xxx CRISP_API_KEY=yyy CRISP_WEBSITE_ID=zzz node scripts/sync-to-crisp.js
@@ -72,6 +76,9 @@ class CrispClient {
     this.websiteId = websiteId;
     this.baseUrl = `https://api.crisp.chat/v1/website/${websiteId}/helpdesk`;
     this.auth = 'Basic ' + Buffer.from(`${identifier}:${key}`).toString('base64');
+    // 'plugin' for a marketplace plugin token, 'user' for a workspace
+    // API token (Settings > Advanced Configuration > API Token).
+    this.tier = process.env.CRISP_API_TIER || 'user';
   }
 
   async request(method, endpoint, body) {
@@ -81,7 +88,7 @@ class CrispClient {
       headers: {
         'Authorization': this.auth,
         'Content-Type': 'application/json',
-        'X-Crisp-Tier': 'plugin',
+        'X-Crisp-Tier': this.tier,
       },
     };
     if (body) {


### PR DESCRIPTION
Follow-up to #549. Crisp **rejected** the marketplace plugin's production-token request and explicitly directed us to use a workspace API Token instead:

> "We have a website token now, please use this. Go to: Crisp app > Settings > Workspace Settings > Advanced Configuration > API Token."

A workspace API token authenticates with `X-Crisp-Tier: user`, but `sync-to-crisp.js` hardcoded `X-Crisp-Tier: plugin` — which is why the sandbox `not_subscribed` 404 happened.

## Change

- `scripts/sync-to-crisp.js`: `X-Crisp-Tier` is now configurable via `CRISP_API_TIER`, **defaulting to `user`** (the now-recommended path). Set `CRISP_API_TIER=plugin` for the legacy marketplace-plugin token.
- Updated the header doc comment to point at the workspace API Token settings path.

No marketplace plugin / sandbox / activation needed anymore.

## Test plan

- [ ] Merge this PR
- [ ] Generate a workspace API token: Crisp app → Settings → Workspace Settings → Advanced Configuration → API Token
- [ ] Update GitHub secrets `CRISP_API_IDENTIFIER` + `CRISP_API_KEY` with the new token values
- [ ] Actions → **Sync Crisp Helpdesk** → Run workflow
- [ ] Confirm it gets past `Syncing categories...` and completes green
- [ ] Refresh dashboard widget → Articles tab populated

---
_Generated by [Claude Code](https://claude.ai/code/session_012Xf1r3kmd3GAHmAh1GB3uQ)_