### PR TITLE
fix: pin Supabase keep-alive to Prod + recover trial emails missed during pause

### DIFF
--- a/netlify/functions/supabase-keepalive-cron.ts
+++ b/netlify/functions/supabase-keepalive-cron.ts
@@ -7,18 +7,43 @@
 // never executes SQL, so it does NOT reset the pause timer. This function
 // performs a lightweight SELECT against a real table to generate genuine
 // database activity.
+//
+// TARGETING: The keep-alive must always hit the PRODUCTION project. It is
+// deliberately decoupled from NEXT_PUBLIC_SUPABASE_URL — that var is the
+// app's runtime pointer and can drift to a Sandbox project during testing,
+// which would let Prod pause while Sandbox stays warm. Set
+// SUPABASE_KEEPALIVE_URL / SUPABASE_KEEPALIVE_KEY to pin this to Prod. If
+// those are unset it falls back to the NEXT_PUBLIC_* vars for compatibility.
 
 export default async function handler() {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const supabaseUrl =
+    process.env.SUPABASE_KEEPALIVE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey =
+    process.env.SUPABASE_KEEPALIVE_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-  if (!supabaseUrl || !supabaseAnonKey) {
+  if (!supabaseUrl || !supabaseKey) {
     console.error('[Supabase Keep-Alive] Missing environment variables');
     return new Response(JSON.stringify({ error: 'Missing Supabase config' }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },
     });
   }
+
+  // Log which project host is actually being kept alive so the target can be
+  // verified from Netlify function logs without guessing.
+  let targetHost = supabaseUrl;
+  try {
+    targetHost = new URL(supabaseUrl).host;
+  } catch {
+    // keep raw value if it isn't a parseable URL
+  }
+  const usingDedicatedTarget = Boolean(process.env.SUPABASE_KEEPALIVE_URL);
+  console.log(
+    `[Supabase Keep-Alive] Target host: ${targetHost} (source: ${
+      usingDedicatedTarget ? 'SUPABASE_KEEPALIVE_URL' : 'NEXT_PUBLIC_SUPABASE_URL'
+    })`
+  );
 
   try {
     // Lightweight SELECT against a core table. This forces PostgREST to
@@ -28,8 +53,8 @@ export default async function handler() {
       {
         method: 'GET',
         headers: {
-          'apikey': supabaseAnonKey,
-          'Authorization': `Bearer ${supabaseAnonKey}`,
+          'apikey': supabaseKey,
+          'Authorization': `Bearer ${supabaseKey}`,
           'Accept': 'application/json',
         },
       }
@@ -38,7 +63,7 @@ export default async function handler() {
     if (!response.ok) {
       const body = await response.text();
       console.error(
-        `[Supabase Keep-Alive] Query failed: ${response.status} ${body}`
+        `[Supabase Keep-Alive] Query failed for ${targetHost}: ${response.status} ${body}`
       );
       return new Response(
         JSON.stringify({ error: 'Keep-alive query failed', status: response.status }),
@@ -46,12 +71,17 @@ export default async function handler() {
       );
     }
 
-    console.log(`[Supabase Keep-Alive] DB query OK: ${response.status}`);
+    console.log(
+      `[Supabase Keep-Alive] DB query OK for ${targetHost}: ${response.status}`
+    );
 
-    return new Response(JSON.stringify({ success: true, status: response.status }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return new Response(
+      JSON.stringify({ success: true, status: response.status, host: targetHost }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
   } catch (error) {
     console.error('[Supabase Keep-Alive] Error:', error);
     return new Response(JSON.stringify({ error: 'Keep-alive ping failed' }), {


### PR DESCRIPTION
## Summary

Two related fixes stemming from the Supabase Prod project being paused for inactivity.

### 1. Keep-alive was pointed at the wrong project

The keep-alive cron piggybacked on `NEXT_PUBLIC_SUPABASE_URL` — the app's runtime pointer, which drifts to Sandbox during testing. It has no prod/sandbox logic, so whatever that var pointed at is what stayed warm. Prod didn't redirect the ping to Sandbox; **Prod paused *because* the ping was going to Sandbox all along.**

- `netlify/functions/supabase-keepalive-cron.ts` now prefers dedicated `SUPABASE_KEEPALIVE_URL` / `SUPABASE_KEEPALIVE_KEY`, decoupled from the app pointer, falling back to the `NEXT_PUBLIC_*` vars so deploys don't break before the new vars are set.
- Logs the target host + source so the kept-alive project is verifiable from Netlify logs.

### 2. Trial reminder emails were skipped during the pause

`trial-reminders` fired each email on **exact-day equality** (`daysLeft === 7/3/1/0/-3`) with no idempotency. Any milestone a trial crossed while Prod was paused was skipped permanently — the next run computed a different `daysLeft` and the branch never matched again. (Other crons use state-based queries and self-heal; this one didn't.)

- New per-milestone `*_sent_at` idempotency columns on `companies` (migration `20260518000000`).
- `trial-reminders` rewritten to use **"threshold crossed AND not yet sent"** windows: a missed day is caught on the next run and never double-sends. Stale earlier milestones are **suppressed** (marked sent, no email) so customers don't get a "7 days left" notice after the trial already ended.
- `scripts/recover-trial-emails.js` (+ `npm run recover:trial-emails`): audits which milestones were missed for a given pause window (read-only by default) and can `--trigger` the deployed route to flush catch-up emails immediately. No email-template duplication — sending always goes through the deployed route.

## Required follow-up (Netlify config — not in this PR)

Set `SUPABASE_KEEPALIVE_URL` / `SUPABASE_KEEPALIVE_KEY` to the **Production** project's URL + anon key. Until then it keeps using `NEXT_PUBLIC_SUPABASE_URL`, so if that points at Sandbox, Prod keeps pausing.

## Migration

`supabase/migrations/20260518000000_add_trial_email_idempotency.sql` adds 5 nullable `timestamptz` columns to `companies` (idempotent `ADD COLUMN IF NOT EXISTS`). Run against Prod before/with deploy.

## Recovery runbook (after deploy + migration)

```
npm run recover:trial-emails -- --pause-start=YYYY-MM-DD --pause-end=YYYY-MM-DD            # audit
npm run recover:trial-emails -- --pause-start=YYYY-MM-DD --pause-end=YYYY-MM-DD --trigger  # flush now
```

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 428/428 pass
- [x] `npm run lint` — no new warnings
- [x] `node --check scripts/recover-trial-emails.js`
- [ ] Apply migration to Prod
- [ ] Set Netlify keep-alive env vars; confirm next cron logs `[Supabase Keep-Alive] Target host:` = Prod
- [ ] Run recovery audit with the real pause dates, then `--trigger`

https://claude.ai/code/session_01A2pXjf9MttrfzwPY22VfR9