### PR TITLE
feat: New Invoice button on customer card + payment methods pointer in Integrations

### DIFF
--- a/src/app/dashboard/customers/page.tsx
+++ b/src/app/dashboard/customers/page.tsx
@@ -294,6 +294,12 @@ export default function CustomersPage() {
                 >
                   New Quote
                 </Link>
+                <Link
+                  href={`/dashboard/invoices?customer=${customer.id}&new=1`}
+                  className="flex-1 text-center py-2 text-sm bg-green-100 text-green-700 rounded-lg hover:bg-green-200"
+                >
+                  New Invoice
+                </Link>
               </div>
             </div>
           ))}

--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, Suspense } from 'react'
 import { supabase } from '@/lib/supabase'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuth } from '@/contexts/AuthContext'
 
 type PaymentTerms = 'due_on_receipt' | 'net_15' | 'net_30' | 'net_60'
@@ -49,6 +49,14 @@ interface Invoice {
 }
 
 export default function InvoicesPage() {
+  return (
+    <Suspense fallback={<div className="flex items-center justify-center min-h-screen"><div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" /></div>}>
+      <InvoicesContent />
+    </Suspense>
+  )
+}
+
+function InvoicesContent() {
   const [invoices, setInvoices] = useState<Invoice[]>([])
   const [customers, setCustomers] = useState<InvoiceCustomer[]>([])
   const [loading, setLoading] = useState(true)
@@ -57,6 +65,9 @@ export default function InvoicesPage() {
   const [editingInvoice, setEditingInvoice] = useState<Invoice | null>(null)
 
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const presetCustomerId = searchParams.get('customer')
+  const shouldOpenNew = searchParams.get('new') === '1'
   const { user, dbUser, company, isLoading: authLoading } = useAuth()
 
   // Get company_id from AuthContext
@@ -150,6 +161,14 @@ export default function InvoicesPage() {
       fetchInvoices(companyId)
     }
   }, [filter, companyId, fetchInvoices])
+
+  // Auto-open the "New Invoice" modal when arriving from a customer card link
+  useEffect(() => {
+    if (shouldOpenNew && presetCustomerId && customers.length > 0 && !showModal) {
+      setEditingInvoice(null)
+      setShowModal(true)
+    }
+  }, [shouldOpenNew, presetCustomerId, customers.length, showModal])
 
   const updateInvoiceStatus = async (invoiceId: string, newStatus: string) => {
     try {
@@ -592,9 +611,14 @@ export default function InvoicesPage() {
           invoice={editingInvoice}
           companyId={companyId!}
           customers={customers}
-          onClose={() => setShowModal(false)}
+          presetCustomerId={editingInvoice ? null : presetCustomerId}
+          onClose={() => {
+            setShowModal(false)
+            if (shouldOpenNew) router.replace('/dashboard/invoices')
+          }}
           onSave={() => {
             setShowModal(false)
+            if (shouldOpenNew) router.replace('/dashboard/invoices')
             if (companyId) fetchInvoices(companyId)
           }}
           onSaveAndSend={async (invoiceId: string) => {
@@ -637,14 +661,30 @@ const STATE_TAX_RATES: Record<string, number> = {
   WA: 6.5, WV: 6, WI: 5, WY: 4,
 }
 
-function InvoiceModal({ invoice, companyId, customers, onClose, onSave, onSaveAndSend }: {
+function InvoiceModal({ invoice, companyId, customers, presetCustomerId, onClose, onSave, onSaveAndSend }: {
   invoice: Invoice | null
   companyId: string
   customers: InvoiceCustomer[]
+  presetCustomerId?: string | null
   onClose: () => void
   onSave: () => void
   onSaveAndSend?: (invoiceId: string) => void
 }) {
+  const presetCustomer = presetCustomerId ? customers.find(c => c.id === presetCustomerId) : undefined
+  const initialTaxRate =
+    invoice?.tax_rate != null ? String(invoice.tax_rate) :
+    presetCustomer?.state && STATE_TAX_RATES[presetCustomer.state.toUpperCase()] !== undefined
+      ? String(STATE_TAX_RATES[presetCustomer.state.toUpperCase()])
+      : '0'
+  const initialTerms: PaymentTerms | '' =
+    (invoice?.payment_terms as PaymentTerms | undefined) ||
+    (presetCustomer?.customer_type === 'commercial' ? 'net_30' : '')
+  const initialDueDate =
+    invoice?.due_date ||
+    (initialTerms
+      ? new Date(Date.now() + (PAYMENT_TERMS_OPTIONS.find(o => o.value === initialTerms)?.days ?? 30) * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+      : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0])
+
   const [formData, setFormData] = useState<{
     customer_id: string
     notes: string
@@ -653,12 +693,12 @@ function InvoiceModal({ invoice, companyId, customers, onClose, onSave, onSaveAn
     po_number: string
     payment_terms: PaymentTerms | ''
   }>({
-    customer_id: invoice?.customer_id || '',
+    customer_id: invoice?.customer_id || presetCustomerId || '',
     notes: invoice?.notes || '',
-    due_date: invoice?.due_date || new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-    tax_rate: invoice?.tax_rate ? String(invoice.tax_rate) : '0',
+    due_date: initialDueDate,
+    tax_rate: initialTaxRate,
     po_number: invoice?.po_number || '',
-    payment_terms: (invoice?.payment_terms as PaymentTerms | undefined) || '',
+    payment_terms: initialTerms,
   })
   const [items, setItems] = useState<{ description: string; quantity: number; unit_price: number }[]>(
     invoice?.items?.map(i => ({ description: i.description, quantity: i.quantity, unit_price: i.unit_price })) ||

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1007,6 +1007,22 @@ function SettingsContent() {
 
           {/* Stripe Payments Integration */}
           <StripeConnectCard />
+
+          {/* Other payment methods note */}
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mt-4">
+            <p className="text-sm text-blue-900">
+              <span className="font-semibold">Want to offer Zelle, Venmo, Cash App, check, or other payment options?</span>{' '}
+              Stripe is just for credit-card payments. To add other payment methods that show up on your invoices, go to{' '}
+              <button
+                type="button"
+                onClick={() => setActiveTab('account')}
+                className="underline font-medium hover:text-blue-700"
+              >
+                Settings → Account
+              </button>{' '}
+              and scroll down to <span className="font-medium">Payment Methods</span>.
+            </p>
+          </div>
         </div>
       )}
 

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -264,6 +264,7 @@ Complete list of ToolTime Pro API endpoints, auto-generated from source code.
 | `/api/website-builder/create-site` | `POST` | `src/app/api/website-builder/create-site/route.js` |
 | `/api/website-builder/delete-site` | `DELETE` | `src/app/api/website-builder/delete-site/route.js` |
 | `/api/website-builder/domain-register` | `GET` `POST` | `src/app/api/website-builder/domain-register/route.js` |
+| `/api/website-builder/health` | `GET` | `src/app/api/website-builder/health/route.js` |
 | `/api/website-builder/leads` | `POST` | `src/app/api/website-builder/leads/route.js` |
 | `/api/website-builder/public-site` | `GET` | `src/app/api/website-builder/public-site/route.js` |
 | `/api/website-builder/publish-status` | `GET` | `src/app/api/website-builder/publish-status/route.js` |
@@ -279,6 +280,6 @@ Complete list of ToolTime Pro API endpoints, auto-generated from source code.
 
 ---
 
-> **Total endpoints:** 93 routes across 35 groups
+> **Total endpoints:** 94 routes across 35 groups
 
 _Last generated: 2026-05-31_


### PR DESCRIPTION
## Summary

Two small follow-ups on the commercial customer work:

1. **"New Invoice" button on every customer card** (alongside View Jobs and New Quote). Clicking it goes to `/dashboard/invoices?customer=<id>&new=1`, which:
   - Auto-opens the invoice modal
   - Pre-selects the customer
   - Pre-fills tax rate from the customer's state
   - Defaults payment terms to Net 30 if the customer is commercial
   - Cleans the URL on close/save

2. **Pointer note in Settings → Integrations** explaining Stripe is just for credit cards, and pointing users to `Settings → Account → Payment Methods` for Zelle, Venmo, Cash App, check, and other non-Stripe options. Includes a clickable link that jumps to the Account tab.

## Test plan (on sandbox)

- [ ] Customers page → any customer card now has 3 buttons: View Jobs, New Quote, **New Invoice** (green)
- [ ] Click **New Invoice** on Qualys → lands on invoices page with modal already open, Qualys selected, Net 30 + due date populated
- [ ] Cancel → URL cleans up to `/dashboard/invoices` (no leftover query params)
- [ ] Click **New Invoice** on a residential customer → modal opens with that customer selected, no Net 30 default
- [ ] Settings → Integrations → scroll past Stripe → see the blue callout about Zelle/Venmo/Check
- [ ] Click the "Settings → Account" link in the callout → jumps to the Account tab
- [ ] Existing direct "+ New Invoice" flow from the invoices page still works unchanged

https://claude.ai/code/session_01UwuGFNSk9cN9ATKk46bXnR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwuGFNSk9cN9ATKk46bXnR)_