### PR TITLE
fix(webhook): auto-provision account when customer pays before signing up

### DIFF
--- a/src/__tests__/api/webhook-stripe.test.js
+++ b/src/__tests__/api/webhook-stripe.test.js
@@ -12,6 +12,7 @@ const mockSupabaseFrom = jest.fn();
 const mockSendWelcomeEmail = jest.fn().mockResolvedValue(undefined);
 const mockCustomersRetrieve = jest.fn().mockResolvedValue({ id: 'cus_test', metadata: {}, deleted: false });
 const mockCustomersUpdate = jest.fn().mockResolvedValue({ id: 'cus_test' });
+const mockAutoCreate = jest.fn().mockResolvedValue({ companyId: null, error: 'mocked' });
 
 jest.mock('stripe', () => {
   return jest.fn(() => ({
@@ -33,6 +34,10 @@ jest.mock('@supabase/supabase-js', () => ({
 
 jest.mock('@/lib/email', () => ({
   sendWelcomeEmail: mockSendWelcomeEmail,
+}));
+
+jest.mock('@/lib/auto-provision', () => ({
+  autoCreateCompanyForCheckout: mockAutoCreate,
 }));
 
 process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
@@ -259,6 +264,54 @@ describe('/api/webhook/stripe', () => {
     expect(response.status).toBe(200);
     expect(mockSupabaseFrom).toHaveBeenCalledWith('companies');
     expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it('auto-provisions a company when no user matches and skips the duplicate welcome email', async () => {
+    // Regression test: customers who pay via Stripe Checkout without first
+    // signing up would previously get a 200 OK from the webhook with no
+    // company row created (a "ghost subscription"). The webhook should now
+    // call autoCreateCompanyForCheckout, which creates the account and sends
+    // a magic-link login email — replacing the regular welcome email.
+    mockConstructEvent.mockReturnValue({
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_live_autoprov',
+          customer_email: 'fresh@example.com',
+          customer_details: { email: 'fresh@example.com', name: 'Fresh Buyer' },
+          customer: 'cus_autoprov',
+          metadata: { plan: 'pro', tier: 'pro', billing: 'monthly', skipTrial: 'true' },
+        },
+      },
+    });
+
+    // All five lookup paths return null so the auto-provision branch runs.
+    mockSingle.mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+    mockAutoCreate.mockResolvedValueOnce({
+      companyId: 'company-auto-created',
+      error: null,
+    });
+
+    const request = makeWebhookRequest();
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(mockAutoCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'fresh@example.com',
+        fullName: 'Fresh Buyer',
+        plan: 'pro',
+        stripeCustomerId: 'cus_autoprov',
+        skipTrial: true,
+      })
+    );
+    // Welcome email is suppressed because auto-provision already sent the
+    // magic-link login email.
+    expect(mockSendWelcomeEmail).not.toHaveBeenCalled();
+    // The new company id is written back to the Stripe customer.
+    expect(mockCustomersUpdate).toHaveBeenCalledWith('cus_autoprov', {
+      metadata: { companyId: 'company-auto-created' },
+    });
   });
 
   it('sends welcome email on checkout completion', async () => {

--- a/src/app/api/webhook/stripe/route.js
+++ b/src/app/api/webhook/stripe/route.js
@@ -2,6 +2,7 @@ import Stripe from 'stripe';
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { sendWelcomeEmail } from '@/lib/email';
+import { autoCreateCompanyForCheckout } from '@/lib/auto-provision';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -179,7 +180,52 @@ async function handleCheckoutComplete(session) {
     }
   }
 
-  if (resolvedCompanyId) {
+  // No matching company → first-time customer paid before signing up.
+  // Provision an account from the checkout email and skip the regular
+  // welcome email (autoCreate sends a magic-link login email instead).
+  let autoProvisioned = false;
+  if (!resolvedCompanyId && customerEmail) {
+    const baseUrl =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      (session.success_url ? new URL(session.success_url).origin : null) ||
+      'https://tooltimepro.com';
+    const skipTrial = metadata.skipTrial === 'true';
+    try {
+      const result = await autoCreateCompanyForCheckout({
+        email: customerEmail,
+        fullName: session.customer_details?.name || '',
+        plan: plan || 'starter',
+        addons,
+        stripeCustomerId: customerId,
+        skipTrial,
+        baseUrl,
+      });
+      if (result.companyId) {
+        resolvedCompanyId = result.companyId;
+        resolutionSource = 'auto_created';
+        autoProvisioned = true;
+        console.info('Company auto-provisioned after checkout', {
+          sessionId: session.id,
+          companyId: resolvedCompanyId,
+          email: customerEmail,
+        });
+      } else if (result.error) {
+        console.error('Auto-provision failed for checkout session', {
+          sessionId: session.id,
+          email: customerEmail,
+          error: result.error,
+        });
+      }
+    } catch (err) {
+      console.error('Auto-provision threw for checkout session', {
+        sessionId: session.id,
+        email: customerEmail,
+        error: err.message,
+      });
+    }
+  }
+
+  if (resolvedCompanyId && !autoProvisioned) {
     // Treat checkout.session.completed as the moment the company becomes a
     // paying subscriber — even when the session started a Stripe-side trial,
     // payment-method-on-file means we no longer need to gate on trial_ends_at.
@@ -222,20 +268,7 @@ async function handleCheckoutComplete(session) {
         stripeCustomerId: customerId,
       });
     }
-
-    // Persist company id back to the Stripe Customer so any future event on
-    // this customer can be resolved to the same company even if our local DB
-    // pointers go stale.
-    if (customerId) {
-      try {
-        await getStripe().customers.update(customerId, {
-          metadata: { companyId: resolvedCompanyId },
-        });
-      } catch (err) {
-        console.error('Failed to write companyId back to Stripe customer:', err.message);
-      }
-    }
-  } else {
+  } else if (!resolvedCompanyId) {
     console.error('No company found for checkout session — DB not updated', {
       sessionId: session.id,
       stripeCustomerId: customerId,
@@ -245,6 +278,19 @@ async function handleCheckoutComplete(session) {
       customerEmail,
       lookupEmailUsed: lookupEmail || null,
     });
+  }
+
+  // Persist company id back to the Stripe Customer so any future event on
+  // this customer can be resolved to the same company even if local DB
+  // pointers go stale. Runs for both lookup-resolved and auto-provisioned.
+  if (resolvedCompanyId && customerId) {
+    try {
+      await getStripe().customers.update(customerId, {
+        metadata: { companyId: resolvedCompanyId },
+      });
+    } catch (err) {
+      console.error('Failed to write companyId back to Stripe customer:', err.message);
+    }
   }
 
   const onboarding = metadata.onboarding;
@@ -265,7 +311,8 @@ async function handleCheckoutComplete(session) {
     }
   }
 
-  if (customerEmail) {
+  // Auto-provisioned customers got a magic-link login email — don't double up.
+  if (customerEmail && !autoProvisioned) {
     try {
       await sendWelcomeEmail({
         to: customerEmail,

--- a/src/lib/auto-provision.js
+++ b/src/lib/auto-provision.js
@@ -1,0 +1,164 @@
+import { createClient } from '@supabase/supabase-js';
+import crypto from 'crypto';
+import { sendCheckoutWelcomeWithLoginLink } from '@/lib/email';
+
+let supabaseAdmin = null;
+
+function getSupabaseAdmin() {
+  if (!supabaseAdmin) {
+    supabaseAdmin = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY
+    );
+  }
+  return supabaseAdmin;
+}
+
+// Provisions a brand-new company for a customer who paid via Stripe Checkout
+// before signing up. Mirrors the regular /api/signup flow (auth user +
+// handle_new_signup RPC + magic-link email), but without requiring a company
+// name from the customer — they'll set that during onboarding.
+//
+// Returns { companyId, error }. companyId is null on failure.
+export async function autoCreateCompanyForCheckout({
+  email,
+  fullName,
+  plan,
+  addons = [],
+  stripeCustomerId,
+  skipTrial = false,
+  baseUrl,
+}) {
+  if (!email) {
+    return { companyId: null, error: 'email is required' };
+  }
+
+  const admin = getSupabaseAdmin();
+  const normalizedEmail = email.trim().toLowerCase();
+  const derivedName = (fullName && fullName.trim()) || normalizedEmail.split('@')[0];
+  // Placeholder — customer renames during onboarding. The trailing
+  // "(pending setup)" makes orphans easy to spot in admin views.
+  const companyName = `${derivedName} (pending setup)`;
+
+  // Reuse an existing auth user if present (e.g. they signed up but the
+  // signup trigger never finished). Otherwise create one.
+  let authUserId;
+  let createdAuthUser = false;
+  try {
+    const { data: listData } = await admin.auth.admin.listUsers();
+    const existing = listData?.users?.find(
+      (u) => u.email?.toLowerCase() === normalizedEmail
+    );
+
+    if (existing) {
+      authUserId = existing.id;
+    } else {
+      const tempPassword = crypto.randomUUID() + 'Aa1!';
+      const { data: createData, error: createError } =
+        await admin.auth.admin.createUser({
+          email: normalizedEmail,
+          password: tempPassword,
+          email_confirm: true,
+          user_metadata: { full_name: derivedName, needs_password: true },
+          app_metadata: { needs_password: true },
+        });
+      if (createError || !createData?.user) {
+        return {
+          companyId: null,
+          error: createError?.message || 'failed to create auth user',
+        };
+      }
+      authUserId = createData.user.id;
+      createdAuthUser = true;
+    }
+  } catch (err) {
+    return { companyId: null, error: `auth user lookup/create failed: ${err.message}` };
+  }
+
+  // Create company + users-row via the same RPC the signup endpoint uses.
+  // If the rows already exist (rare race), we'll find the company below
+  // and skip the create error.
+  const { error: rpcError } = await admin.rpc('handle_new_signup', {
+    p_user_id: authUserId,
+    p_email: normalizedEmail,
+    p_full_name: derivedName,
+    p_company_name: companyName,
+  });
+
+  if (rpcError) {
+    const duplicate = /duplicate|already exists|unique/i.test(rpcError.message || '');
+    if (!duplicate) {
+      if (createdAuthUser) {
+        await admin.auth.admin.deleteUser(authUserId).catch(() => {});
+      }
+      return { companyId: null, error: `handle_new_signup failed: ${rpcError.message}` };
+    }
+  }
+
+  // Look up the company we just created (or found).
+  const { data: company, error: lookupError } = await admin
+    .from('companies')
+    .select('id')
+    .ilike('email', normalizedEmail)
+    .single();
+
+  if (lookupError || !company?.id) {
+    return {
+      companyId: null,
+      error: lookupError?.message || 'company not found after signup',
+    };
+  }
+
+  const updateData = {
+    stripe_customer_id: stripeCustomerId,
+    plan: plan || 'starter',
+    subscription_status: skipTrial ? 'active' : 'trialing',
+    updated_at: new Date().toISOString(),
+  };
+  if (addons.length > 0) {
+    updateData.addons = addons;
+  }
+
+  const { error: updateError } = await admin
+    .from('companies')
+    .update(updateData)
+    .eq('id', company.id);
+
+  if (updateError) {
+    return { companyId: company.id, error: `company update failed: ${updateError.message}` };
+  }
+
+  // Issue a magic link the customer can click from the welcome email to log
+  // in without needing to set a password first. generateLink can clear
+  // user_metadata, so we re-affirm needs_password after.
+  let loginUrl = `${baseUrl}/auth/login`;
+  try {
+    const { data: linkData, error: linkError } = await admin.auth.admin.generateLink({
+      type: 'magiclink',
+      email: normalizedEmail,
+      options: { redirectTo: `${baseUrl}/auth/callback` },
+    });
+    if (!linkError && linkData?.properties?.hashed_token) {
+      loginUrl = `${baseUrl}/auth/callback?token_hash=${linkData.properties.hashed_token}&type=magiclink`;
+    }
+    await admin.auth.admin.updateUserById(authUserId, {
+      user_metadata: { full_name: derivedName, needs_password: true },
+      app_metadata: { needs_password: true },
+    });
+  } catch (err) {
+    console.error('Magic-link generation failed, falling back to login URL:', err.message);
+  }
+
+  try {
+    await sendCheckoutWelcomeWithLoginLink({
+      to: normalizedEmail,
+      name: derivedName,
+      plan: plan || 'starter',
+      loginUrl,
+    });
+  } catch (err) {
+    return { companyId: company.id, error: `welcome email failed: ${err.message}` };
+  }
+
+  return { companyId: company.id, error: null };
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -292,6 +292,57 @@ export async function sendImmediateWelcomeEmail({
 // Subscription Welcome Email (after Stripe payment)
 // ============================================
 
+// ============================================
+// Subscription Welcome Email (after Stripe payment)
+// ============================================
+
+export async function sendCheckoutWelcomeWithLoginLink({
+  to,
+  name,
+  plan,
+  loginUrl,
+}: {
+  to: string;
+  name: string;
+  plan: string;
+  loginUrl: string;
+}) {
+  const planName = formatPlanName(plan);
+  const firstName = name?.split(' ')[0] || 'there';
+
+  const { data, error } = await getResend().emails.send({
+    from: FROM_EMAIL,
+    to,
+    subject: 'Your ToolTime Pro account is ready — log in',
+    html: emailLayout(`
+      <h2 style="color: #111827; margin: 0 0 16px 0; font-size: 22px;">Welcome, ${firstName}!</h2>
+
+      <p style="color: #4b5563; font-size: 16px; line-height: 1.6;">
+        Thanks for subscribing to <strong>${planName}</strong>. We've created your account &mdash;
+        click the button below to log in. No password needed for this first login.
+      </p>
+
+      ${ctaButton('Log in to ToolTime Pro', loginUrl)}
+
+      <p style="color: #6b7280; font-size: 14px; line-height: 1.6; margin-top: 24px;">
+        Once you're in, you'll set up your password, finish your company profile, and
+        invite your team. The whole onboarding takes about 5 minutes.
+      </p>
+
+      <p style="color: #9ca3af; font-size: 13px; margin-top: 32px; padding-top: 16px; border-top: 1px solid #e5e7eb;">
+        For your security, this login link expires in 1 hour. If it's expired by the time
+        you click it, just go to ${BASE_URL}/auth/login and request a new one.
+      </p>
+    `),
+  });
+
+  if (error) {
+    throw new Error(`Failed to send email: ${error.message}`);
+  }
+
+  return data;
+}
+
 export async function sendWelcomeEmail({
   to,
   plan,


### PR DESCRIPTION
## Summary

Fixes the "ghost subscription" bug: a customer who hits Subscribe Now without first signing up gets charged at Stripe, the webhook fires, but no account is created on the ToolTime side. They get the welcome email but can't log in — support has to manually create the account.

Now: when the webhook can't resolve a company from any of the five existing lookup paths (`client_reference_id`, `metadata.companyId`, `users.email`, `companies.email`, Stripe customer metadata), it calls `autoCreateCompanyForCheckout` which:

1. Creates a Supabase auth user (with `email_confirm: true` since they paid) — or reuses an existing one
2. Runs the same `handle_new_signup` RPC the regular signup flow uses to create `users` + `companies` rows (placeholder company name `<derived> (pending setup)` — they rename it in onboarding)
3. Updates the new company with `plan` / `subscription_status` / `stripe_customer_id` / `addons` from checkout metadata
4. Generates a magic-link login token via Supabase Auth admin
5. Sends a "Your account is ready — log in" email with the magic link, **replacing** the regular welcome email (no double email)

Customer flow becomes: enter email + card → pay → click email link → land logged in on dashboard. No password setup, no signup form, no friction.

The companyId write-back to the Stripe Customer now runs for both lookup-resolved and auto-provisioned paths, so future events on the same customer resolve cleanly via `stripe_customer.metadata`.

## Files

- **`src/lib/auto-provision.js`** — new helper module
- **`src/lib/email.ts`** — new `sendCheckoutWelcomeWithLoginLink` function
- **`src/app/api/webhook/stripe/route.js`** — call auto-provision in `handleCheckoutComplete` when no company resolves; skip regular welcome email when auto-provisioned
- **`src/__tests__/api/webhook-stripe.test.js`** — mock for auto-provision + new regression test for the auto-create path

## Test plan

- [x] `npm test` — 424/424 passing (added 1 new test)
- [x] `npm run build` — compiles
- [ ] After deploy, test on prod with a brand new email (no existing account):
  - [ ] Complete Stripe Checkout
  - [ ] Verify Supabase `companies` and `users` tables now have rows for that email
  - [ ] Verify the welcome email contains a "Log in" button with `/auth/callback?token_hash=…`
  - [ ] Click the link → land logged in on dashboard

## Notes

- Existing customers (whose lookups resolve) are unaffected — the lookup path runs first and only falls through to auto-provision when nothing matches.
- Manual cleanup needed for `missmv@gmail.com`: that subscription was created before this fix, so the account still doesn't exist. Easiest: sign up via `/auth/signup` and link via SQL, or refund + re-purchase to trigger the new flow.


---
_Generated by [Claude Code](https://claude.ai/code/session_014R4qreyksf4WUe8MwmsFF5)_