### PR TITLE
docs: Google Calendar OAuth setup + verification guides; privacy Limited Use disclosure

### DIFF
--- a/docs/google-calendar-oauth-setup.md
+++ b/docs/google-calendar-oauth-setup.md
@@ -1,0 +1,134 @@
+# Google Calendar Integration — Google Cloud Setup Guide
+
+This is the click-by-click guide for getting ToolTime Pro's Google Calendar
+integration approved and live. The **application code is already complete**
+(connect → callback → sync, with token refresh). Everything below is the
+**Google Cloud Console + Netlify** configuration that the code depends on.
+
+The connect route returns `"Google Calendar is not configured"` until
+`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set in Netlify — completing
+this guide is what turns the feature on.
+
+---
+
+## At a glance
+
+| Item | Value |
+| --- | --- |
+| Google API to enable | **Google Calendar API** |
+| OAuth client type | **Web application** |
+| Scope requested | `https://www.googleapis.com/auth/calendar.events` (sensitive, **not** restricted) |
+| Authorized redirect URI | `https://app.tooltimepro.com/api/google-calendar/callback` |
+| Netlify env vars | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` |
+| Verification needed? | **Yes** for production (the scope is sensitive) |
+| Security audit (CASA) needed? | **No** — `calendar.events` is sensitive but not restricted |
+| Typical review time | A few days to a few weeks |
+
+> **Why verification is not optional:** In unverified "Testing" mode you are
+> capped at 100 test users **and refresh tokens expire after 7 days**. Our sync
+> relies on a stored refresh token to keep calendars in sync in the background,
+> so an expired refresh token would silently break the feature. Publishing +
+> verifying removes both limits.
+
+---
+
+## Part 1 — Cloud Console setup (do this first)
+
+### 1. Create / select a project
+1. Go to <https://console.cloud.google.com/>.
+2. Top bar → project dropdown → **New Project**.
+3. Name it `ToolTime Pro` → **Create** → make sure it's selected.
+
+### 2. Enable the Google Calendar API
+1. Left menu → **APIs & Services → Library**.
+2. Search **Google Calendar API** → open it → **Enable**.
+
+### 3. Configure the OAuth consent screen
+1. **APIs & Services → OAuth consent screen**.
+2. User type: **External** → **Create**.
+3. Fill in **App information**:
+   - App name: `ToolTime Pro`
+   - User support email: `support@tooltimepro.com`
+   - App logo: upload the ToolTime Pro logo (required for verification).
+4. **App domain**:
+   - Application home page: `https://tooltimepro.com`
+   - Privacy policy: `https://tooltimepro.com/privacy`
+   - Terms of service: `https://tooltimepro.com/terms` (if available)
+5. **Authorized domains**: add `tooltimepro.com`.
+   *(This single domain covers `tooltimepro.com` and `app.tooltimepro.com`.)*
+6. Developer contact email: `support@tooltimepro.com`.
+7. **Save and Continue**.
+
+> ⚠️ The homepage, privacy policy, and redirect URI must all live under an
+> authorized domain you own and have verified in Google Search Console.
+> Verify `tooltimepro.com` in Search Console before submitting if you haven't.
+
+### 4. Add the scope
+1. On the **Scopes** step → **Add or Remove Scopes**.
+2. Filter for `calendar.events` and select
+   `https://www.googleapis.com/auth/calendar.events`.
+3. **Update → Save and Continue**.
+
+### 5. Add test users (for now)
+1. On the **Test users** step, add your own Google account(s) so you can test
+   end-to-end before verification completes.
+2. **Save and Continue**.
+
+### 6. Create the OAuth client credentials
+1. **APIs & Services → Credentials → Create Credentials → OAuth client ID**.
+2. Application type: **Web application**.
+3. Name: `ToolTime Pro Web`.
+4. **Authorized redirect URIs → Add URI** — paste **exactly**:
+   ```
+   https://app.tooltimepro.com/api/google-calendar/callback
+   ```
+   *(The code builds this from `NEXT_PUBLIC_APP_URL` + `/api/google-calendar/callback`.
+   If you ever change `NEXT_PUBLIC_APP_URL`, update this URI to match.)*
+5. *(Optional, for local testing)* also add
+   `http://localhost:3000/api/google-calendar/callback`.
+6. **Create**. Copy the **Client ID** and **Client secret** — you'll need them
+   in Part 2.
+
+---
+
+## Part 2 — Wire it into Netlify
+1. Netlify → ToolTime Pro site → **Site configuration → Environment variables**.
+2. Add:
+   - `GOOGLE_CLIENT_ID` = *(the Client ID from step 6)*
+   - `GOOGLE_CLIENT_SECRET` = *(the Client secret from step 6)*
+3. Confirm `NEXT_PUBLIC_APP_URL` = `https://app.tooltimepro.com` (the redirect
+   URI is derived from it).
+4. **Redeploy** the site so the new env vars take effect.
+5. Smoke test: log in → Settings → **Connect Google Calendar**. You should get
+   the Google consent screen (with an "unverified app" warning that's expected
+   pre-verification — click *Advanced → Go to ToolTime Pro* to proceed as a
+   test user). Approve, then run a sync and confirm a job appears on the calendar.
+
+---
+
+## Part 3 — Submit for verification
+1. Back on the **OAuth consent screen**, click **Publish App** → confirm
+   (moves from "Testing" to "In production").
+2. Click **Prepare for verification** and complete the form. Google will ask
+   for:
+   - A justification for the `calendar.events` scope.
+   - A short video (screen recording) showing the OAuth grant flow and how the
+     data is used in the app.
+   - Confirmation your privacy policy discloses Google data use + Limited Use.
+3. Use the ready-made answers in
+   [`google-calendar-verification-answers.md`](./google-calendar-verification-answers.md).
+4. Submit and watch `support@tooltimepro.com` for follow-ups from the Trust &
+   Safety team — replying promptly is the biggest factor in turnaround time.
+
+---
+
+## Troubleshooting
+- **"Google Calendar is not configured"** → env vars missing or site not
+  redeployed after adding them.
+- **`redirect_uri_mismatch`** → the URI in the Console doesn't byte-for-byte
+  match `${NEXT_PUBLIC_APP_URL}/api/google-calendar/callback`. Watch for a
+  trailing slash or `http` vs `https`.
+- **Refresh token stops working after ~7 days** → app is still in "Testing"
+  mode. Publish + verify (Part 3).
+- **`access_denied` on consent** → the test account isn't in the Test users
+  list (pre-verification only).

--- a/docs/google-calendar-verification-answers.md
+++ b/docs/google-calendar-verification-answers.md
@@ -1,0 +1,92 @@
+# Google OAuth Verification — Ready-to-Submit Answers
+
+Copy-paste these into the Google Cloud OAuth verification form. They are written
+to match exactly what ToolTime Pro's code actually does, which is what the Trust
+& Safety reviewers check against the demo video.
+
+---
+
+## Scope requested
+`https://www.googleapis.com/auth/calendar.events` — **one scope only.**
+(Sensitive, not restricted → standard review, no CASA security audit required.)
+
+> Do **not** request `calendar` (full), `calendar.readonly`, or any other scope.
+> Requesting more than you use is the #1 cause of rejection. The code only ever
+> calls the events endpoints with `calendar.events`.
+
+---
+
+## "Why does your app need this scope?" (scope justification)
+
+> ToolTime Pro is a field-service management platform for contractors. When a
+> user connects their Google Calendar, we use the `calendar.events` scope to
+> automatically write their scheduled jobs and appointments onto their own
+> Google Calendar as events, and to keep those events up to date. Specifically,
+> we create an event when a job is scheduled, update the event when the job's
+> time, location, or details change, and delete the event when the job is
+> cancelled. This lets contractors see their ToolTime Pro work alongside the
+> rest of their calendar. We only create and manage events that ToolTime Pro
+> itself generates; we do not read, display, or process the user's pre-existing
+> calendar events. We request `calendar.events` rather than the broader
+> `calendar` scope because we never need to manage calendar settings, sharing,
+> or other calendars — only the job events we create.
+
+## "How is the requested scope used?" (one-line summary)
+
+> Create, update, and delete the user's own job/appointment events on their
+> Google Calendar so their ToolTime Pro schedule stays in sync. No other
+> calendar data is accessed.
+
+---
+
+## Demo video checklist
+The reviewer needs a screen recording (unlisted YouTube link is fine) showing:
+
+1. The app's OAuth consent screen, including the **client ID in the URL** so
+   they can confirm it matches your project.
+2. The user clicking **Connect Google Calendar** and granting the
+   `calendar.events` scope on Google's consent screen.
+3. The app **using** the granted access — i.e. a ToolTime Pro job being synced
+   and the resulting event appearing on the Google Calendar.
+4. (Nice to have) the **Disconnect** flow that revokes access.
+
+Keep it short (60–120s) and narrate what's happening.
+
+---
+
+## Privacy policy — what reviewers verify
+Live at: **https://tooltimepro.com/privacy** (Section 5, "Google Calendar
+Integration"). It already states:
+
+- The exact scope used (`calendar.events`) and what it allows.
+- How the data is used (create/update/delete job events only).
+- That we do **not** read or store pre-existing calendar events.
+- Token storage & encryption at rest; no third-party sharing.
+- **Limited Use** disclosure citing the Google API Services User Data Policy.
+- How to revoke access (in-app Disconnect + Google account permissions page).
+
+No further privacy-policy edits should be needed for submission.
+
+---
+
+## Limited Use statement (in case the form asks for it inline)
+
+> ToolTime Pro's use and transfer of information received from Google APIs to
+> any other app will adhere to the Google API Services User Data Policy,
+> including the Limited Use requirements.
+
+---
+
+## Quick facts the form may ask for
+| Field | Answer |
+| --- | --- |
+| App name | ToolTime Pro |
+| App home page | https://tooltimepro.com |
+| Privacy policy | https://tooltimepro.com/privacy |
+| Authorized domain | tooltimepro.com |
+| Redirect URI | https://app.tooltimepro.com/api/google-calendar/callback |
+| Scopes | https://www.googleapis.com/auth/calendar.events |
+| Restricted scopes? | No (sensitive only — no CASA audit) |
+| Data accessed | Only events ToolTime Pro creates on the user's calendar |
+| Data shared with third parties? | No |
+| Support email | support@tooltimepro.com |

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -160,6 +160,19 @@ export default function PrivacyPolicyPage() {
               used exclusively to provide the calendar sync feature within ToolTime Pro.
             </p>
 
+            <h3 className="font-bold mt-4 mb-2">Limited Use Disclosure</h3>
+            <p>
+              ToolTime Pro&apos;s use and transfer of information received from Google APIs adheres to the{' '}
+              <a href="https://developers.google.com/terms/api-services-user-data-policy" className="text-[#f5a623] hover:underline" target="_blank" rel="noopener noreferrer">
+                Google API Services User Data Policy
+              </a>, including the Limited Use requirements. We do not use Google user data for serving
+              advertisements, do not transfer it to others except as necessary to provide or improve the
+              calendar sync feature (or as required by law), do not allow humans to read the data unless we
+              have your affirmative consent, it is necessary for security purposes (such as investigating
+              abuse), or it is required by law, and we do not use the data for any purpose other than
+              providing the Google Calendar integration you have requested.
+            </p>
+
             <h3 className="font-bold mt-4 mb-2">Revoking Access</h3>
             <p>
               You can disconnect Google Calendar at any time from your ToolTime Pro Settings page. When you


### PR DESCRIPTION
## Summary

Prep work for getting the Google Calendar integration approved and live. The
application code (connect → callback → sync with token refresh) was already
complete; this PR adds the Google Cloud / Netlify setup documentation and the
one privacy-policy change Google reviewers require.

## Changes

- **`docs/google-calendar-oauth-setup.md`** — click-by-click Google Cloud Console
  + Netlify setup checklist (enable Calendar API, create Web OAuth client with the
  exact redirect URI, set `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`, publish &
  verify). Includes a troubleshooting section.
- **`docs/google-calendar-verification-answers.md`** — ready-to-submit OAuth
  verification answers: scope justification for `calendar.events`, demo-video
  checklist, Limited Use statement, and a quick-facts table for the form.
- **`src/app/privacy/page.tsx`** — adds an explicit **Limited Use Disclosure**
  subsection to Section 5 (Google Calendar Integration) citing the Google API
  Services User Data Policy. Reviewers specifically check for this.

## Why this matters

`calendar.events` is a **sensitive** scope, so production use requires OAuth
verification. Without it, the app is capped at 100 test users and refresh tokens
expire after 7 days — which would silently break the stored-token background sync.
The scope is sensitive but **not restricted**, so no CASA security audit is needed.

Google verifies against `https://tooltimepro.com/privacy` (production), so this
needs to reach `main` before submitting the verification request.

## Testing

- `npm run build` passes.
- No functional code changed — docs + static privacy-page copy only.

## Notes / follow-ups (config, not code)

- Verify `tooltimepro.com` in Google Search Console before submitting.
- Register the production redirect URI `https://app.tooltimepro.com/api/google-calendar/callback` in the Google client.
- Set `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` in Netlify and redeploy (the connect route returns "not configured" until then).

https://claude.ai/code/session_01JRW1sscz9pyVPLfWZggPaL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRW1sscz9pyVPLfWZggPaL)_