### PR TITLE
fix(trial-emails): resilient reminder windows + pause recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "cypress:run": "cypress run",
     "test:e2e": "cypress run",
     "sync:crisp": "node scripts/sync-to-crisp.js",
-    "sync:crisp:dry": "node scripts/sync-to-crisp.js --dry-run"
+    "sync:crisp:dry": "node scripts/sync-to-crisp.js --dry-run",
+    "recover:trial-emails": "node scripts/recover-trial-emails.js"
   },
   "dependencies": {
     "@prisma/client": "^5.15.0",

--- a/scripts/recover-trial-emails.js
+++ b/scripts/recover-trial-emails.js
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * ToolTime Pro — Trial Email Recovery (one-off)
+ *
+ * Why this exists:
+ *   The trial-reminders cron used to fire each email on an EXACT day match
+ *   (daysLeft === 7 / 3 / 1 / 0 / -3). While the Supabase Prod project was
+ *   paused for inactivity the cron never ran, so any trial that crossed a
+ *   threshold during the pause window had that email skipped permanently.
+ *
+ * What this does:
+ *   1. AUDIT (default, read-only): lists trial companies whose milestone
+ *      date fell inside the pause window AND whose idempotency column is
+ *      still null — i.e. the emails that were missed. The trial-expired
+ *      notice is the customer-impactful one and is flagged separately.
+ *   2. --trigger: calls the deployed /api/trial-reminders route once so the
+ *      now-resilient logic sends the currently-relevant catch-up email
+ *      immediately (winback reuses the trial-expired template) and marks
+ *      stale countdown reminders as suppressed — instead of waiting up to
+ *      24h for the next daily cron run.
+ *
+ * This script never duplicates the Resend email templates; sending always
+ * goes through the deployed route so there is one source of truth.
+ *
+ * Required env vars:
+ *   NEXT_PUBLIC_SUPABASE_URL (or SUPABASE_URL)  — the PROD project URL
+ *   SUPABASE_SERVICE_ROLE_KEY                   — PROD service role key
+ * For --trigger also:
+ *   SITE_URL     — deployed site base URL (e.g. https://tooltimepro.com)
+ *   CRON_SECRET  — same value configured in Netlify
+ *
+ * Usage:
+ *   node scripts/recover-trial-emails.js --pause-start=2026-05-01 --pause-end=2026-05-17
+ *   node scripts/recover-trial-emails.js --pause-start=2026-05-01 --pause-end=2026-05-17 --trigger
+ */
+
+const { createClient } = require('@supabase/supabase-js');
+
+function arg(name) {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=')[1] : undefined;
+}
+
+const TRIGGER = process.argv.includes('--trigger');
+const pauseStartStr = arg('pause-start');
+const pauseEndStr = arg('pause-end');
+
+if (!pauseStartStr || !pauseEndStr) {
+  console.error(
+    'ERROR: --pause-start=YYYY-MM-DD and --pause-end=YYYY-MM-DD are required.'
+  );
+  process.exit(1);
+}
+
+// Treat the window as inclusive whole days in UTC.
+const pauseStart = new Date(`${pauseStartStr}T00:00:00.000Z`);
+const pauseEnd = new Date(`${pauseEndStr}T23:59:59.999Z`);
+
+if (isNaN(pauseStart) || isNaN(pauseEnd) || pauseStart > pauseEnd) {
+  console.error('ERROR: invalid pause window.');
+  process.exit(1);
+}
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error(
+    'ERROR: NEXT_PUBLIC_SUPABASE_URL (or SUPABASE_URL) and SUPABASE_SERVICE_ROLE_KEY are required.'
+  );
+  process.exit(1);
+}
+
+const DAY = 24 * 60 * 60 * 1000;
+
+// Each milestone's calendar date relative to the trial dates, plus the
+// idempotency column that proves whether it was already sent.
+const MILESTONES = [
+  { key: 'welcome', column: 'welcome_email_sent_at', dateOf: (s) => new Date(s.start.getTime() + 1 * DAY) },
+  { key: 'reminder_7', column: 'trial_reminder_7_sent_at', dateOf: (s) => new Date(s.end.getTime() - 7 * DAY) },
+  { key: 'reminder_3', column: 'trial_reminder_3_sent_at', dateOf: (s) => new Date(s.end.getTime() - 3 * DAY) },
+  { key: 'reminder_1', column: 'trial_reminder_1_sent_at', dateOf: (s) => new Date(s.end.getTime() - 1 * DAY) },
+  { key: 'expired', column: 'trial_expired_sent_at', dateOf: (s) => s.end },
+  { key: 'winback', column: 'trial_winback_sent_at', dateOf: (s) => new Date(s.end.getTime() + 3 * DAY) },
+];
+
+const inWindow = (d) => d >= pauseStart && d <= pauseEnd;
+
+async function main() {
+  const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
+
+  let host = SUPABASE_URL;
+  try {
+    host = new URL(SUPABASE_URL).host;
+  } catch {
+    /* keep raw */
+  }
+  console.log(`Supabase target host: ${host}`);
+  console.log(
+    `Pause window (UTC, inclusive): ${pauseStart.toISOString()} → ${pauseEnd.toISOString()}\n`
+  );
+
+  const { data: companies, error } = await supabase
+    .from('companies')
+    .select(
+      'id, name, email, trial_starts_at, trial_ends_at, welcome_email_sent_at, is_beta_tester, ' +
+        'trial_reminder_7_sent_at, trial_reminder_3_sent_at, trial_reminder_1_sent_at, ' +
+        'trial_expired_sent_at, trial_winback_sent_at'
+    )
+    .is('stripe_customer_id', null)
+    .not('trial_ends_at', 'is', null)
+    .or('is_beta_tester.is.null,is_beta_tester.eq.false');
+
+  if (error) {
+    console.error('Query failed:', error.message);
+    process.exit(1);
+  }
+
+  const missed = [];
+  for (const c of companies || []) {
+    if (!c.trial_starts_at || !c.trial_ends_at) continue;
+    const s = { start: new Date(c.trial_starts_at), end: new Date(c.trial_ends_at) };
+    for (const m of MILESTONES) {
+      const d = m.dateOf(s);
+      if (inWindow(d) && !c[m.column]) {
+        missed.push({
+          company: c.name || c.id,
+          email: c.email,
+          milestone: m.key,
+          dueDate: d.toISOString().slice(0, 10),
+          impactful: m.key === 'expired',
+        });
+      }
+    }
+  }
+
+  if (missed.length === 0) {
+    console.log('No missed trial emails found in the pause window. Nothing to recover.');
+    return;
+  }
+
+  missed.sort((a, b) => a.dueDate.localeCompare(b.dueDate));
+  console.log(`Missed milestones during the pause window (${missed.length}):\n`);
+  for (const m of missed) {
+    const flag = m.impactful ? '  ⟵ EXPIRY NOTICE (customer-impactful)' : '';
+    console.log(
+      `  ${m.dueDate}  ${m.milestone.padEnd(11)}  ${m.company} <${m.email}>${flag}`
+    );
+  }
+
+  const expiredCount = missed.filter((m) => m.impactful).length;
+  console.log(
+    `\nSummary: ${missed.length} missed total, ${expiredCount} missed EXPIRY notices.`
+  );
+
+  if (!TRIGGER) {
+    console.log(
+      '\nDry run (audit only). Re-run with --trigger to flush catch-up emails now\n' +
+        'via the deployed /api/trial-reminders route (requires SITE_URL + CRON_SECRET).'
+    );
+    return;
+  }
+
+  const siteUrl = process.env.SITE_URL;
+  const cronSecret = process.env.CRON_SECRET;
+  if (!siteUrl || !cronSecret) {
+    console.error('\nERROR: --trigger requires SITE_URL and CRON_SECRET env vars.');
+    process.exit(1);
+  }
+
+  console.log(`\nTriggering ${siteUrl}/api/trial-reminders ...`);
+  const res = await fetch(`${siteUrl}/api/trial-reminders`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${cronSecret}` },
+  });
+  const body = await res.json().catch(() => ({}));
+  console.log(`HTTP ${res.status}`);
+  console.log(JSON.stringify(body, null, 2));
+  if (!res.ok) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error('Recovery failed:', e);
+  process.exit(1);
+});

--- a/src/app/api/trial-reminders/route.ts
+++ b/src/app/api/trial-reminders/route.ts
@@ -16,7 +16,36 @@ function getSupabaseAdmin() {
   return createClient(supabaseUrl, supabaseServiceKey);
 }
 
-// This endpoint should be called by a cron job (e.g., Vercel Cron, Supabase Edge Function)
+// Trial lifecycle milestones, ordered from earliest (most days left) to
+// latest (post-expiry). Each has a resilient window and a dedicated
+// idempotency column so a milestone fires once and only once — even if
+// the cron skipped the exact threshold day (e.g. Supabase Prod paused).
+//
+// A long gap can skip several windows at once. We only send the email
+// for the milestone matching the CURRENT state and SUPPRESS (mark sent,
+// no email) any earlier unsent milestones — a stale "7 days left" notice
+// when the trial already expired would confuse customers.
+type MilestoneKey =
+  | 'reminder_7'
+  | 'reminder_3'
+  | 'reminder_1'
+  | 'expired'
+  | 'winback';
+
+const MILESTONES: {
+  key: MilestoneKey;
+  column: string;
+  // Whether `daysLeft` falls in this milestone's current window.
+  inWindow: (daysLeft: number) => boolean;
+}[] = [
+  { key: 'reminder_7', column: 'trial_reminder_7_sent_at', inWindow: (d) => d >= 4 && d <= 7 },
+  { key: 'reminder_3', column: 'trial_reminder_3_sent_at', inWindow: (d) => d >= 2 && d <= 3 },
+  { key: 'reminder_1', column: 'trial_reminder_1_sent_at', inWindow: (d) => d === 1 },
+  { key: 'expired', column: 'trial_expired_sent_at', inWindow: (d) => d <= 0 && d >= -2 },
+  { key: 'winback', column: 'trial_winback_sent_at', inWindow: (d) => d <= -3 },
+];
+
+// This endpoint should be called by a cron job (e.g., Netlify Scheduled Function)
 // Schedule: once per day
 // Security: protected by CRON_SECRET header
 export async function GET(request: Request) {
@@ -32,6 +61,7 @@ export async function GET(request: Request) {
     welcome: [] as string[],
     reminders: [] as string[],
     expired: [] as string[],
+    suppressed: [] as string[],
     errors: [] as string[],
   };
 
@@ -42,7 +72,7 @@ export async function GET(request: Request) {
     // Skip beta testers - they don't get trial reminder emails
     const { data: companies, error } = await supabaseAdmin
       .from('companies')
-      .select('id, name, email, trial_starts_at, trial_ends_at, welcome_email_sent_at, is_beta_tester')
+      .select('id, name, email, trial_starts_at, trial_ends_at, welcome_email_sent_at, is_beta_tester, trial_reminder_7_sent_at, trial_reminder_3_sent_at, trial_reminder_1_sent_at, trial_expired_sent_at, trial_winback_sent_at')
       .is('stripe_customer_id', null)
       .not('trial_ends_at', 'is', null)
       .or('is_beta_tester.is.null,is_beta_tester.eq.false');
@@ -61,7 +91,9 @@ export async function GET(request: Request) {
       const trialEnd = new Date(company.trial_ends_at);
       const trialStart = new Date(company.trial_starts_at);
       const daysLeft = Math.ceil((trialEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
-      const daysSinceStart = Math.ceil((now.getTime() - trialStart.getTime()) / (1000 * 60 * 60 * 24));
+      const daysSinceStart = Math.ceil(
+        (now.getTime() - trialStart.getTime()) / (1000 * 60 * 60 * 24)
+      );
 
       // Get company owner for sending emails
       const { data: owner } = await supabaseAdmin
@@ -76,37 +108,68 @@ export async function GET(request: Request) {
       const emailTo = owner.email;
       const name = owner.full_name?.split(' ')[0] || 'there';
 
+      // Accumulate column updates so each company is written once.
+      const updates: Record<string, string> = {};
+      const nowIso = now.toISOString();
+
       try {
-        // Day 1: Welcome email (sent once, 1 day after signup)
-        // Skip if the user already received the immediate welcome email at password-set time
-        if (daysSinceStart === 1 && !company.welcome_email_sent_at) {
+        // Welcome email — independent of the countdown milestones.
+        // Resilient: ">= 1 day since start" + idempotency guard, so a
+        // missed day-1 run still sends it on the next run (once).
+        if (daysSinceStart >= 1 && !company.welcome_email_sent_at) {
           await sendTrialWelcomeEmail({ to: emailTo, name });
+          updates.welcome_email_sent_at = nowIso;
           results.welcome.push(emailTo);
         }
-        // Day 7: Mid-trial reminder
-        else if (daysLeft === 7) {
-          await sendTrialReminderEmail({ to: emailTo, name, daysLeft: 7 });
-          results.reminders.push(emailTo);
+
+        // Find the milestone matching the CURRENT trial state.
+        const currentIdx = MILESTONES.findIndex((m) => m.inWindow(daysLeft));
+
+        if (currentIdx !== -1) {
+          // Suppress any earlier, now-stale milestones that were never
+          // sent (e.g. skipped during a pause) — mark them sent without
+          // emailing so they never fire late.
+          for (let i = 0; i < currentIdx; i++) {
+            const m = MILESTONES[i];
+            const sentAt = (company as Record<string, unknown>)[m.column];
+            if (!sentAt) {
+              updates[m.column] = nowIso;
+              results.suppressed.push(`${emailTo}:${m.key}`);
+            }
+          }
+
+          // Send the current milestone's email if it hasn't been sent.
+          const current = MILESTONES[currentIdx];
+          const currentSentAt = (company as Record<string, unknown>)[current.column];
+          if (!currentSentAt) {
+            switch (current.key) {
+              case 'reminder_7':
+                await sendTrialReminderEmail({ to: emailTo, name, daysLeft: 7 });
+                results.reminders.push(emailTo);
+                break;
+              case 'reminder_3':
+                await sendTrialReminderEmail({ to: emailTo, name, daysLeft: 3 });
+                results.reminders.push(emailTo);
+                break;
+              case 'reminder_1':
+                await sendTrialReminderEmail({ to: emailTo, name, daysLeft: 1 });
+                results.reminders.push(emailTo);
+                break;
+              case 'expired':
+                await sendTrialExpiredEmail({ to: emailTo, name });
+                results.expired.push(emailTo);
+                break;
+              case 'winback':
+                await sendTrialExpiredEmail({ to: emailTo, name });
+                results.expired.push(emailTo);
+                break;
+            }
+            updates[current.column] = nowIso;
+          }
         }
-        // Day 11 (3 days left): Urgent reminder
-        else if (daysLeft === 3) {
-          await sendTrialReminderEmail({ to: emailTo, name, daysLeft: 3 });
-          results.reminders.push(emailTo);
-        }
-        // Day 13 (1 day left): Final warning
-        else if (daysLeft === 1) {
-          await sendTrialReminderEmail({ to: emailTo, name, daysLeft: 1 });
-          results.reminders.push(emailTo);
-        }
-        // Day 14: Trial expired
-        else if (daysLeft === 0) {
-          await sendTrialExpiredEmail({ to: emailTo, name });
-          results.expired.push(emailTo);
-        }
-        // Day 17: "We miss you" follow-up (3 days after expiry)
-        else if (daysLeft === -3) {
-          await sendTrialExpiredEmail({ to: emailTo, name });
-          results.expired.push(emailTo);
+
+        if (Object.keys(updates).length > 0) {
+          await supabaseAdmin.from('companies').update(updates).eq('id', company.id);
         }
       } catch (emailError) {
         const msg = emailError instanceof Error ? emailError.message : 'Unknown error';

--- a/supabase/migrations/20260518000000_add_trial_email_idempotency.sql
+++ b/supabase/migrations/20260518000000_add_trial_email_idempotency.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- Migration: Trial Email Idempotency Columns
+-- Date: 2026-05-18
+--
+-- The trial-reminders cron previously fired each email on an EXACT
+-- day match (daysLeft === 7 / 3 / 1 / 0 / -3). If the cron did not
+-- run on that exact day (e.g. the Supabase Prod project was paused
+-- for inactivity), the email was skipped permanently — the next run
+-- computed a different daysLeft and the branch never matched again.
+--
+-- These columns let the cron use resilient "threshold crossed AND
+-- not yet sent" windows instead of exact-day equality, so a missed
+-- day is caught on the next run and never double-sends.
+--
+-- companies.welcome_email_sent_at already exists and is unchanged.
+-- ============================================================
+
+ALTER TABLE companies
+  ADD COLUMN IF NOT EXISTS trial_reminder_7_sent_at  timestamptz,
+  ADD COLUMN IF NOT EXISTS trial_reminder_3_sent_at  timestamptz,
+  ADD COLUMN IF NOT EXISTS trial_reminder_1_sent_at  timestamptz,
+  ADD COLUMN IF NOT EXISTS trial_expired_sent_at     timestamptz,
+  ADD COLUMN IF NOT EXISTS trial_winback_sent_at     timestamptz;
+
+COMMENT ON COLUMN companies.trial_reminder_7_sent_at IS 'When the 7-days-left trial reminder email was sent (idempotency guard).';
+COMMENT ON COLUMN companies.trial_reminder_3_sent_at IS 'When the 3-days-left trial reminder email was sent (idempotency guard).';
+COMMENT ON COLUMN companies.trial_reminder_1_sent_at IS 'When the 1-day-left trial reminder email was sent (idempotency guard).';
+COMMENT ON COLUMN companies.trial_expired_sent_at    IS 'When the trial-expired email was sent (idempotency guard).';
+COMMENT ON COLUMN companies.trial_winback_sent_at    IS 'When the post-expiry "we miss you" email was sent (idempotency guard).';


### PR DESCRIPTION
## Why a second PR

PR #554 was merged with **only the keep-alive fix** (commit `ebfd1ba`), before the trial-email work was pushed. The keep-alive change is already in `main`. This PR carries the remaining, separately-reviewed work.

## Summary

`trial-reminders` fired each email on **exact-day equality** (`daysLeft === 7/3/1/0/-3`) with no idempotency. Any milestone a trial crossed while Supabase Prod was paused was skipped permanently — the next run computed a different `daysLeft` and the branch never matched again.

- New per-milestone `*_sent_at` idempotency columns on `companies` — migration `supabase/migrations/20260518000000_add_trial_email_idempotency.sql` (idempotent `ADD COLUMN IF NOT EXISTS`).
- `src/app/api/trial-reminders/route.ts` rewritten to use **"threshold crossed AND not yet sent"** windows: a missed day is caught on the next run and never double-sends. Stale earlier milestones are **suppressed** (marked sent, no email) so customers don't get a "7 days left" notice after the trial already ended.
- `scripts/recover-trial-emails.js` (+ `npm run recover:trial-emails`): audits which milestones were missed for a given pause window (read-only by default) and can `--trigger` the deployed route to flush catch-up emails immediately. No email-template duplication — sending always goes through the deployed route.

## Migration

Run `20260518000000_add_trial_email_idempotency.sql` against Prod before/with deploy. Adds 5 nullable `timestamptz` columns to `companies`.

## Recovery runbook (pause was 2026-05-18, single day)

```
npm run recover:trial-emails -- --pause-start=2026-05-18 --pause-end=2026-05-18            # audit (read-only)
npm run recover:trial-emails -- --pause-start=2026-05-18 --pause-end=2026-05-18 --trigger  # flush now
```
Impact is bounded to the one missed daily cron run; the resilient logic also self-heals on the next 9am UTC run.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 428/428 pass
- [x] `npm run lint` — no new warnings
- [x] `node --check scripts/recover-trial-emails.js`
- [ ] Apply migration to Prod
- [ ] Run recovery audit with `--pause-start=2026-05-18 --pause-end=2026-05-18`, then `--trigger`

https://claude.ai/code/session_01A2pXjf9MttrfzwPY22VfR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2pXjf9MttrfzwPY22VfR9)_