### PR TITLE
feat(help): hide Crisp bubble — Ask Jenny is the only visible launcher

### DIFF
--- a/src/components/help/CrispChat.tsx
+++ b/src/components/help/CrispChat.tsx
@@ -48,6 +48,14 @@ export default function CrispChat() {
     // Brand colors: ToolTime Pro gold
     window.$crisp.push(['config', 'color:theme', ['#f5a623']]);
 
+    // Hide the floating bubble — Ask Jenny is the visible help launcher.
+    // Crisp is summoned on demand via the drawer's "Talk to a human" button,
+    // and re-hides itself when the user closes the chat.
+    window.$crisp.push(['do', 'chat:hide']);
+    window.$crisp.push(['on', 'chat:closed', () => {
+      window.$crisp.push(['do', 'chat:hide']);
+    }]);
+
     return () => {
       // Cleanup on unmount (e.g., logout)
       const existingScript = document.getElementById('crisp-widget-script');


### PR DESCRIPTION
Follow-up to #560. With Ask Jenny shipped as a floating launcher (bottom-left), Crisp's bubble (bottom-right) competed for attention — two help affordances in the same screen made the right one ambiguous.

## Change

In `CrispChat.tsx`, after Crisp loads:
- `chat:hide` — hides the floating bubble by default
- `chat:closed` handler — re-hides whenever the user closes the chat panel

The drawer's "Talk to a human" button already calls `chat:show` + `chat:open`, so escalation still works — Crisp now appears on demand instead of sitting there competing with Ask Jenny.

Net UX:
- Default: one help button visible — **Ask Jenny**.
- Click "Talk to a human" → Crisp chat opens.
- Close Crisp → bubble disappears again. Back to one launcher.

## Test plan

- [ ] Merge
- [ ] Dashboard: only the Ask Jenny launcher should be visible (no orange Crisp bubble in the bottom-right)
- [ ] Open Ask Jenny → "Talk to a human" → Crisp chat opens
- [ ] Close Crisp chat → bubble disappears
- [ ] Reload page → still no Crisp bubble until summoned

---
_Generated by [Claude Code](https://claude.ai/code/session_012Xf1r3kmd3GAHmAh1GB3uQ)_