### PR TITLE
feat(customers,invoices): add commercial customer support

### DIFF
--- a/database/migrations/037_commercial_customers.sql
+++ b/database/migrations/037_commercial_customers.sql
@@ -1,0 +1,47 @@
+-- Migration: 037_commercial_customers.sql
+-- Adds commercial customer support: residential/commercial type on customers,
+-- business_name (DBA / legal entity for invoices), and PO number + payment
+-- terms on invoices so contractors can bill commercial clients' AP departments
+-- properly.
+--
+-- Non-breaking: all columns are nullable / have defaults, and existing UI
+-- gracefully no-ops if a column is missing.
+
+-- ============================================
+-- CUSTOMERS: type + business name
+-- ============================================
+
+-- customer_type: 'residential' (default) or 'commercial'
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS customer_type VARCHAR(20) DEFAULT 'residential';
+
+-- Backfill any nulls left by older rows
+UPDATE customers SET customer_type = 'residential' WHERE customer_type IS NULL;
+
+-- business_name: the entity name on the invoice when customer_type = 'commercial'
+-- (the existing `name` column holds the primary on-site contact's name)
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS business_name VARCHAR(255);
+
+CREATE INDEX IF NOT EXISTS idx_customers_company_type
+  ON customers (company_id, customer_type);
+
+-- ============================================
+-- INVOICES: PO number + payment terms
+-- ============================================
+
+-- po_number: customer's purchase order number — required by most commercial AP
+ALTER TABLE invoices ADD COLUMN IF NOT EXISTS po_number VARCHAR(100);
+
+-- payment_terms: 'due_on_receipt' | 'net_15' | 'net_30' | 'net_60'
+-- Stored as text rather than enum to stay flexible without future migrations.
+ALTER TABLE invoices ADD COLUMN IF NOT EXISTS payment_terms VARCHAR(20);
+
+CREATE INDEX IF NOT EXISTS idx_invoices_po_number
+  ON invoices (company_id, po_number) WHERE po_number IS NOT NULL;
+
+-- ============================================
+-- COMMENTS (for schema documentation)
+-- ============================================
+COMMENT ON COLUMN customers.customer_type IS 'residential | commercial - drives invoice formatting and filtering';
+COMMENT ON COLUMN customers.business_name IS 'Legal entity / DBA shown on invoices when customer_type = commercial';
+COMMENT ON COLUMN invoices.po_number IS 'Customer PO number - required by commercial AP departments to process payment';
+COMMENT ON COLUMN invoices.payment_terms IS 'due_on_receipt | net_15 | net_30 | net_60 - auto-computes due_date';

--- a/src/app/dashboard/customers/page.tsx
+++ b/src/app/dashboard/customers/page.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
 
+type CustomerType = 'residential' | 'commercial'
+
 interface Customer {
   id: string
   name: string
@@ -19,6 +21,8 @@ interface Customer {
   source: string
   sms_consent: boolean
   sms_consent_date: string | null
+  customer_type?: CustomerType | null
+  business_name?: string | null
   created_at: string
   jobs?: { id: string; status: string }[]
   invoices?: { id: string; status: string; total: number }[]
@@ -29,6 +33,7 @@ export default function CustomersPage() {
   const [customers, setCustomers] = useState<Customer[]>([])
   const [loading, setLoading] = useState(true)
   const [searchTerm, setSearchTerm] = useState('')
+  const [typeFilter, setTypeFilter] = useState<'all' | CustomerType>('all')
   const [showModal, setShowModal] = useState(false)
   const [editingCustomer, setEditingCustomer] = useState<Customer | null>(null)
 
@@ -77,11 +82,19 @@ export default function CustomersPage() {
     setLoading(false)
   }
 
-  const filteredCustomers = customers.filter(c =>
-    c.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    c.email?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    c.phone?.includes(searchTerm)
-  )
+  const filteredCustomers = customers.filter(c => {
+    const matchesSearch =
+      c.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      c.business_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      c.email?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      c.phone?.includes(searchTerm)
+    if (!matchesSearch) return false
+    if (typeFilter === 'all') return true
+    const t = c.customer_type || 'residential'
+    return t === typeFilter
+  })
+
+  const commercialCount = customers.filter(c => c.customer_type === 'commercial').length
 
   const deleteCustomer = async (id: string) => {
     if (!confirm('Are you sure you want to delete this customer?')) return
@@ -129,15 +142,34 @@ export default function CustomersPage() {
         </div>
       </div>
 
-      {/* Search */}
-      <div className="mb-6">
+      {/* Search + Type Filter */}
+      <div className="mb-6 flex flex-col md:flex-row md:items-center gap-3">
         <input
           type="text"
-          placeholder="Search customers by name, email, or phone..."
+          placeholder="Search customers by name, business, email, or phone..."
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
           className="w-full md:w-96 px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
         />
+        <div className="flex gap-2">
+          {([
+            { key: 'all', label: 'All' },
+            { key: 'residential', label: 'Residential' },
+            { key: 'commercial', label: 'Commercial' },
+          ] as const).map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() => setTypeFilter(key)}
+              className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                typeFilter === key
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Stats */}
@@ -145,6 +177,9 @@ export default function CustomersPage() {
         <div className="bg-white p-4 rounded-lg border">
           <p className="text-sm text-gray-500">Total Customers</p>
           <p className="text-2xl font-bold">{customers.length}</p>
+          {commercialCount > 0 && (
+            <p className="text-xs text-gray-500 mt-1">{commercialCount} commercial</p>
+          )}
         </div>
         <div className="bg-white p-4 rounded-lg border">
           <p className="text-sm text-gray-500">Active Jobs</p>
@@ -186,11 +221,21 @@ export default function CustomersPage() {
           {filteredCustomers.map((customer) => (
             <div key={customer.id} className="bg-white rounded-xl border p-6 hover:shadow-md transition-shadow">
               <div className="flex justify-between items-start mb-4">
-                <div>
-                  <Link href={`/dashboard/customers/${customer.id}`} className="font-semibold text-gray-900 hover:text-blue-600">
-                    {customer.name}
+                <div className="min-w-0">
+                  {customer.customer_type === 'commercial' && (
+                    <span className="inline-block mb-1 text-xs px-2 py-0.5 rounded-full bg-purple-100 text-purple-700 font-medium">
+                      Commercial
+                    </span>
+                  )}
+                  <Link href={`/dashboard/customers/${customer.id}`} className="block font-semibold text-gray-900 hover:text-blue-600 truncate">
+                    {customer.customer_type === 'commercial' && customer.business_name
+                      ? customer.business_name
+                      : customer.name}
                   </Link>
-                  <p className="text-sm text-gray-500">{customer.email}</p>
+                  {customer.customer_type === 'commercial' && customer.business_name && (
+                    <p className="text-xs text-gray-500 truncate">Contact: {customer.name}</p>
+                  )}
+                  <p className="text-sm text-gray-500 truncate">{customer.email}</p>
                 </div>
                 <div className="flex gap-1">
                   <button
@@ -299,6 +344,8 @@ function CustomerModal({ customer, companyId, onClose, onSave }: {
   onSave: () => void
 }) {
   const [formData, setFormData] = useState({
+    customer_type: (customer?.customer_type as CustomerType) || 'residential',
+    business_name: customer?.business_name || '',
     name: customer?.name || '',
     email: customer?.email || '',
     phone: customer?.phone || '',
@@ -369,6 +416,15 @@ function CustomerModal({ customer, companyId, onClose, onSave }: {
 
       let { error } = await saveData(data)
 
+      // Retry without customer_type/business_name if migration 037 not applied yet
+      if (error?.message?.includes('customer_type') || error?.message?.includes('business_name')) {
+        const stripped = Object.fromEntries(
+          Object.entries(data).filter(([k]) => k !== 'customer_type' && k !== 'business_name')
+        )
+        const retry = await saveData(stripped as typeof data)
+        error = retry.error
+      }
+
       // Retry without sms_consent_date if column doesn't exist yet
       if (error?.message?.includes('sms_consent_date')) {
         const { sms_consent_date: _, ...dataWithoutConsentDate } = data as typeof data & { sms_consent_date?: string }
@@ -406,14 +462,54 @@ function CustomerModal({ customer, companyId, onClose, onSave }: {
         <h2 className="text-xl font-bold mb-4">{customer ? 'Edit Customer' : 'Add New Customer'}</h2>
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Customer Type */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Name *</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Customer Type</label>
+            <div className="grid grid-cols-2 gap-2">
+              {(['residential', 'commercial'] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setFormData({ ...formData, customer_type: t })}
+                  className={`px-3 py-2 rounded-lg border text-sm font-medium transition-colors ${
+                    formData.customer_type === t
+                      ? 'bg-blue-600 text-white border-blue-600'
+                      : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                  }`}
+                >
+                  {t === 'residential' ? 'Residential' : 'Commercial'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Business Name (commercial only) */}
+          {formData.customer_type === 'commercial' && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Business Name *</label>
+              <input
+                type="text"
+                required
+                value={formData.business_name}
+                onChange={(e) => setFormData({ ...formData, business_name: e.target.value })}
+                className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+                placeholder="Acme Corp"
+              />
+              <p className="text-xs text-gray-500 mt-1">Shown on invoices and quotes as the bill-to entity.</p>
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              {formData.customer_type === 'commercial' ? 'Primary Contact Name *' : 'Name *'}
+            </label>
             <input
               type="text"
               required
               value={formData.name}
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
               className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+              placeholder={formData.customer_type === 'commercial' ? 'Jane Smith (on-site contact)' : ''}
             />
           </div>
 

--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -5,11 +5,34 @@ import { supabase } from '@/lib/supabase'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@/contexts/AuthContext'
 
+type PaymentTerms = 'due_on_receipt' | 'net_15' | 'net_30' | 'net_60'
+
+const PAYMENT_TERMS_OPTIONS: { value: PaymentTerms; label: string; days: number }[] = [
+  { value: 'due_on_receipt', label: 'Due on receipt', days: 0 },
+  { value: 'net_15', label: 'Net 15', days: 15 },
+  { value: 'net_30', label: 'Net 30', days: 30 },
+  { value: 'net_60', label: 'Net 60', days: 60 },
+]
+
+interface InvoiceCustomer {
+  id: string
+  name: string
+  email: string
+  phone?: string
+  address?: string
+  city?: string
+  state?: string
+  zip?: string
+  sms_consent?: boolean
+  customer_type?: 'residential' | 'commercial' | null
+  business_name?: string | null
+}
+
 interface Invoice {
   id: string
   invoice_number: string
   customer_id: string
-  customer: { id: string; name: string; email: string; phone?: string; address?: string; city?: string; state?: string; zip?: string; sms_consent?: boolean } | null
+  customer: InvoiceCustomer | null
   status: string
   subtotal: number
   tax_rate: number
@@ -20,12 +43,14 @@ interface Invoice {
   paid_at: string | null
   sent_at: string | null
   created_at: string
+  po_number?: string | null
+  payment_terms?: PaymentTerms | null
   items?: { id: string; description: string; quantity: number; unit_price: number; total: number }[]
 }
 
 export default function InvoicesPage() {
   const [invoices, setInvoices] = useState<Invoice[]>([])
-  const [customers, setCustomers] = useState<{ id: string; name: string; email: string; phone?: string; address?: string; city?: string; state?: string; zip?: string; sms_consent?: boolean }[]>([])
+  const [customers, setCustomers] = useState<InvoiceCustomer[]>([])
   const [loading, setLoading] = useState(true)
   const [filter, setFilter] = useState<string>('all')
   const [showModal, setShowModal] = useState(false)
@@ -42,7 +67,7 @@ export default function InvoicesPage() {
       .from('invoices')
       .select(`
         *,
-        customer:customers(id, name, email, phone, address, city, state, zip, sms_consent),
+        customer:customers(id, name, email, phone, address, city, state, zip, sms_consent, customer_type, business_name),
         items:invoice_items(*)
       `)
       .eq('company_id', compId)
@@ -52,7 +77,26 @@ export default function InvoicesPage() {
       query = query.eq('status', filter)
     }
 
-    const { data, error } = await query
+    let { data, error } = await query
+
+    if (error?.message?.includes('customer_type') || error?.message?.includes('business_name')) {
+      // Migration 037 not applied — retry without commercial columns
+      let fallback = supabase
+        .from('invoices')
+        .select(`
+          *,
+          customer:customers(id, name, email, phone, address, city, state, zip, sms_consent),
+          items:invoice_items(*)
+        `)
+        .eq('company_id', compId)
+        .order('created_at', { ascending: false })
+      if (filter !== 'all') {
+        fallback = fallback.eq('status', filter)
+      }
+      const retry = await fallback
+      data = retry.data
+      error = retry.error
+    }
 
     if (error) {
       console.error('Error fetching invoices:', error)
@@ -63,11 +107,21 @@ export default function InvoicesPage() {
   }, [filter])
 
   const fetchCustomers = useCallback(async (compId: string) => {
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from('customers')
-      .select('id, name, email, phone, address, city, state, zip')
+      .select('id, name, email, phone, address, city, state, zip, customer_type, business_name')
       .eq('company_id', compId)
       .order('name')
+    if (error?.message?.includes('customer_type') || error?.message?.includes('business_name')) {
+      // Migration 037 not applied yet — fall back to the legacy column set
+      const retry = await supabase
+        .from('customers')
+        .select('id, name, email, phone, address, city, state, zip')
+        .eq('company_id', compId)
+        .order('name')
+      setCustomers(retry.data || [])
+      return
+    }
     setCustomers(data || [])
   }, [])
 
@@ -443,7 +497,19 @@ export default function InvoicesPage() {
                       <p className="text-sm text-gray-500">{new Date(invoice.created_at).toLocaleDateString()}</p>
                     </td>
                     <td className="px-6 py-4">
-                      <p className="text-sm text-gray-900">{invoice.customer?.name || '-'}</p>
+                      <p className="text-sm text-gray-900 flex items-center gap-2">
+                        {invoice.customer?.customer_type === 'commercial' && invoice.customer?.business_name
+                          ? invoice.customer.business_name
+                          : invoice.customer?.name || '-'}
+                        {invoice.customer?.customer_type === 'commercial' && (
+                          <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-700 font-medium">
+                            Commercial
+                          </span>
+                        )}
+                      </p>
+                      {invoice.po_number && (
+                        <p className="text-xs text-gray-500">PO #{invoice.po_number}</p>
+                      )}
                       <p className="text-sm text-gray-500">{invoice.customer?.email}</p>
                     </td>
                     <td className="px-6 py-4">
@@ -536,11 +602,19 @@ export default function InvoicesPage() {
             if (companyId) {
               await fetchInvoices(companyId)
               // Fetch the just-saved invoice with full customer/items data to send it
-              const { data } = await supabase
+              let { data } = await supabase
                 .from('invoices')
-                .select('*, customer:customers(id, name, email, phone, address, city, state, zip, sms_consent), items:invoice_items(*)')
+                .select('*, customer:customers(id, name, email, phone, address, city, state, zip, sms_consent, customer_type, business_name), items:invoice_items(*)')
                 .eq('id', invoiceId)
                 .single()
+              if (!data) {
+                const retry = await supabase
+                  .from('invoices')
+                  .select('*, customer:customers(id, name, email, phone, address, city, state, zip, sms_consent), items:invoice_items(*)')
+                  .eq('id', invoiceId)
+                  .single()
+                data = retry.data
+              }
               if (data) {
                 await sendInvoice(data as Invoice)
               }
@@ -566,16 +640,25 @@ const STATE_TAX_RATES: Record<string, number> = {
 function InvoiceModal({ invoice, companyId, customers, onClose, onSave, onSaveAndSend }: {
   invoice: Invoice | null
   companyId: string
-  customers: { id: string; name: string; email: string; phone?: string; address?: string; city?: string; state?: string; zip?: string }[]
+  customers: InvoiceCustomer[]
   onClose: () => void
   onSave: () => void
   onSaveAndSend?: (invoiceId: string) => void
 }) {
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<{
+    customer_id: string
+    notes: string
+    due_date: string
+    tax_rate: string
+    po_number: string
+    payment_terms: PaymentTerms | ''
+  }>({
     customer_id: invoice?.customer_id || '',
     notes: invoice?.notes || '',
     due_date: invoice?.due_date || new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
     tax_rate: invoice?.tax_rate ? String(invoice.tax_rate) : '0',
+    po_number: invoice?.po_number || '',
+    payment_terms: (invoice?.payment_terms as PaymentTerms | undefined) || '',
   })
   const [items, setItems] = useState<{ description: string; quantity: number; unit_price: number }[]>(
     invoice?.items?.map(i => ({ description: i.description, quantity: i.quantity, unit_price: i.unit_price })) ||
@@ -587,6 +670,20 @@ function InvoiceModal({ invoice, companyId, customers, onClose, onSave, onSaveAn
   const [sendAfterSave, setSendAfterSave] = useState(false)
 
   const selectedCustomer = customers.find(c => c.id === formData.customer_id) || null
+
+  const dueDateFromTerms = (terms: PaymentTerms): string => {
+    const opt = PAYMENT_TERMS_OPTIONS.find(o => o.value === terms)
+    const days = opt?.days ?? 30
+    return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+  }
+
+  const handleTermsChange = (terms: PaymentTerms | '') => {
+    if (!terms) {
+      setFormData({ ...formData, payment_terms: '' })
+      return
+    }
+    setFormData({ ...formData, payment_terms: terms, due_date: dueDateFromTerms(terms) })
+  }
 
   const addItem = () => setItems([...items, { description: '', quantity: 1, unit_price: 0 }])
   const removeItem = (index: number) => setItems(items.filter((_, i) => i !== index))
@@ -625,12 +722,24 @@ function InvoiceModal({ invoice, companyId, customers, onClose, onSave, onSaveAn
         total,
         status: invoice?.status || 'draft',
         updated_at: new Date().toISOString(),
+        ...(formData.po_number ? { po_number: formData.po_number } : { po_number: null }),
+        ...(formData.payment_terms ? { payment_terms: formData.payment_terms } : { payment_terms: null }),
+      }
+
+      const stripCommercialColumns = (payload: typeof invoiceData) => {
+        const { po_number: _po, payment_terms: _pt, ...rest } = payload
+        return rest
       }
 
       let invoiceId = invoice?.id
 
       if (invoice) {
-        const { error: updateError } = await supabase.from('invoices').update(invoiceData).eq('id', invoice.id)
+        let { error: updateError } = await supabase.from('invoices').update(invoiceData).eq('id', invoice.id)
+        if (updateError?.message?.includes('po_number') || updateError?.message?.includes('payment_terms')) {
+          // Migration 037 not applied — retry without commercial columns
+          const retry = await supabase.from('invoices').update(stripCommercialColumns(invoiceData)).eq('id', invoice.id)
+          updateError = retry.error
+        }
         if (updateError) {
           throw new Error(`Failed to update invoice: ${updateError.message}`)
         }
@@ -639,7 +748,12 @@ function InvoiceModal({ invoice, companyId, customers, onClose, onSave, onSaveAn
           throw new Error(`Failed to update line items: ${deleteItemsError.message}`)
         }
       } else {
-        const { data, error: insertError } = await supabase.from('invoices').insert(invoiceData).select().single()
+        let { data, error: insertError } = await supabase.from('invoices').insert(invoiceData).select().single()
+        if (insertError?.message?.includes('po_number') || insertError?.message?.includes('payment_terms')) {
+          const retry = await supabase.from('invoices').insert(stripCommercialColumns(invoiceData)).select().single()
+          data = retry.data
+          insertError = retry.error
+        }
         if (insertError) {
           throw new Error(`Failed to create invoice: ${insertError.message}`)
         }
@@ -695,16 +809,29 @@ function InvoiceModal({ invoice, companyId, customers, onClose, onSave, onSaveAn
                   const autoTaxRate = cust?.state && STATE_TAX_RATES[cust.state.toUpperCase()] !== undefined
                     ? String(STATE_TAX_RATES[cust.state.toUpperCase()])
                     : formData.tax_rate
-                  setFormData({ ...formData, customer_id: custId, tax_rate: autoTaxRate })
+                  // Commercial customers default to Net 30 unless terms are already set
+                  const shouldDefaultTerms = cust?.customer_type === 'commercial' && !formData.payment_terms
+                  const nextTerms: PaymentTerms | '' = shouldDefaultTerms ? 'net_30' : formData.payment_terms
+                  const nextDueDate = shouldDefaultTerms ? dueDateFromTerms('net_30') : formData.due_date
+                  setFormData({
+                    ...formData,
+                    customer_id: custId,
+                    tax_rate: autoTaxRate,
+                    payment_terms: nextTerms,
+                    due_date: nextDueDate,
+                  })
                   setCustomerError(null)
                 }}
                 className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 ${customerError ? 'border-red-500' : ''}`}
                 required
               >
                 <option value="">Select customer...</option>
-                {customers.map((c) => (
-                  <option key={c.id} value={c.id}>{c.name}</option>
-                ))}
+                {customers.map((c) => {
+                  const display = c.customer_type === 'commercial' && c.business_name
+                    ? `${c.business_name} (${c.name})`
+                    : c.name
+                  return <option key={c.id} value={c.id}>{display}</option>
+                })}
               </select>
               {customerError && <p className="text-red-500 text-xs mt-1">{customerError}</p>}
             </div>
@@ -719,10 +846,45 @@ function InvoiceModal({ invoice, companyId, customers, onClose, onSave, onSaveAn
             </div>
           </div>
 
+          {/* Payment Terms + PO Number */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Payment Terms</label>
+              <select
+                value={formData.payment_terms}
+                onChange={(e) => handleTermsChange(e.target.value as PaymentTerms | '')}
+                className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="">— None (use due date) —</option>
+                {PAYMENT_TERMS_OPTIONS.map(o => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                PO Number{selectedCustomer?.customer_type === 'commercial' && (
+                  <span className="ml-1 text-xs text-gray-500 font-normal">(recommended for commercial)</span>
+                )}
+              </label>
+              <input
+                type="text"
+                value={formData.po_number}
+                onChange={(e) => setFormData({ ...formData, po_number: e.target.value })}
+                className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+                placeholder="e.g. PO-12345"
+              />
+            </div>
+          </div>
+
           {/* Customer Address */}
           {selectedCustomer && (selectedCustomer.address || selectedCustomer.city || selectedCustomer.state) && (
             <div className="bg-gray-50 rounded-lg p-3">
-              <p className="text-xs font-medium text-gray-500 mb-1">Customer Address</p>
+              <p className="text-xs font-medium text-gray-500 mb-1">
+                {selectedCustomer.customer_type === 'commercial' && selectedCustomer.business_name
+                  ? `Bill To: ${selectedCustomer.business_name}`
+                  : 'Customer Address'}
+              </p>
               <p className="text-sm text-gray-800">
                 {[selectedCustomer.address, [selectedCustomer.city, selectedCustomer.state, selectedCustomer.zip].filter(Boolean).join(', ')].filter(Boolean).join(', ')}
               </p>

--- a/src/app/invoice/[id]/InvoiceViewClient.tsx
+++ b/src/app/invoice/[id]/InvoiceViewClient.tsx
@@ -32,6 +32,15 @@ const PAYMENT_METHOD_LABELS: Record<string, { label: string; icon: string }> = {
   other: { label: 'Other', icon: '💳' },
 };
 
+type PaymentTerms = 'due_on_receipt' | 'net_15' | 'net_30' | 'net_60';
+
+const PAYMENT_TERMS_LABELS: Record<PaymentTerms, string> = {
+  due_on_receipt: 'Due on receipt',
+  net_15: 'Net 15',
+  net_30: 'Net 30',
+  net_60: 'Net 60',
+};
+
 interface InvoiceWithDetails {
   id: string;
   invoice_number: string | null;
@@ -45,8 +54,10 @@ interface InvoiceWithDetails {
   due_date: string | null;
   notes: string | null;
   created_at: string;
+  po_number: string | null;
+  payment_terms: PaymentTerms | null;
   company: Company | null;
-  customer: Customer | null;
+  customer: (Customer & { customer_type?: 'residential' | 'commercial' | null; business_name?: string | null }) | null;
 }
 
 export default function InvoiceViewClient({ params }: { params: { id: string } }) {
@@ -286,13 +297,20 @@ export default function InvoiceViewClient({ params }: { params: { id: string } }
               </div>
               <div>
                 <div className="text-xs font-medium text-gray-400 uppercase mb-1">{t('billTo')}</div>
-                <div className="font-semibold text-gray-800">{invoice.customer?.name || 'Customer'}</div>
+                {invoice.customer?.customer_type === 'commercial' && invoice.customer?.business_name ? (
+                  <>
+                    <div className="font-semibold text-gray-800">{invoice.customer.business_name}</div>
+                    <div className="text-sm text-gray-600">Attn: {invoice.customer.name}</div>
+                  </>
+                ) : (
+                  <div className="font-semibold text-gray-800">{invoice.customer?.name || 'Customer'}</div>
+                )}
                 {customerAddress && <div className="text-sm text-gray-600">{customerAddress}</div>}
                 {invoice.customer?.email && <div className="text-sm text-gray-600">{invoice.customer.email}</div>}
                 {invoice.customer?.phone && <div className="text-sm text-gray-600">{invoice.customer.phone}</div>}
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-4 mt-4 pt-4 border-t border-gray-100">
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4 pt-4 border-t border-gray-100">
               <div>
                 <div className="text-xs text-gray-400">{t('invoiceDate')}</div>
                 <div className="text-sm font-medium text-gray-800">{formatDate(invoice.created_at)}</div>
@@ -304,6 +322,20 @@ export default function InvoiceViewClient({ params }: { params: { id: string } }
                   {isOverdue && ` (${t('overdue')})`}
                 </div>
               </div>
+              {invoice.payment_terms && (
+                <div>
+                  <div className="text-xs text-gray-400">Terms</div>
+                  <div className="text-sm font-medium text-gray-800">
+                    {PAYMENT_TERMS_LABELS[invoice.payment_terms] || invoice.payment_terms}
+                  </div>
+                </div>
+              )}
+              {invoice.po_number && (
+                <div>
+                  <div className="text-xs text-gray-400">PO Number</div>
+                  <div className="text-sm font-medium text-gray-800">{invoice.po_number}</div>
+                </div>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
Adds the minimum needed for contractors to bill commercial clients professionally:

- Customer type (residential | commercial) + business_name on the customers table; commercial customers show a badge and use their business name as the bill-to entity.
- PO number + payment terms (due_on_receipt, net_15/30/60) on invoices; selecting a term auto-computes due_date, and picking a commercial customer defaults the term to Net 30.
- Public invoice view renders business name as Bill To with "Attn:" for the on-site contact, plus PO and Terms when set.

Migration 037 is non-breaking — UI gracefully falls back if the columns do not yet exist (same retry pattern used for sms_consent).

https://claude.ai/code/session_01UwuGFNSk9cN9ATKk46bXnR