### PR TITLE
Add explicit text-white color to demo page headings

### DIFF
--- a/src/app/demo/chatbot/page.tsx
+++ b/src/app/demo/chatbot/page.tsx
@@ -41,7 +41,7 @@ export default function ChatbotDemoPage() {
           </div>
           <div className="flex items-center gap-3 mb-2">
             <span className="text-4xl">🤖</span>
-            <h1 className="text-3xl font-bold">{t('title')}</h1>
+            <h1 className="text-3xl font-bold text-white">{t('title')}</h1>
           </div>
           <p className="text-white/80">{t('subtitle')}</p>
         </div>

--- a/src/app/demo/invoicing/page.tsx
+++ b/src/app/demo/invoicing/page.tsx
@@ -71,7 +71,7 @@ export default function InvoicingDemoPage() {
           </Link>
           <div className="flex items-center gap-3 mb-2">
             <span className="text-4xl">💰</span>
-            <h1 className="text-3xl font-bold">{t('title')}</h1>
+            <h1 className="text-3xl font-bold text-white">{t('title')}</h1>
             <div className="ml-auto"><LanguageSwitcher /></div>
           </div>
           <p className="text-white/80">{t('subtitle')}</p>
@@ -253,7 +253,7 @@ export default function InvoicingDemoPage() {
 
             {/* Payment Methods */}
             <div className="bg-gradient-to-br from-[#1a1a2e] to-[#2d2d4a] rounded-xl p-6 text-white">
-              <h3 className="font-semibold mb-4">{t('acceptedPaymentMethods')}</h3>
+              <h3 className="font-semibold mb-4 text-white">{t('acceptedPaymentMethods')}</h3>
               <div className="flex gap-3 mb-4">
                 <div className="bg-white/10 rounded-lg px-3 py-2 text-sm font-medium">💳 {t('creditCard')}</div>
                 <div className="bg-white/10 rounded-lg px-3 py-2 text-sm font-medium">🏦 {t('ach')}</div>
@@ -282,7 +282,7 @@ export default function InvoicingDemoPage() {
 
         {/* Bottom CTA */}
         <div className="mt-12 bg-gradient-to-r from-[#1a1a2e] to-[#2d2d4a] rounded-2xl p-8 text-center text-white">
-          <h2 className="text-2xl font-bold mb-4">{t('stopChasing')}</h2>
+          <h2 className="text-2xl font-bold mb-4 text-white">{t('stopChasing')}</h2>
           <p className="text-white/80 mb-6 max-w-2xl mx-auto">
             {t('stopChasingDesc')}
           </p>

--- a/src/app/demo/phone-receptionist/page.tsx
+++ b/src/app/demo/phone-receptionist/page.tsx
@@ -181,7 +181,7 @@ export default function PhoneReceptionistDemo() {
               📞
             </div>
             <div>
-              <h1 className="text-3xl font-extrabold drop-shadow-lg">{t('title')}</h1>
+              <h1 className="text-3xl font-extrabold drop-shadow-lg text-white">{t('title')}</h1>
               <p className="text-white/90 mt-1">{t('subtitle')}</p>
             </div>
             <span className="ml-auto bg-[#f5a623] text-[#1a1a2e] px-4 py-1.5 rounded-full text-sm font-bold">

--- a/src/app/demo/quickbooks/page.tsx
+++ b/src/app/demo/quickbooks/page.tsx
@@ -102,7 +102,7 @@ export default function QuickBooksDemoPage() {
               </svg>
             </div>
             <div>
-              <h1 className="text-3xl font-bold">{t('title')}</h1>
+              <h1 className="text-3xl font-bold text-white">{t('title')}</h1>
               <p className="text-white/70 mt-1">{t('subtitle')}</p>
             </div>
             <span className="ml-auto bg-white/10 text-white px-4 py-1.5 rounded-full text-sm font-medium border border-white/20">

--- a/src/app/demo/route-optimization/page.tsx
+++ b/src/app/demo/route-optimization/page.tsx
@@ -91,7 +91,7 @@ export default function RouteOptimizationDemo() {
               🗺️
             </div>
             <div>
-              <h1 className="text-3xl font-bold">{t('title')}</h1>
+              <h1 className="text-3xl font-bold text-white">{t('title')}</h1>
               <p className="text-white/70 mt-1">{t('subtitle')}</p>
             </div>
             <span className="ml-auto bg-gradient-to-r from-[#f5a623] to-[#e6991a] text-[#1a1a2e] px-4 py-1.5 rounded-full text-sm font-bold">

--- a/src/app/demo/scheduling/page.tsx
+++ b/src/app/demo/scheduling/page.tsx
@@ -67,7 +67,7 @@ export default function SchedulingDemoPage() {
           </Link>
           <div className="flex items-center gap-3 mb-2">
             <span className="text-4xl">📅</span>
-            <h1 className="text-3xl font-bold">{t('title')}</h1>
+            <h1 className="text-3xl font-bold text-white">{t('title')}</h1>
             <div className="ml-auto"><LanguageSwitcher /></div>
           </div>
           <p className="text-white/80">{t('subtitle')}</p>

--- a/src/app/demo/shield/page.tsx
+++ b/src/app/demo/shield/page.tsx
@@ -85,7 +85,7 @@ export default function ShieldDemoPage() {
           </Link>
           <div className="flex items-center gap-3 mb-2">
             <span className="text-4xl">🛡️</span>
-            <h1 className="text-3xl font-bold">{t('title')}</h1>
+            <h1 className="text-3xl font-bold text-white">{t('title')}</h1>
             <div className="ml-auto"><LanguageSwitcher /></div>
           </div>
           <p className="text-white/80">{t('subtitle')}</p>

--- a/src/app/demo/website/page.tsx
+++ b/src/app/demo/website/page.tsx
@@ -379,7 +379,7 @@ export default function WebsiteDemoPage() {
           </div>
           <div className="flex items-center gap-3 mb-2">
             <span className="text-4xl">🌐</span>
-            <h1 className="text-3xl font-bold">{t('title')}</h1>
+            <h1 className="text-3xl font-bold text-white">{t('title')}</h1>
           </div>
           <p className="text-white/80">{t('subtitle')}</p>
         </div>

--- a/src/app/demo/worker/page.tsx
+++ b/src/app/demo/worker/page.tsx
@@ -96,7 +96,7 @@ export default function WorkerDemoPage() {
             {/* Today&apos;s Overview */}
             <div className="bg-gradient-to-r from-[#1a1a2e] to-[#2d2d4a] rounded-xl p-4 mb-4 text-white">
               <div className="flex items-center justify-between mb-3">
-                <h2 className="font-bold text-lg">{t('todaysJobs')}</h2>
+                <h2 className="font-bold text-lg text-white">{t('todaysJobs')}</h2>
                 <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
                   {demoJobs.length} jobs
                 </span>


### PR DESCRIPTION
## Summary
Added explicit `text-white` class to heading elements across all demo pages to ensure consistent text color rendering and improve visual clarity against dark gradient backgrounds.

## Changes
- **invoicing/page.tsx**: Added `text-white` to main title (h1), payment methods heading (h3), and bottom CTA heading (h2)
- **chatbot/page.tsx**: Added `text-white` to main title (h1)
- **phone-receptionist/page.tsx**: Added `text-white` to main title (h1)
- **quickbooks/page.tsx**: Added `text-white` to main title (h1)
- **route-optimization/page.tsx**: Added `text-white` to main title (h1)
- **scheduling/page.tsx**: Added `text-white` to main title (h1)
- **shield/page.tsx**: Added `text-white` to main title (h1)
- **website/page.tsx**: Added `text-white` to main title (h1)
- **worker/page.tsx**: Added `text-white` to "Today's Jobs" heading (h2)

## Implementation Details
These changes ensure that heading text maintains proper contrast and visibility on the dark gradient backgrounds (`from-[#1a1a2e] to-[#2d2d4a]`) used throughout the demo pages. While some headings may have inherited white color from parent containers, explicitly declaring `text-white` provides better consistency and prevents potential color inheritance issues.

https://claude.ai/code/session_01N4S3C1NeQeDH3XAUqWPV3Y