### PR TITLE
fix(invoice): hide Pay Now when company hasn't connected Stripe

### DIFF
--- a/src/app/invoice/[id]/InvoiceViewClient.tsx
+++ b/src/app/invoice/[id]/InvoiceViewClient.tsx
@@ -413,8 +413,10 @@ export default function InvoiceViewClient({ params }: { params: { id: string } }
             </div>
           </div>
 
-          {/* Pay Now Button */}
-          {invoice.status !== 'paid' && balanceDue > 0 && !paymentSuccess && (
+          {/* Pay Now Button — only when the company has actually onboarded Stripe Connect.
+              Otherwise the API returns 500 and the customer hits a dead-end.
+              Customers can still pay via the alternative methods below (Zelle/Venmo/check/etc). */}
+          {invoice.status !== 'paid' && balanceDue > 0 && !paymentSuccess && invoice.company?.stripe_connect_onboarded && (
             <div className="px-6 pb-6">
               {payError && (
                 <div className="bg-red-50 border border-red-200 text-red-700 text-sm p-3 rounded-lg mb-3">


### PR DESCRIPTION
## Summary

Hides the "Pay Now" button on the public invoice view when the contractor hasn't onboarded Stripe Connect.

## Why

The button was rendering for every unpaid invoice regardless of Stripe setup. When a customer clicked it for a company that hadn't connected Stripe, `/api/invoice/pay` returned 500 (the route requires a Connect account ID to route money to) — and the customer had no path forward.

## What changes

Single-line condition added: `&& invoice.company?.stripe_connect_onboarded`.

The alternative payment methods section (Zelle, Venmo, Cash App, check, etc.) still renders regardless, so customers always have a way to pay — they just don't see a broken button anymore.

## Test plan

- [ ] Sandbox invoice for "Mint And Pink" (no Stripe Connect) → public link shows alternative payment methods, **no Pay Now button**
- [ ] Connect Stripe on Mint And Pink in test mode → public link now shows both Pay Now AND alternative methods
- [ ] Existing prod invoices where Stripe IS connected → Pay Now still renders normally

https://claude.ai/code/session_01UwuGFNSk9cN9ATKk46bXnR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwuGFNSk9cN9ATKk46bXnR)_