### PR TITLE
Harden Name.com registration against silent sandbox fallback

### DIFF
--- a/src/app/api/website-builder/domain-register/route.js
+++ b/src/app/api/website-builder/domain-register/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { registerDomain, setDNSRecords } from '@/lib/namecom';
+import { registerDomain, setDNSRecords, verifyDomainRegistered, getApiMode } from '@/lib/namecom';
 import { authenticateRequest } from '@/lib/server-auth';
 
 export const dynamic = 'force-dynamic';
@@ -80,14 +80,42 @@ export async function POST(request) {
       email: user.email || company?.email || '',
     };
 
+    const apiMode = getApiMode();
+
+    // Refuse to take real money in production without real registrar creds.
+    if (process.env.NODE_ENV === 'production' && apiMode !== 'production') {
+      await logDomainAction(site.id, user.id, site.company_id, cleanDomain, 'register', 'failed', null, {
+        error: 'Name.com production credentials missing',
+        apiMode,
+      });
+      return NextResponse.json({
+        error: 'Domain registration is temporarily unavailable. Our registrar is not configured for production. Please contact support — no charge has been made.',
+      }, { status: 503 });
+    }
+
     // Log attempt
-    await logDomainAction(site.id, user.id, site.company_id, cleanDomain, 'register', 'pending');
+    await logDomainAction(site.id, user.id, site.company_id, cleanDomain, 'register', 'pending', { apiMode });
 
     // Register domain
     const regResult = await registerDomain(cleanDomain, contacts);
     if (!regResult.success) {
-      await logDomainAction(site.id, user.id, site.company_id, cleanDomain, 'register', 'failed', null, { error: regResult.error });
+      await logDomainAction(site.id, user.id, site.company_id, cleanDomain, 'register', 'failed', null, { error: regResult.error, apiMode });
       return NextResponse.json({ error: `Domain registration failed: ${regResult.error}` }, { status: 500 });
+    }
+
+    // Verify the domain actually persisted at the registrar. If the API call
+    // claimed success but the domain can't be looked up afterward, treat it as
+    // a failure so we don't mark a non-existent domain as "active".
+    const verify = await verifyDomainRegistered(cleanDomain);
+    if (!verify.verified) {
+      await logDomainAction(site.id, user.id, site.company_id, cleanDomain, 'register', 'failed', null, {
+        error: 'Post-registration verification failed — domain not found at registrar',
+        verifyError: verify.error,
+        apiMode,
+      });
+      return NextResponse.json({
+        error: 'Domain registration could not be verified at the registrar. Please contact support before retrying to avoid duplicate charges.',
+      }, { status: 502 });
     }
 
     // Set DNS records
@@ -95,7 +123,7 @@ export async function POST(request) {
     try {
       dnsResult = await setDNSRecords(cleanDomain);
       await logDomainAction(site.id, user.id, site.company_id, cleanDomain, 'dns_update',
-        dnsResult.success ? 'success' : 'failed', { records: dnsResult.records });
+        dnsResult.success ? 'success' : 'failed', { records: dnsResult.records, apiMode });
     } catch (dnsError) {
       console.error('[Domain Register] DNS setup error:', dnsError.message);
     }
@@ -114,7 +142,7 @@ export async function POST(request) {
       .eq('id', siteId);
 
     await logDomainAction(site.id, user.id, site.company_id, cleanDomain, 'register', 'success', {
-      expireDate: regResult.expireDate, dnsConfigured: dnsResult.success,
+      expireDate: regResult.expireDate, dnsConfigured: dnsResult.success, apiMode,
     });
 
     return NextResponse.json({

--- a/src/lib/namecom.js
+++ b/src/lib/namecom.js
@@ -7,17 +7,40 @@
 
 const isProduction = process.env.NODE_ENV === 'production';
 
+const PROD_USERNAME = process.env.NAMECOM_USERNAME;
+const PROD_TOKEN = process.env.NAMECOM_API_TOKEN;
+const TEST_USERNAME = process.env.NAMECOM_TEST_USERNAME;
+const TEST_TOKEN = process.env.NAMECOM_TEST_TOKEN;
+
+const hasProdCreds = !!(PROD_USERNAME && PROD_TOKEN);
+// In production, only use the real API if prod creds are present. We do NOT
+// silently fall back to the sandbox in prod — that has historically caused
+// "registrations" that never actually existed at the registrar.
+const useProdApi = isProduction && hasProdCreds;
+const apiMode = useProdApi ? 'production' : 'sandbox';
+
 const config = {
-  baseUrl: isProduction
+  baseUrl: useProdApi
     ? 'https://api.name.com/v4'
     : 'https://api.dev.name.com/v4',
-  username: isProduction
-    ? process.env.NAMECOM_USERNAME
-    : process.env.NAMECOM_TEST_USERNAME,
-  token: isProduction
-    ? process.env.NAMECOM_API_TOKEN
-    : process.env.NAMECOM_TEST_TOKEN,
+  username: useProdApi ? PROD_USERNAME : TEST_USERNAME,
+  token: useProdApi ? PROD_TOKEN : TEST_TOKEN,
+  mode: apiMode,
 };
+
+function assertRealRegistrarForProd(action) {
+  if (isProduction && !hasProdCreds) {
+    throw new Error(
+      `[Name.com] Refusing to ${action} in production: NAMECOM_USERNAME and/or NAMECOM_API_TOKEN are not set. ` +
+      `Configure them in the Netlify environment before retrying — silently using the sandbox API would lead to ` +
+      `a fake registration that does not exist at the real registrar.`
+    );
+  }
+}
+
+export function getApiMode() {
+  return config.mode;
+}
 
 function getAuthHeader() {
   const credentials = `${config.username}:${config.token}`;
@@ -112,6 +135,7 @@ export async function checkDomain(domainName) {
 export async function registerDomain(domainName, contacts) {
   if (!domainName) throw new Error('Domain name is required');
   if (!contacts) throw new Error('Contact information is required');
+  assertRealRegistrarForProd('register a domain');
   const clean = domainName.toLowerCase().trim();
   const contactInfo = {
     firstName: contacts.firstName || 'ToolTime',
@@ -149,15 +173,39 @@ export async function registerDomain(domainName, contacts) {
       expireDate: data.domain?.expireDate,
       autoRenew: data.domain?.autoRenewEnabled,
       locked: data.domain?.locked,
+      apiMode: config.mode,
     };
   } catch (error) {
-    console.error('[Name.com] Register domain error:', error.message);
-    return { success: false, domainName: clean, error: error.message, details: error.details };
+    console.error(`[Name.com][${config.mode}] Register domain error:`, error.message);
+    return { success: false, domainName: clean, error: error.message, details: error.details, apiMode: config.mode };
+  }
+}
+
+export async function verifyDomainRegistered(domainName) {
+  if (!domainName) throw new Error('Domain name is required');
+  const clean = domainName.toLowerCase().trim();
+  try {
+    const info = await namecomRequest(`/domains/${clean}`);
+    return {
+      verified: !!info?.domainName,
+      domainName: info?.domainName || clean,
+      expireDate: info?.expireDate,
+      apiMode: config.mode,
+    };
+  } catch (error) {
+    return {
+      verified: false,
+      domainName: clean,
+      error: error.message,
+      status: error.status,
+      apiMode: config.mode,
+    };
   }
 }
 
 export async function setDNSRecords(domainName) {
   if (!domainName) throw new Error('Domain name is required');
+  assertRealRegistrarForProd('set DNS records');
   const clean = domainName.toLowerCase().trim();
   const records = [];
   const errors = [];
@@ -179,7 +227,13 @@ export async function setDNSRecords(domainName) {
   } catch (error) {
     errors.push({ type: 'CNAME', error: error.message });
   }
-  return { success: errors.length === 0, domainName: clean, records, errors: errors.length > 0 ? errors : undefined };
+  return {
+    success: errors.length === 0,
+    domainName: clean,
+    records,
+    errors: errors.length > 0 ? errors : undefined,
+    apiMode: config.mode,
+  };
 }
 
 export async function getDomainInfo(domainName) {
@@ -282,13 +336,16 @@ export function generateDomainSuggestions(businessName, state = 'CA') {
 }
 
 const namecom = {
-  searchDomains, checkDomain, registerDomain, setDNSRecords, getDomainInfo,
+  searchDomains, checkDomain, registerDomain, verifyDomainRegistered, setDNSRecords, getDomainInfo,
   setAutoRenew, getAuthCode, unlockDomain, listAllDomains, generateDomainSuggestions,
+  getApiMode,
   getConfig: () => ({
     baseUrl: config.baseUrl,
     username: config.username ? `${config.username.substring(0, 3)}***` : 'NOT SET',
     hasToken: !!config.token,
     isProduction,
+    apiMode: config.mode,
+    hasProdCreds,
   }),
 };
 


### PR DESCRIPTION
Previously, when NODE_ENV was production but NAMECOM_USERNAME/ NAMECOM_API_TOKEN were missing, the client silently used Name.com's dev sandbox, which returns success but never registers a real domain. This produced "registered" domains that did not actually exist at the registrar.

- Refuse to use the sandbox when NODE_ENV=production and prod creds are absent; throw a clear error instead.
- Add verifyDomainRegistered() and call it after registerDomain() in the API route; treat a missing lookup as failure rather than marking the site active.
- Tag every domain action log entry with apiMode so we can tell at a glance whether a record came from the sandbox or production.