### PR TITLE
fix(crisp-sync): default tier to plugin for workspace API token

### DIFF
--- a/.github/workflows/sync-crisp.yml
+++ b/.github/workflows/sync-crisp.yml
@@ -44,6 +44,9 @@ jobs:
           CRISP_API_IDENTIFIER: ${{ secrets.CRISP_API_IDENTIFIER }}
           CRISP_API_KEY: ${{ secrets.CRISP_API_KEY }}
           CRISP_WEBSITE_ID: ${{ secrets.CRISP_WEBSITE_ID }}
+          # Workspace API tokens authenticate as tier 'plugin'. Override
+          # with a CRISP_API_TIER repo secret if ever needed.
+          CRISP_API_TIER: ${{ secrets.CRISP_API_TIER || 'plugin' }}
         run: |
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             node scripts/sync-to-crisp.js --dry-run

--- a/scripts/sync-to-crisp.js
+++ b/scripts/sync-to-crisp.js
@@ -78,7 +78,7 @@ class CrispClient {
     this.auth = 'Basic ' + Buffer.from(`${identifier}:${key}`).toString('base64');
     // 'plugin' for a marketplace plugin token, 'user' for a workspace
     // API token (Settings > Advanced Configuration > API Token).
-    this.tier = process.env.CRISP_API_TIER || 'user';
+    this.tier = process.env.CRISP_API_TIER || 'plugin';
   }
 
   async request(method, endpoint, body) {


### PR DESCRIPTION
Follow-up to #552. The workspace API token (Crisp app → Settings → Workspace Settings → Advanced Configuration → API Token) with `X-Crisp-Tier: user` returns `401 invalid_session`.

Empirically:
- Marketplace token + tier `plugin` → auth **succeeded** (failed later on sandbox check)
- Workspace token + tier `user` → auth **fails** (`invalid_session`)

So the workspace token authenticates as tier `plugin`. It's the workspace's own credential, so unlike the marketplace dev token it has no sandbox restriction — tier `plugin` should both authenticate and have full helpdesk access.

## Changes

- `scripts/sync-to-crisp.js`: default `CRISP_API_TIER` is now `plugin` (was `user`).
- `.github/workflows/sync-crisp.yml`: explicitly passes `CRISP_API_TIER` (defaults to `plugin`, overridable via a `CRISP_API_TIER` repo secret).

No secret changes needed — the existing recreated workspace token's Identifier/Key stay as-is.

## Test plan

- [ ] Merge this PR
- [ ] Actions → **Sync Crisp Helpdesk** → Run workflow → main
- [ ] Confirm it passes `Syncing categories...` (no more 401)
- [ ] Refresh dashboard chat widget → Articles tab populated

---
_Generated by [Claude Code](https://claude.ai/code/session_012Xf1r3kmd3GAHmAh1GB3uQ)_