### PR TITLE
promote: sandbox → main (health endpoint fix + migration 037)

### DIFF
--- a/database/migrations/037_website_builder_service_role_grants.sql
+++ b/database/migrations/037_website_builder_service_role_grants.sql
@@ -1,0 +1,38 @@
+-- ============================================
+-- Migration: 037_website_builder_service_role_grants.sql
+-- ============================================
+-- Why this exists
+--
+-- Migration 003 created the website_builder tables with RLS enabled and
+-- per-row policies tied to auth.uid(). It assumed Supabase's default
+-- privileges would automatically extend table grants to service_role.
+-- That assumption breaks when a table is created by a role that isn't
+-- covered by the project's ALTER DEFAULT PRIVILEGES (e.g. when running
+-- DDL via the Supabase SQL Editor instead of via the migration tooling).
+--
+-- Symptom: the backend, connecting with SUPABASE_SERVICE_ROLE_KEY, gets
+-- "permission denied for table website_sites" (Postgres 42501) even
+-- though the JWT verifies and PostgREST routes it correctly as
+-- service_role. The role is valid; the role just has zero grants on
+-- these tables.
+--
+-- This migration is idempotent — re-running it is safe.
+-- ============================================
+
+GRANT ALL ON TABLE public.website_sites      TO service_role;
+GRANT ALL ON TABLE public.website_leads      TO service_role;
+GRANT ALL ON TABLE public.website_domain_log TO service_role;
+GRANT ALL ON TABLE public.website_templates  TO service_role;
+
+-- Cover any sequences these tables rely on for default values.
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO service_role;
+
+-- Belt-and-suspenders: also fix default privileges going forward so any
+-- table created after this point by the postgres role gets the grants
+-- automatically. This is what stock Supabase configures by default; we
+-- restate it here so a sandbox / fresh project provisioned outside the
+-- normal flow inherits the right behavior.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT ALL ON TABLES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO service_role;

--- a/src/app/api/website-builder/health/route.js
+++ b/src/app/api/website-builder/health/route.js
@@ -54,8 +54,10 @@ export async function GET(request) {
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
+  let supabaseHost = null;
+  try { supabaseHost = supabaseUrl ? new URL(supabaseUrl).host : null; } catch { /* ignore */ }
   checks.envVars = {
-    NEXT_PUBLIC_SUPABASE_URL: supabaseUrl ? 'set' : 'MISSING',
+    NEXT_PUBLIC_SUPABASE_URL: supabaseUrl ? `set (host: ${supabaseHost})` : 'MISSING',
     SUPABASE_SERVICE_ROLE_KEY: serviceKey ? `set (${shortKey(serviceKey)})` : 'MISSING',
     NEXT_PUBLIC_SUPABASE_ANON_KEY: anonKey ? `set (${shortKey(anonKey)})` : 'MISSING',
     NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV || '(unset)',
@@ -97,6 +99,41 @@ export async function GET(request) {
 
   // 3. Live database connectivity — read against website_sites
   if (supabaseUrl && serviceKey) {
+    // 3a. Raw HTTP probe so we see the actual PostgREST status / body
+    try {
+      const probe = await fetch(`${supabaseUrl}/rest/v1/website_sites?select=id&limit=1`, {
+        headers: {
+          apikey: serviceKey,
+          Authorization: `Bearer ${serviceKey}`,
+        },
+      });
+      const probeBody = await probe.text();
+      let parsedBody = null;
+      try { parsedBody = JSON.parse(probeBody); } catch { /* keep as text */ }
+      checks.postgrestProbe = {
+        status: probe.status,
+        statusText: probe.statusText,
+        body: parsedBody || probeBody.slice(0, 500),
+        headers: {
+          contentType: probe.headers.get('content-type'),
+          wwwAuthenticate: probe.headers.get('www-authenticate'),
+        },
+      };
+      if (probe.status === 401) {
+        diagnoses.push('PostgREST returned 401. JWT was rejected — most likely the Supabase project JWT secret was rotated after this key was issued, OR the key is from a different project than the URL.');
+      } else if (probe.status === 403) {
+        diagnoses.push('PostgREST returned 403. Role lacks permission on website_sites.');
+      } else if (probe.status === 404) {
+        diagnoses.push('PostgREST returned 404. The Supabase project URL may be wrong, or the website_sites table does not exist.');
+      } else if (probe.status >= 500) {
+        diagnoses.push(`PostgREST returned ${probe.status}. Supabase is unhealthy or misconfigured.`);
+      }
+    } catch (err) {
+      checks.postgrestProbe = { status: 'FAIL', error: err.message };
+      diagnoses.push(`Network error reaching PostgREST: ${err.message}`);
+    }
+
+    // 3b. supabase-js client path — same query, fuller error object
     try {
       const supabase = createClient(supabaseUrl, serviceKey, {
         auth: { autoRefreshToken: false, persistSession: false },
@@ -105,20 +142,23 @@ export async function GET(request) {
         .from('website_sites')
         .select('id', { count: 'exact', head: true });
       if (readError) {
-        checks.websiteSitesRead = { status: 'FAIL', code: readError.code, message: readError.message };
+        // Dump every enumerable field so we don't lose info to undefined codes
+        const dump = {};
+        for (const k of Object.keys(readError)) dump[k] = readError[k];
+        checks.websiteSitesRead = { status: 'FAIL', errorObject: dump };
         if (readError.code === '42501') {
           diagnoses.push('SELECT on website_sites was denied. Confirms the SUPABASE_SERVICE_ROLE_KEY is not actually a service-role key for this project.');
         } else if (readError.code === '42P01') {
           diagnoses.push('Table website_sites does not exist in this Supabase project. Migrations have not been applied.');
         } else {
-          diagnoses.push(`Unexpected error reading website_sites: ${readError.message}`);
+          diagnoses.push(`supabase-js error reading website_sites — code=${readError.code || '(none)'} message=${readError.message || '(empty)'}`);
         }
       } else {
         checks.websiteSitesRead = { status: 'OK', count };
       }
     } catch (err) {
       checks.websiteSitesRead = { status: 'FAIL', error: err.message };
-      diagnoses.push(`Could not reach Supabase: ${err.message}`);
+      diagnoses.push(`Could not reach Supabase via supabase-js: ${err.message}`);
     }
   } else {
     checks.websiteSitesRead = 'skipped (env vars missing)';

--- a/src/app/api/website-builder/health/route.js
+++ b/src/app/api/website-builder/health/route.js
@@ -25,6 +25,56 @@ function decodeJwtPayload(token) {
   }
 }
 
+// Supabase issues two key formats in the wild:
+//   1. Legacy JWT format ("eyJhbG…") — encodes role/ref/iss in the payload.
+//   2. New opaque format (sb_secret_… for service role, sb_publishable_… for
+//      anon) introduced in late 2025. These don't encode the project ref.
+// Both work with @supabase/supabase-js and PostgREST. This describer figures
+// out which format a key is in and whether it matches the expected role.
+function describeKey(key, expectedRole) {
+  if (!key) return { format: 'MISSING', valid: false };
+  if (key.startsWith('sb_secret_')) {
+    return {
+      format: 'sb_secret (new opaque)',
+      role: 'service_role',
+      valid: expectedRole === 'service_role',
+      note: expectedRole !== 'service_role'
+        ? `Expected ${expectedRole} key but got a service_role (sb_secret_*) key.`
+        : null,
+    };
+  }
+  if (key.startsWith('sb_publishable_')) {
+    return {
+      format: 'sb_publishable (new opaque)',
+      role: 'anon/publishable',
+      valid: expectedRole === 'anon',
+      note: expectedRole !== 'anon'
+        ? `Expected ${expectedRole} key but got an anon/publishable (sb_publishable_*) key. This will get "permission denied" on any write.`
+        : null,
+    };
+  }
+  if (key.startsWith('eyJ')) {
+    const payload = decodeJwtPayload(key);
+    if (!payload) return { format: 'malformed jwt', valid: false, note: 'Key starts with eyJ but does not parse as a JWT.' };
+    return {
+      format: 'jwt (legacy)',
+      role: payload.role || '(none)',
+      ref: payload.ref || '(none)',
+      iss: payload.iss || '(none)',
+      exp: payload.exp ? new Date(payload.exp * 1000).toISOString() : '(none)',
+      valid: payload.role === expectedRole,
+      note: payload.role !== expectedRole
+        ? `JWT has role="${payload.role}", expected "${expectedRole}". This is the most common cause of "permission denied for table" errors.`
+        : null,
+    };
+  }
+  return {
+    format: 'unknown',
+    valid: false,
+    note: 'Key does not match any known Supabase format. Expected sb_secret_*, sb_publishable_*, or eyJ… (JWT).',
+  };
+}
+
 function shortKey(key) {
   if (!key) return null;
   if (key.length <= 12) return '***';
@@ -67,34 +117,22 @@ export async function GET(request) {
   if (!supabaseUrl) diagnoses.push('NEXT_PUBLIC_SUPABASE_URL is missing.');
   if (!serviceKey) diagnoses.push('SUPABASE_SERVICE_ROLE_KEY is missing.');
 
-  // 2. JWT decode — verify the service-role key really is a service-role key
-  if (serviceKey) {
-    const payload = decodeJwtPayload(serviceKey);
-    if (!payload) {
-      checks.serviceRoleKeyShape = 'not a valid JWT';
-      diagnoses.push('SUPABASE_SERVICE_ROLE_KEY is not a valid JWT. Did someone paste a random string?');
-    } else {
-      checks.serviceRoleKeyShape = {
-        role: payload.role || '(none)',
-        ref: payload.ref || '(none)',
-        iss: payload.iss || '(none)',
-        exp: payload.exp ? new Date(payload.exp * 1000).toISOString() : '(none)',
-      };
-      if (payload.role !== 'service_role') {
-        diagnoses.push(`SUPABASE_SERVICE_ROLE_KEY has role="${payload.role}" — should be "service_role". This is the most common cause of "permission denied for table" errors.`);
-      }
-    }
+  // 2. Key format + role check (works for both legacy JWT and new opaque keys)
+  const serviceKeyInfo = describeKey(serviceKey, 'service_role');
+  const anonKeyInfo = describeKey(anonKey, 'anon');
+  checks.serviceRoleKeyShape = serviceKeyInfo;
+  checks.anonKeyShape = anonKeyInfo;
+  if (serviceKeyInfo.note) diagnoses.push(`SERVICE_ROLE_KEY: ${serviceKeyInfo.note}`);
+  if (anonKeyInfo.note) diagnoses.push(`ANON_KEY: ${anonKeyInfo.note}`);
 
-    // Sanity check: anon and service-role keys should belong to the same Supabase project
-    const anonPayload = anonKey ? decodeJwtPayload(anonKey) : null;
-    if (anonPayload && payload && anonPayload.ref !== payload.ref) {
-      diagnoses.push(`Anon key project ref (${anonPayload.ref}) does not match service-role key project ref (${payload.ref}). One of the env vars is from the wrong Supabase project.`);
-    }
-
-    // Sanity check: the supabase URL should reference the same project ref as the keys
-    if (supabaseUrl && payload?.ref && !supabaseUrl.includes(payload.ref)) {
-      diagnoses.push(`NEXT_PUBLIC_SUPABASE_URL (${supabaseUrl}) does not contain the service-role key project ref (${payload.ref}). URL is pointing at a different Supabase project than the keys.`);
-    }
+  // Cross-project checks only meaningful for legacy JWT keys (the new opaque
+  // format doesn't expose the project ref). The PostgREST probe below
+  // catches mismatches end-to-end anyway via a real round-trip.
+  if (serviceKeyInfo.format === 'jwt (legacy)' && anonKeyInfo.format === 'jwt (legacy)' && serviceKeyInfo.ref !== anonKeyInfo.ref) {
+    diagnoses.push(`Anon key project ref (${anonKeyInfo.ref}) does not match service-role key project ref (${serviceKeyInfo.ref}). One env var is from the wrong Supabase project.`);
+  }
+  if (serviceKeyInfo.format === 'jwt (legacy)' && supabaseUrl && !supabaseUrl.includes(serviceKeyInfo.ref)) {
+    diagnoses.push(`NEXT_PUBLIC_SUPABASE_URL (host: ${supabaseHost}) does not contain the service-role key project ref (${serviceKeyInfo.ref}). URL is pointing at a different Supabase project than the keys.`);
   }
 
   // 3. Live database connectivity — read against website_sites

--- a/src/app/dashboard/customers/page.tsx
+++ b/src/app/dashboard/customers/page.tsx
@@ -294,6 +294,12 @@ export default function CustomersPage() {
                 >
                   New Quote
                 </Link>
+                <Link
+                  href={`/dashboard/invoices?customer=${customer.id}&new=1`}
+                  className="flex-1 text-center py-2 text-sm bg-green-100 text-green-700 rounded-lg hover:bg-green-200"
+                >
+                  New Invoice
+                </Link>
               </div>
             </div>
           ))}

--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, Suspense } from 'react'
 import { supabase } from '@/lib/supabase'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuth } from '@/contexts/AuthContext'
 
 type PaymentTerms = 'due_on_receipt' | 'net_15' | 'net_30' | 'net_60'
@@ -49,6 +49,14 @@ interface Invoice {
 }
 
 export default function InvoicesPage() {
+  return (
+    <Suspense fallback={<div className="flex items-center justify-center min-h-screen"><div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" /></div>}>
+      <InvoicesContent />
+    </Suspense>
+  )
+}
+
+function InvoicesContent() {
   const [invoices, setInvoices] = useState<Invoice[]>([])
   const [customers, setCustomers] = useState<InvoiceCustomer[]>([])
   const [loading, setLoading] = useState(true)
@@ -57,6 +65,9 @@ export default function InvoicesPage() {
   const [editingInvoice, setEditingInvoice] = useState<Invoice | null>(null)
 
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const presetCustomerId = searchParams.get('customer')
+  const shouldOpenNew = searchParams.get('new') === '1'
   const { user, dbUser, company, isLoading: authLoading } = useAuth()
 
   // Get company_id from AuthContext
@@ -150,6 +161,14 @@ export default function InvoicesPage() {
       fetchInvoices(companyId)
     }
   }, [filter, companyId, fetchInvoices])
+
+  // Auto-open the "New Invoice" modal when arriving from a customer card link
+  useEffect(() => {
+    if (shouldOpenNew && presetCustomerId && customers.length > 0 && !showModal) {
+      setEditingInvoice(null)
+      setShowModal(true)
+    }
+  }, [shouldOpenNew, presetCustomerId, customers.length, showModal])
 
   const updateInvoiceStatus = async (invoiceId: string, newStatus: string) => {
     try {
@@ -592,9 +611,14 @@ export default function InvoicesPage() {
           invoice={editingInvoice}
           companyId={companyId!}
           customers={customers}
-          onClose={() => setShowModal(false)}
+          presetCustomerId={editingInvoice ? null : presetCustomerId}
+          onClose={() => {
+            setShowModal(false)
+            if (shouldOpenNew) router.replace('/dashboard/invoices')
+          }}
           onSave={() => {
             setShowModal(false)
+            if (shouldOpenNew) router.replace('/dashboard/invoices')
             if (companyId) fetchInvoices(companyId)
           }}
           onSaveAndSend={async (invoiceId: string) => {
@@ -637,14 +661,30 @@ const STATE_TAX_RATES: Record<string, number> = {
   WA: 6.5, WV: 6, WI: 5, WY: 4,
 }
 
-function InvoiceModal({ invoice, companyId, customers, onClose, onSave, onSaveAndSend }: {
+function InvoiceModal({ invoice, companyId, customers, presetCustomerId, onClose, onSave, onSaveAndSend }: {
   invoice: Invoice | null
   companyId: string
   customers: InvoiceCustomer[]
+  presetCustomerId?: string | null
   onClose: () => void
   onSave: () => void
   onSaveAndSend?: (invoiceId: string) => void
 }) {
+  const presetCustomer = presetCustomerId ? customers.find(c => c.id === presetCustomerId) : undefined
+  const initialTaxRate =
+    invoice?.tax_rate != null ? String(invoice.tax_rate) :
+    presetCustomer?.state && STATE_TAX_RATES[presetCustomer.state.toUpperCase()] !== undefined
+      ? String(STATE_TAX_RATES[presetCustomer.state.toUpperCase()])
+      : '0'
+  const initialTerms: PaymentTerms | '' =
+    (invoice?.payment_terms as PaymentTerms | undefined) ||
+    (presetCustomer?.customer_type === 'commercial' ? 'net_30' : '')
+  const initialDueDate =
+    invoice?.due_date ||
+    (initialTerms
+      ? new Date(Date.now() + (PAYMENT_TERMS_OPTIONS.find(o => o.value === initialTerms)?.days ?? 30) * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+      : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0])
+
   const [formData, setFormData] = useState<{
     customer_id: string
     notes: string
@@ -653,12 +693,12 @@ function InvoiceModal({ invoice, companyId, customers, onClose, onSave, onSaveAn
     po_number: string
     payment_terms: PaymentTerms | ''
   }>({
-    customer_id: invoice?.customer_id || '',
+    customer_id: invoice?.customer_id || presetCustomerId || '',
     notes: invoice?.notes || '',
-    due_date: invoice?.due_date || new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-    tax_rate: invoice?.tax_rate ? String(invoice.tax_rate) : '0',
+    due_date: initialDueDate,
+    tax_rate: initialTaxRate,
     po_number: invoice?.po_number || '',
-    payment_terms: (invoice?.payment_terms as PaymentTerms | undefined) || '',
+    payment_terms: initialTerms,
   })
   const [items, setItems] = useState<{ description: string; quantity: number; unit_price: number }[]>(
     invoice?.items?.map(i => ({ description: i.description, quantity: i.quantity, unit_price: i.unit_price })) ||

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1007,6 +1007,22 @@ function SettingsContent() {
 
           {/* Stripe Payments Integration */}
           <StripeConnectCard />
+
+          {/* Other payment methods note */}
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mt-4">
+            <p className="text-sm text-blue-900">
+              <span className="font-semibold">Want to offer Zelle, Venmo, Cash App, check, or other payment options?</span>{' '}
+              Stripe is just for credit-card payments. To add other payment methods that show up on your invoices, go to{' '}
+              <button
+                type="button"
+                onClick={() => setActiveTab('account')}
+                className="underline font-medium hover:text-blue-700"
+              >
+                Settings → Account
+              </button>{' '}
+              and scroll down to <span className="font-medium">Payment Methods</span>.
+            </p>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
Promotes the post-#572 sandbox work to prod:

- **Health endpoint now recognizes Supabase's new opaque key format** (`sb_secret_*` / `sb_publishable_*`). Prod is on the new format and was incorrectly flagged as "not a valid JWT" by the previous version. Prod's Supabase is actually healthy — the diagnostic was wrong.
- **Migration `037_website_builder_service_role_grants.sql`** — idempotent SQL that explicitly grants `service_role` on the website-builder tables and pins default privileges going forward. On prod this is a no-op safety net (prod was already correctly granted — proven by the live health check showing `count: 3`). On any future Supabase project that gets provisioned from migrations, it prevents the sandbox bug from happening at all.
- Unrelated: PR #573 ("New invoice from customer card") was merged into sandbox earlier; that ships along too.

## After merging

1. Wait for the prod Netlify deploy to finish.
2. Hit `https://<prod-domain>/api/website-builder/health/?token=<HEALTH_CHECK_TOKEN>` — should report `ok: true` with `serviceRoleKeyShape.format: "sb_secret (new opaque)"`.
3. Optionally run `database/migrations/037_…` in the prod Supabase SQL Editor for extra peace of mind (it's a no-op if grants were already correct).

## Test plan

- [x] `npm run build` passes on sandbox HEAD
- [x] Sandbox health endpoint returned `ok: true` after grants fix
- [ ] Prod health endpoint returns `ok: true` post-merge with the new key-format diagnosis


---
_Generated by [Claude Code](https://claude.ai/code/session_012jTkmt64AiutMQFQDZ7J19)_