### PR TITLE
fix(crisp-sync): trim credentials — root cause of 401 was newline in WEBSITE_ID

### DIFF
--- a/scripts/sync-to-crisp.js
+++ b/scripts/sync-to-crisp.js
@@ -266,9 +266,11 @@ function getTitleFromMd(content) {
 }
 
 async function main() {
-  const identifier = process.env.CRISP_API_IDENTIFIER;
-  const key = process.env.CRISP_API_KEY;
-  const websiteId = process.env.CRISP_WEBSITE_ID;
+  // Trim defensively — a trailing newline pasted into a CI secret
+  // silently malforms the request URL and yields 401 invalid_session.
+  const identifier = (process.env.CRISP_API_IDENTIFIER || '').trim();
+  const key = (process.env.CRISP_API_KEY || '').trim();
+  const websiteId = (process.env.CRISP_WEBSITE_ID || '').trim();
 
   if (!DRY_RUN && (!identifier || !key || !websiteId)) {
     console.error('Missing required env vars: CRISP_API_IDENTIFIER, CRISP_API_KEY, CRISP_WEBSITE_ID');


### PR DESCRIPTION
## Root cause found

The diagnostic from #556 gave us hard data:

```
IDENTIFIER length: 36   ✓
KEY        length: 64   ✓
WEBSITE_ID len   : 37   ✗  (should be 36)
```

`CRISP_WEBSITE_ID` has a stray trailing character (a newline pasted into the GitHub secret). `6baf2f53-e868-4a02-a9c7-eef3e5549db6` is exactly 36 chars. That extra byte got injected into the request URL path, malforming it — which is the persistent `401 invalid_session` we chased through tier `user`/`plugin` and a token recreate. (curl in the diagnostic even bailed with exit 3 = malformed URL.)

## Fix

- `scripts/sync-to-crisp.js`: `.trim()` all three credential env vars so a pasted newline/space can never silently break auth again.

## Also required (not code)

The `CRISP_WEBSITE_ID` secret should be re-entered cleanly (typed, not pasted) as exactly `6baf2f53-e868-4a02-a9c7-eef3e5549db6`. The trim makes the script resilient even if it isn't, but fixing the secret is the clean fix.

## Test plan

- [ ] Merge
- [ ] (Recommended) re-enter `CRISP_WEBSITE_ID` secret without trailing newline
- [ ] Actions → **Sync Crisp Helpdesk** → Run workflow → main
- [ ] Diagnostic step should show `WEBSITE_ID len : 36` and the test auth call should return HTTP 200
- [ ] `Sync wiki to Crisp` completes; dashboard widget Articles tab populated
- [ ] Follow-up: remove the temporary diagnostic step once confirmed green

---
_Generated by [Claude Code](https://claude.ai/code/session_012Xf1r3kmd3GAHmAh1GB3uQ)_