### PR TITLE
fix: ship stranded demo lead-capture + tier-extras + missing i18n keys

### DIFF
--- a/messages/en/demo.json
+++ b/messages/en/demo.json
@@ -1,5 +1,22 @@
 {
   "demo": {
+    "common": {
+      "leadCapture": {
+        "teaser": "Want a personalized walkthrough of {feature} for your business?",
+        "button": "Get a personalized demo",
+        "modalTitle": "See {feature} in action",
+        "modalDesc": "Tell us a little about your business and we'll send a personalized demo and follow up within one business day.",
+        "name": "Your name",
+        "email": "Email",
+        "phone": "Phone (optional)",
+        "business": "Business name (optional)",
+        "submit": "Request my demo",
+        "sending": "Sending...",
+        "cancel": "Cancel",
+        "success": "Got it! We'll be in touch within one business day.",
+        "error": "Couldn't send. Please try again."
+      }
+    },
     "booking": {
       "bannerText": "This is a preview of the customer booking experience.",
       "bannerSignUp": "Sign up",

--- a/messages/en/demo.json
+++ b/messages/en/demo.json
@@ -18,6 +18,7 @@
       }
     },
     "booking": {
+      "backToHome": "Back to Home",
       "bannerText": "This is a preview of the customer booking experience.",
       "bannerSignUp": "Sign up",
       "bannerSuffix": "to get your own booking page.",
@@ -262,6 +263,7 @@
       "poweredBy": "Powered by"
     },
     "reviews": {
+      "backToHome": "Back to Home",
       "bannerText": "This is a preview of the Review Machine — powered by Jenny AI.",
       "bannerSignUp": "Sign up",
       "bannerSuffix": "to automate your review requests.",

--- a/messages/es/demo.json
+++ b/messages/es/demo.json
@@ -18,6 +18,7 @@
       }
     },
     "booking": {
+      "backToHome": "Volver al Inicio",
       "bannerText": "Esta es una vista previa de la experiencia de reservas en linea.",
       "bannerSignUp": "Registrese",
       "bannerSuffix": "para obtener su propia pagina de reservas.",
@@ -262,6 +263,7 @@
       "poweredBy": "Desarrollado por"
     },
     "reviews": {
+      "backToHome": "Volver al Inicio",
       "bannerText": "Esta es una vista previa de la Maquina de Resenas — impulsada por Jenny AI.",
       "bannerSignUp": "Registrese",
       "bannerSuffix": "para automatizar sus solicitudes de resenas.",

--- a/messages/es/demo.json
+++ b/messages/es/demo.json
@@ -1,5 +1,22 @@
 {
   "demo": {
+    "common": {
+      "leadCapture": {
+        "teaser": "¿Quiere un recorrido personalizado de {feature} para su negocio?",
+        "button": "Obtener una demo personalizada",
+        "modalTitle": "Vea {feature} en accion",
+        "modalDesc": "Cuentenos sobre su negocio y le enviaremos una demo personalizada con seguimiento en un dia habil.",
+        "name": "Su nombre",
+        "email": "Correo electronico",
+        "phone": "Telefono (opcional)",
+        "business": "Nombre del negocio (opcional)",
+        "submit": "Solicitar mi demo",
+        "sending": "Enviando...",
+        "cancel": "Cancelar",
+        "success": "¡Recibido! Le contactaremos en un dia habil.",
+        "error": "No se pudo enviar. Intente de nuevo."
+      }
+    },
     "booking": {
       "bannerText": "Esta es una vista previa de la experiencia de reservas en linea.",
       "bannerSignUp": "Registrese",

--- a/src/app/api/ai-quote/route.ts
+++ b/src/app/api/ai-quote/route.ts
@@ -312,10 +312,10 @@ function buildTiers(services: ServiceMatch[], subtotal: number) {
   return {
     good: {
       name: 'Good',
-      description: 'Essential services only',
+      description: 'Essential service only',
       services: services.map(s => s.name),
       multiplier: 1.0,
-      extras: ['Core services included', 'Standard scheduling', 'Basic cleanup'],
+      extras: ['Core service included', 'Standard scheduling', 'Basic cleanup of work area'],
     },
     better: {
       name: 'Better',
@@ -325,8 +325,8 @@ function buildTiers(services: ServiceMatch[], subtotal: number) {
       extras: [
         'Everything in Good',
         'Priority scheduling',
-        'Detailed cleanup and hauling',
-        'Post-service yard inspection',
+        'Thorough cleanup and debris removal',
+        'Post-service walkthrough with you',
       ],
     },
     best: {
@@ -338,8 +338,8 @@ function buildTiers(services: ServiceMatch[], subtotal: number) {
         'Everything in Better',
         'Same-day / next-day availability',
         'Before & after photos sent to you',
-        'Satisfaction guarantee with free follow-up',
-        'Seasonal maintenance recommendations',
+        'Satisfaction guarantee with free touch-up if needed',
+        'Maintenance recommendations to keep results lasting',
       ],
     },
   };

--- a/src/app/demo/booking/page.tsx
+++ b/src/app/demo/booking/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 // Demo services
 const demoServices = [
@@ -644,6 +645,8 @@ export default function DemoBookingPage() {
                 </div>
               </div>
             </div>
+
+            <DemoLeadCapture featureName="Online Booking" source="booking_demo" />
 
             {/* Demo CTA */}
             <div className="bg-[#fef3d6] rounded-xl p-6 max-w-md mx-auto">

--- a/src/app/demo/chatbot/page.tsx
+++ b/src/app/demo/chatbot/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations, useLocale } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 const chatMessagesEn = [
   { sender: 'customer', text: 'Hi, do you do pool cleaning?' },
@@ -209,6 +210,8 @@ export default function ChatbotDemoPage() {
             </div>
           </div>
         </div>
+
+        <DemoLeadCapture featureName="Jenny AI Chatbot" source="chatbot_demo" />
 
         {/* Bottom CTA Section */}
         <div className="mt-16 bg-gradient-to-r from-[#1a1a2e] to-[#2d2d4a] rounded-2xl p-8 md:p-12 text-center text-white">

--- a/src/app/demo/dashboard/page.tsx
+++ b/src/app/demo/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 // --- Demo Data ---
 const demoStats = {
@@ -567,6 +568,8 @@ export default function DashboardDemoPage() {
               ))}
             </div>
           </div>
+
+          <DemoLeadCapture featureName="ToolTime Pro Dashboard" source="dashboard_demo" />
 
           {/* CTA */}
           <div className="bg-gradient-to-r from-[#1a1a2e] to-[#2d2d4a] rounded-xl p-6 text-white">

--- a/src/app/demo/dispatch/page.jsx
+++ b/src/app/demo/dispatch/page.jsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 // ============================================
 // DEMO DATA
@@ -790,6 +791,10 @@ export default function DispatchBoardPage() {
           {notificationMessage}
         </div>
       )}
+
+      <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '0 20px' }}>
+        <DemoLeadCapture featureName="Dispatch Board" source="dispatch_demo" />
+      </div>
 
       {/* Upgrade CTA for non-Elite users */}
       <div className="upgrade-banner">

--- a/src/app/demo/estimator/page.tsx
+++ b/src/app/demo/estimator/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 import {
   Calculator,
   DollarSign,
@@ -321,6 +322,8 @@ export default function EstimatorDemo() {
             </div>
           </div>
         )}
+
+        <DemoLeadCapture featureName="Smart Material Estimator" source="estimator_demo" />
 
         {/* CTA */}
         <div className="bg-[#fef3d6] rounded-xl p-8 text-center">

--- a/src/app/demo/invoicing/page.tsx
+++ b/src/app/demo/invoicing/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 // Demo invoice data
 const demoInvoices = [
@@ -279,6 +280,8 @@ export default function InvoicingDemoPage() {
             </div>
           </div>
         </div>
+
+        <DemoLeadCapture featureName="Invoicing & Payments" source="invoicing_demo" />
 
         {/* Bottom CTA */}
         <div className="mt-12 bg-gradient-to-r from-[#1a1a2e] to-[#2d2d4a] rounded-2xl p-8 text-center text-white">

--- a/src/app/demo/phone-receptionist/page.tsx
+++ b/src/app/demo/phone-receptionist/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 // Demo call scenarios
 const demoScenarios = [
@@ -441,6 +442,8 @@ export default function PhoneReceptionistDemo() {
             ))}
           </div>
         </div>
+
+        <DemoLeadCapture featureName="Jenny AI Phone Receptionist" source="phone_receptionist_demo" />
 
         {/* CTA Section */}
         <div className="bg-gradient-to-r from-[#1a1a2e] to-[#2d2d44] rounded-2xl p-10 text-center text-white">

--- a/src/app/demo/quickbooks/page.tsx
+++ b/src/app/demo/quickbooks/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 // Demo sync data
 const demoInvoices = [
@@ -385,6 +386,8 @@ export default function QuickBooksDemoPage() {
             ))}
           </div>
         </div>
+
+        <DemoLeadCapture featureName="QuickBooks Sync" source="quickbooks_demo" />
 
         {/* CTA Section */}
         <div className="bg-gradient-to-r from-[#2ca01c] to-[#238c17] rounded-2xl p-10 text-center text-white">

--- a/src/app/demo/reviews/page.tsx
+++ b/src/app/demo/reviews/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 import {
   Star,
   Send,
@@ -340,6 +341,8 @@ export default function DemoReviewsPage() {
             </table>
           </div>
         </div>
+
+        <DemoLeadCapture featureName="Review Automation" source="reviews_demo" />
 
         {/* CTA */}
         <div className="bg-[#fef3d6] rounded-xl p-8 text-center">

--- a/src/app/demo/route-optimization/page.tsx
+++ b/src/app/demo/route-optimization/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 // Demo jobs for route optimization
 const demoJobs = [
@@ -413,6 +414,8 @@ export default function RouteOptimizationDemo() {
             ))}
           </div>
         </div>
+
+        <DemoLeadCapture featureName="Route Optimization" source="route_optimization_demo" />
 
         {/* CTA Section */}
         <div className="mt-16 bg-gradient-to-r from-[#1a1a2e] to-[#2d2d44] rounded-2xl p-10 text-center text-white">

--- a/src/app/demo/scheduling/page.tsx
+++ b/src/app/demo/scheduling/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 // Demo data for calendar
 const demoJobs = [
@@ -265,6 +266,8 @@ export default function SchedulingDemoPage() {
             </div>
           </div>
         </div>
+
+        <DemoLeadCapture featureName="Job Scheduling" source="scheduling_demo" />
 
         {/* Bottom CTA */}
         <div className="mt-12 bg-gradient-to-r from-[#1a1a2e] to-[#2d2d4a] rounded-2xl p-8 text-center text-white">

--- a/src/app/demo/shield/page.tsx
+++ b/src/app/demo/shield/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 // Demo data
 const complianceScore = 85;
@@ -453,6 +454,8 @@ export default function ShieldDemoPage() {
             </div>
           </div>
         )}
+
+        <DemoLeadCapture featureName="Compliance Shield" source="shield_demo" />
 
         {/* Bottom CTA */}
         <div className="mt-8 bg-gradient-to-r from-[#1a1a2e] to-[#2d2d4a] rounded-2xl p-8 text-center text-white">

--- a/src/app/demo/website/page.tsx
+++ b/src/app/demo/website/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 // Industry options with default content
 const industryOptions = [
@@ -655,6 +656,8 @@ export default function WebsiteDemoPage() {
 
             {/* Website Preview */}
             {renderWebsitePreview()}
+
+            <DemoLeadCapture featureName="Website Builder" source="website_demo" />
 
             {/* CTA Section */}
             <div className="mt-8 bg-gradient-to-r from-navy-500 to-navy-600 rounded-xl p-8 text-center text-white">

--- a/src/app/demo/worker/page.tsx
+++ b/src/app/demo/worker/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import DemoLeadCapture from '@/components/demo/DemoLeadCapture';
 
 // Demo data for worker app
 const demoUser = {
@@ -402,6 +403,10 @@ export default function WorkerDemoPage() {
           </div>
         </div>
       )}
+
+      <div className="max-w-md mx-auto px-4 pb-32">
+        <DemoLeadCapture featureName="Worker Mobile App" source="worker_demo" />
+      </div>
 
       {/* CTA Overlay */}
       <div className="fixed bottom-20 left-4 right-4 bg-gradient-to-r from-[#1a1a2e] to-[#2d2d4a] rounded-xl p-4 text-white shadow-lg">

--- a/src/components/demo/DemoLeadCapture.tsx
+++ b/src/components/demo/DemoLeadCapture.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Mail, X, CheckCircle } from 'lucide-react';
+
+interface DemoLeadCaptureProps {
+  featureName: string;
+  source: string;
+}
+
+export default function DemoLeadCapture({ featureName, source }: DemoLeadCaptureProps) {
+  const t = useTranslations('demo.common.leadCapture');
+
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [businessName, setBusinessName] = useState('');
+  const [sending, setSending] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim() || !email.trim()) return;
+    setSending(true);
+    setStatus('idle');
+    try {
+      const message = [
+        `Demo interest: ${featureName}`,
+        businessName.trim() ? `Business: ${businessName.trim()}` : null,
+      ].filter(Boolean).join('\n');
+
+      const res = await fetch('/api/website-builder/leads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          email,
+          phone,
+          service: featureName,
+          message,
+          source,
+        }),
+      });
+      if (!res.ok) throw new Error('Lead API returned ' + res.status);
+      setStatus('success');
+      setOpen(false);
+    } catch (err) {
+      console.error(err);
+      setStatus('error');
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="bg-white rounded-xl border border-gray-200 p-6 mb-8 text-center">
+        <p className="text-sm text-[#5c5c70] mb-3">
+          {t('teaser', { feature: featureName })}
+        </p>
+        <button
+          onClick={() => {
+            setStatus('idle');
+            setOpen(true);
+          }}
+          className="inline-flex items-center gap-2 px-6 py-3 bg-[#f5a623] text-[#1a1a2e] rounded-lg font-bold hover:bg-[#e09913] transition-colors"
+        >
+          <Mail size={16} />
+          {t('button')}
+        </button>
+        {status === 'success' && (
+          <p className="mt-3 inline-flex items-center gap-1.5 text-sm text-green-700 font-medium">
+            <CheckCircle size={14} />
+            {t('success')}
+          </p>
+        )}
+      </div>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+          <div className="bg-white rounded-xl max-w-md w-full p-6 relative">
+            <button
+              onClick={() => setOpen(false)}
+              className="absolute top-4 right-4 text-[#5c5c70] hover:text-[#1a1a2e]"
+              aria-label="Close"
+            >
+              <X size={20} />
+            </button>
+            <h3 className="text-lg font-bold text-[#1a1a2e] mb-1">
+              {t('modalTitle', { feature: featureName })}
+            </h3>
+            <p className="text-sm text-[#5c5c70] mb-4">{t('modalDesc')}</p>
+
+            <form onSubmit={handleSubmit} className="space-y-3">
+              <div>
+                <label className="block text-sm font-semibold text-[#1a1a2e] mb-1.5">
+                  {t('name')}
+                </label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  required
+                  className="w-full px-3 py-2.5 rounded-lg border border-gray-300 text-[#1a1a2e] focus:border-[#f5a623] focus:outline-none focus:ring-2 focus:ring-[#fef3d6]"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-semibold text-[#1a1a2e] mb-1.5">
+                  {t('email')}
+                </label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  className="w-full px-3 py-2.5 rounded-lg border border-gray-300 text-[#1a1a2e] focus:border-[#f5a623] focus:outline-none focus:ring-2 focus:ring-[#fef3d6]"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-semibold text-[#1a1a2e] mb-1.5">
+                  {t('phone')}
+                </label>
+                <input
+                  type="tel"
+                  value={phone}
+                  onChange={(e) => setPhone(e.target.value)}
+                  className="w-full px-3 py-2.5 rounded-lg border border-gray-300 text-[#1a1a2e] focus:border-[#f5a623] focus:outline-none focus:ring-2 focus:ring-[#fef3d6]"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-semibold text-[#1a1a2e] mb-1.5">
+                  {t('business')}
+                </label>
+                <input
+                  type="text"
+                  value={businessName}
+                  onChange={(e) => setBusinessName(e.target.value)}
+                  className="w-full px-3 py-2.5 rounded-lg border border-gray-300 text-[#1a1a2e] focus:border-[#f5a623] focus:outline-none focus:ring-2 focus:ring-[#fef3d6]"
+                />
+              </div>
+
+              {status === 'error' && (
+                <p className="text-sm text-red-700">{t('error')}</p>
+              )}
+
+              <div className="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  className="flex-1 px-4 py-2.5 bg-white text-[#1a1a2e] border border-gray-300 rounded-lg font-semibold hover:bg-gray-50 transition-colors"
+                >
+                  {t('cancel')}
+                </button>
+                <button
+                  type="submit"
+                  disabled={sending}
+                  className="flex-1 px-4 py-2.5 bg-[#1a1a2e] text-white rounded-lg font-bold hover:bg-[#2d2d44] transition-colors disabled:opacity-50"
+                >
+                  {sending ? t('sending') : t('submit')}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Why

PR #567 was merged early — only the first commit (smart-quote interactive form) made it into main. Two follow-up commits got stranded on the closed branch and never shipped to prod. This PR brings them in, plus fixes a pre-existing translation bug introduced by PR #568.

## What changed

**1. Tier extras now trade-agnostic** (`src/app/api/ai-quote/route.ts`)
- The Good/Better/Best tier extras were hardcoded with landscaping wording ("Detailed cleanup and hauling", "Post-service yard inspection", "Seasonal maintenance recommendations"). For a painting or plumbing quote, those read nonsensically.
- Reworded to universal phrasing: "Thorough cleanup and debris removal", "Post-service walkthrough with you", "Free touch-up if needed", "Maintenance recommendations to keep results lasting".

**2. Personalized-demo lead capture on the 14 remaining demos** (`src/components/demo/DemoLeadCapture.tsx` + each demo page)
- New reusable button + modal component (name, email, optional phone, optional business name).
- Inserted into all 14 demos that lacked a lead-capture path: booking, chatbot, dashboard, dispatch, estimator, invoicing, phone-receptionist, quickbooks, reviews, route-optimization, scheduling, shield, website, worker.
- Each demo passes a unique `source` tag (e.g. `dashboard_demo`, `chatbot_demo`) so sales can filter the `leads` table by which feature drew the prospect in.
- Posts to the existing `/api/website-builder/leads` endpoint (already supports anonymous leads from PR #567).

**3. Missing i18n keys** (`messages/en/demo.json`, `messages/es/demo.json`)
- PR #568 added `t('backToHome')` to demo pages but forgot the translation keys for the booking and reviews namespaces — those pages are currently throwing `MISSING_MESSAGE` errors when prerendered. Adds the keys in en and es.

## Quality gates

- `npm run build` — clean (the only remaining MISSING_MESSAGE is unrelated: `misc.jenny.womenOwned`)
- `npm test` — 430/430 passing
- `npm run lint` — no new warnings

## Verification after merge

On `tooltimepro.com/demo/smart-quote/`, generate a painting quote — the Better/Best tier extras should read "Thorough cleanup and debris removal" / "Post-service walkthrough" / "touch-up if needed" instead of the old yard/hauling wording. On any other demo (e.g. `/demo/dashboard`, `/demo/dispatch`), a "Get a personalized demo" button should appear before the existing CTA.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABYFWnvoLJYRCThdS1NTgG)_