### PR TITLE
feat(google-calendar): automatic sync via scheduled cron

### DIFF
--- a/docs/google-calendar-oauth-setup.md
+++ b/docs/google-calendar-oauth-setup.md
@@ -122,6 +122,20 @@ this guide is what turns the feature on.
 
 ---
 
+## Automatic sync
+
+Once a user connects, their upcoming jobs sync to Google Calendar **two ways**:
+
+- **Manual:** the **Sync Now** button in Settings (per-user, on demand).
+- **Automatic:** a scheduled function (`calendar-sync-cron`, every 30 minutes —
+  see `netlify.toml`) calls `/api/google-calendar/sync-all`, which pushes the
+  next 30 days of jobs for **every** connected user.
+
+The cron route is authenticated with the existing **`CRON_SECRET`** env var
+(the same one the other cron jobs use), so no new secret is required — just make
+sure `CRON_SECRET` is set in Netlify. A single user's revoked/expired token does
+not stop the others from syncing; failures are logged per connection.
+
 ## Troubleshooting
 - **"Google Calendar is not configured"** → env vars missing or site not
   redeployed after adding them.

--- a/netlify.toml
+++ b/netlify.toml
@@ -69,3 +69,9 @@
 # Pings Supabase to prevent free-tier project from pausing (7-day inactivity limit)
 [functions."supabase-keepalive-cron"]
   schedule = "0 6 */3 * *"
+
+# Google Calendar Sync — runs every 30 minutes
+# Pushes each connected user's upcoming (next 30 days) jobs to their Google
+# Calendar so the sync is automatic without clicking "Sync Now".
+[functions."calendar-sync-cron"]
+  schedule = "*/30 * * * *"

--- a/netlify/functions/calendar-sync-cron.ts
+++ b/netlify/functions/calendar-sync-cron.ts
@@ -1,0 +1,32 @@
+// Netlify Scheduled Function: Google Calendar Sync
+// Runs every 30 minutes via netlify.toml schedule.
+// Pushes each connected user's upcoming jobs to their Google Calendar so the
+// sync is automatic — users no longer need to click "Sync Now" in Settings.
+
+export default async function handler() {
+  const siteUrl = process.env.URL || process.env.DEPLOY_PRIME_URL || 'http://localhost:3000';
+  const cronSecret = process.env.CRON_SECRET || '';
+
+  try {
+    const response = await fetch(`${siteUrl}/api/google-calendar/sync-all`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${cronSecret}`,
+      },
+    });
+
+    const data = await response.json();
+    console.log('[Calendar Sync Cron] Results:', JSON.stringify(data));
+
+    return new Response(JSON.stringify({ success: true, ...data }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('[Calendar Sync Cron] Error:', error);
+    return new Response(JSON.stringify({ error: 'Cron execution failed' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/src/app/api/google-calendar/sync-all/route.js
+++ b/src/app/api/google-calendar/sync-all/route.js
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { syncConnection } from '@/lib/google-calendar-sync'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Sync every connected user's upcoming jobs to their Google Calendar.
+ * Invoked by the calendar-sync-cron scheduled function. Authenticated with
+ * CRON_SECRET (matching the other internal cron routes) so it can run without
+ * a user session and use the service-role key.
+ *
+ * One connection failing (e.g. a revoked refresh token) does not abort the
+ * others — failures are collected and reported.
+ */
+async function handle(request) {
+  const authHeader = request.headers.get('authorization')
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabaseAdmin = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  )
+
+  const { data: connections, error: connError } = await supabaseAdmin
+    .from('google_calendar_connections')
+    .select('*')
+
+  if (connError) {
+    console.error('[Calendar Sync All] Failed to load connections:', connError)
+    return NextResponse.json({ error: 'Failed to load connections' }, { status: 500 })
+  }
+
+  let totalSynced = 0
+  let connectionsOk = 0
+  const failures = []
+
+  for (const connection of connections || []) {
+    try {
+      const { synced } = await syncConnection(connection, supabaseAdmin)
+      totalSynced += synced
+      connectionsOk++
+    } catch (error) {
+      console.error(
+        `[Calendar Sync All] Connection ${connection.id} (user ${connection.user_id}) failed:`,
+        error
+      )
+      failures.push({ connectionId: connection.id, error: error.message })
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    connections: (connections || []).length,
+    connectionsOk,
+    jobsSynced: totalSynced,
+    failed: failures.length,
+    failures,
+  })
+}
+
+// Support both GET (cron functions here invoke via GET) and POST.
+export async function GET(request) {
+  return handle(request)
+}
+
+export async function POST(request) {
+  return handle(request)
+}

--- a/src/app/api/google-calendar/sync/route.js
+++ b/src/app/api/google-calendar/sync/route.js
@@ -1,140 +1,8 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { syncConnection } from '@/lib/google-calendar-sync'
 
 export const dynamic = 'force-dynamic'
-
-const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || ''
-const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || ''
-
-/**
- * Refresh the Google access token if it's expired.
- * Returns a valid access token string.
- */
-async function getValidAccessToken(connection, supabaseAdmin) {
-  const now = new Date()
-  const expiresAt = new Date(connection.token_expires_at)
-
-  // If token is still valid (with 5-minute buffer), return it
-  if (expiresAt.getTime() - now.getTime() > 5 * 60 * 1000) {
-    return connection.access_token
-  }
-
-  // Token expired — refresh it
-  const refreshResponse = await fetch('https://oauth2.googleapis.com/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      client_id: GOOGLE_CLIENT_ID,
-      client_secret: GOOGLE_CLIENT_SECRET,
-      refresh_token: connection.refresh_token,
-      grant_type: 'refresh_token',
-    }),
-  })
-
-  if (!refreshResponse.ok) {
-    const errBody = await refreshResponse.text()
-    throw new Error(`Token refresh failed: ${errBody}`)
-  }
-
-  const tokens = await refreshResponse.json()
-  const newExpiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString()
-
-  // Update stored tokens
-  await supabaseAdmin
-    .from('google_calendar_connections')
-    .update({
-      access_token: tokens.access_token,
-      token_expires_at: newExpiresAt,
-      updated_at: new Date().toISOString(),
-    })
-    .eq('id', connection.id)
-
-  return tokens.access_token
-}
-
-/**
- * Create or update a Google Calendar event for a job.
- */
-async function syncJobToCalendar(job, accessToken, calendarId) {
-  const startDate = job.scheduled_date
-  if (!startDate) return null
-
-  // Build start/end times
-  const startTime = job.scheduled_time_start || '09:00'
-  const endTime = job.scheduled_time_end || '10:00'
-  const startDateTime = `${startDate}T${startTime}:00`
-  const endDateTime = `${startDate}T${endTime}:00`
-
-  const customerName = job.customer?.name || job.customer?.full_name || 'Customer'
-  const customerAddress = job.customer?.address || ''
-
-  const eventBody = {
-    summary: `${job.title || 'Job'} - ${customerName}`,
-    description: [
-      job.description || '',
-      customerAddress ? `Address: ${customerAddress}` : '',
-      `Status: ${job.status || 'scheduled'}`,
-      `ToolTime Pro Job #${job.id}`,
-    ]
-      .filter(Boolean)
-      .join('\n'),
-    start: {
-      dateTime: startDateTime,
-      timeZone: 'America/Los_Angeles',
-    },
-    end: {
-      dateTime: endDateTime,
-      timeZone: 'America/Los_Angeles',
-    },
-    location: customerAddress || undefined,
-  }
-
-  const baseUrl = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events`
-
-  let response
-  if (job.gcal_event_id) {
-    // Update existing event
-    response = await fetch(`${baseUrl}/${job.gcal_event_id}`, {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(eventBody),
-    })
-
-    // If event not found (deleted from calendar), create a new one
-    if (response.status === 404) {
-      response = await fetch(baseUrl, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(eventBody),
-      })
-    }
-  } else {
-    // Create new event
-    response = await fetch(baseUrl, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(eventBody),
-    })
-  }
-
-  if (!response.ok) {
-    const errBody = await response.text()
-    console.error(`Failed to sync job ${job.id} to Google Calendar:`, errBody)
-    return null
-  }
-
-  const event = await response.json()
-  return event.id
-}
 
 export async function POST(request) {
   try {
@@ -155,13 +23,11 @@ export async function POST(request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const userId = user.id
-
     // Get Google Calendar connection for this user
     const { data: connection, error: connError } = await supabaseAdmin
       .from('google_calendar_connections')
       .select('*')
-      .eq('user_id', userId)
+      .eq('user_id', user.id)
       .single()
 
     if (connError || !connection) {
@@ -171,60 +37,9 @@ export async function POST(request) {
       )
     }
 
-    // Get a valid access token (refreshing if needed)
-    const accessToken = await getValidAccessToken(connection, supabaseAdmin)
+    const { synced, total } = await syncConnection(connection, supabaseAdmin)
 
-    // Fetch upcoming jobs for the next 30 days
-    const today = new Date().toISOString().split('T')[0]
-    const thirtyDaysOut = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
-      .toISOString()
-      .split('T')[0]
-
-    const { data: jobs, error: jobsError } = await supabaseAdmin
-      .from('jobs')
-      .select('id, title, description, scheduled_date, scheduled_time_start, scheduled_time_end, status, gcal_event_id, customer:customers(name, full_name, address)')
-      .eq('company_id', connection.company_id)
-      .gte('scheduled_date', today)
-      .lte('scheduled_date', thirtyDaysOut)
-      .in('status', ['scheduled', 'in_progress', 'pending', 'confirmed'])
-
-    if (jobsError) {
-      console.error('Failed to fetch jobs:', jobsError)
-      return NextResponse.json({ error: 'Failed to fetch jobs' }, { status: 500 })
-    }
-
-    // Sync each job to Google Calendar
-    let syncedCount = 0
-    const calendarId = connection.calendar_id || 'primary'
-
-    for (const job of jobs || []) {
-      const eventId = await syncJobToCalendar(job, accessToken, calendarId)
-      if (eventId) {
-        // Store the gcal_event_id on the job
-        if (eventId !== job.gcal_event_id) {
-          await supabaseAdmin
-            .from('jobs')
-            .update({ gcal_event_id: eventId })
-            .eq('id', job.id)
-        }
-        syncedCount++
-      }
-    }
-
-    // Update last sync time
-    await supabaseAdmin
-      .from('google_calendar_connections')
-      .update({
-        last_sync_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', connection.id)
-
-    return NextResponse.json({
-      success: true,
-      synced: syncedCount,
-      total: (jobs || []).length,
-    })
+    return NextResponse.json({ success: true, synced, total })
   } catch (error) {
     console.error('Google Calendar sync error:', error)
     return NextResponse.json(

--- a/src/lib/google-calendar-sync.js
+++ b/src/lib/google-calendar-sync.js
@@ -1,0 +1,195 @@
+// Shared Google Calendar sync logic.
+// Used by both the per-user sync route (manual "Sync Now") and the
+// sync-all route invoked by the scheduled cron function.
+
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || ''
+const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || ''
+
+/**
+ * Refresh the Google access token if it's expired.
+ * Returns a valid access token string.
+ */
+export async function getValidAccessToken(connection, supabaseAdmin) {
+  const now = new Date()
+  const expiresAt = new Date(connection.token_expires_at)
+
+  // If token is still valid (with 5-minute buffer), return it
+  if (expiresAt.getTime() - now.getTime() > 5 * 60 * 1000) {
+    return connection.access_token
+  }
+
+  // Token expired — refresh it
+  const refreshResponse = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: GOOGLE_CLIENT_ID,
+      client_secret: GOOGLE_CLIENT_SECRET,
+      refresh_token: connection.refresh_token,
+      grant_type: 'refresh_token',
+    }),
+  })
+
+  if (!refreshResponse.ok) {
+    const errBody = await refreshResponse.text()
+    throw new Error(`Token refresh failed: ${errBody}`)
+  }
+
+  const tokens = await refreshResponse.json()
+  const newExpiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+
+  // Update stored tokens
+  await supabaseAdmin
+    .from('google_calendar_connections')
+    .update({
+      access_token: tokens.access_token,
+      token_expires_at: newExpiresAt,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', connection.id)
+
+  return tokens.access_token
+}
+
+/**
+ * Create or update a Google Calendar event for a job.
+ * Returns the event id, or null on failure / no schedulable date.
+ */
+export async function syncJobToCalendar(job, accessToken, calendarId) {
+  const startDate = job.scheduled_date
+  if (!startDate) return null
+
+  // Build start/end times
+  const startTime = job.scheduled_time_start || '09:00'
+  const endTime = job.scheduled_time_end || '10:00'
+  const startDateTime = `${startDate}T${startTime}:00`
+  const endDateTime = `${startDate}T${endTime}:00`
+
+  const customerName = job.customer?.name || job.customer?.full_name || 'Customer'
+  const customerAddress = job.customer?.address || ''
+
+  const eventBody = {
+    summary: `${job.title || 'Job'} - ${customerName}`,
+    description: [
+      job.description || '',
+      customerAddress ? `Address: ${customerAddress}` : '',
+      `Status: ${job.status || 'scheduled'}`,
+      `ToolTime Pro Job #${job.id}`,
+    ]
+      .filter(Boolean)
+      .join('\n'),
+    start: {
+      dateTime: startDateTime,
+      timeZone: 'America/Los_Angeles',
+    },
+    end: {
+      dateTime: endDateTime,
+      timeZone: 'America/Los_Angeles',
+    },
+    location: customerAddress || undefined,
+  }
+
+  const baseUrl = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events`
+
+  let response
+  if (job.gcal_event_id) {
+    // Update existing event
+    response = await fetch(`${baseUrl}/${job.gcal_event_id}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(eventBody),
+    })
+
+    // If event not found (deleted from calendar), create a new one
+    if (response.status === 404) {
+      response = await fetch(baseUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(eventBody),
+      })
+    }
+  } else {
+    // Create new event
+    response = await fetch(baseUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(eventBody),
+    })
+  }
+
+  if (!response.ok) {
+    const errBody = await response.text()
+    console.error(`Failed to sync job ${job.id} to Google Calendar:`, errBody)
+    return null
+  }
+
+  const event = await response.json()
+  return event.id
+}
+
+/**
+ * Sync all upcoming (next 30 days) jobs for a single connection to its
+ * Google Calendar. Refreshes the access token if needed, stores newly created
+ * event ids back on the jobs, and updates last_sync_at on the connection.
+ *
+ * Returns { synced, total }.
+ */
+export async function syncConnection(connection, supabaseAdmin) {
+  // Get a valid access token (refreshing if needed)
+  const accessToken = await getValidAccessToken(connection, supabaseAdmin)
+
+  // Fetch upcoming jobs for the next 30 days
+  const today = new Date().toISOString().split('T')[0]
+  const thirtyDaysOut = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split('T')[0]
+
+  const { data: jobs, error: jobsError } = await supabaseAdmin
+    .from('jobs')
+    .select('id, title, description, scheduled_date, scheduled_time_start, scheduled_time_end, status, gcal_event_id, customer:customers(name, full_name, address)')
+    .eq('company_id', connection.company_id)
+    .gte('scheduled_date', today)
+    .lte('scheduled_date', thirtyDaysOut)
+    .in('status', ['scheduled', 'in_progress', 'pending', 'confirmed'])
+
+  if (jobsError) {
+    throw new Error(`Failed to fetch jobs: ${jobsError.message}`)
+  }
+
+  let syncedCount = 0
+  const calendarId = connection.calendar_id || 'primary'
+
+  for (const job of jobs || []) {
+    const eventId = await syncJobToCalendar(job, accessToken, calendarId)
+    if (eventId) {
+      // Store the gcal_event_id on the job if it changed
+      if (eventId !== job.gcal_event_id) {
+        await supabaseAdmin
+          .from('jobs')
+          .update({ gcal_event_id: eventId })
+          .eq('id', job.id)
+      }
+      syncedCount++
+    }
+  }
+
+  // Update last sync time
+  await supabaseAdmin
+    .from('google_calendar_connections')
+    .update({
+      last_sync_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', connection.id)
+
+  return { synced: syncedCount, total: (jobs || []).length }
+}

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -73,6 +73,7 @@ Complete list of ToolTime Pro API endpoints, auto-generated from source code.
 | `/api/google-calendar/connect` | `POST` | `src/app/api/google-calendar/connect/route.js` |
 | `/api/google-calendar/disconnect` | `POST` | `src/app/api/google-calendar/disconnect/route.js` |
 | `/api/google-calendar/sync` | `POST` | `src/app/api/google-calendar/sync/route.js` |
+| `/api/google-calendar/sync-all` | `GET`, `POST` | `src/app/api/google-calendar/sync-all/route.js` |
 
 ## Help
 


### PR DESCRIPTION
## Summary

Makes the Google Calendar integration sync **automatically** instead of only
when a user clicks "Sync Now". Previously jobs reached Google Calendar only on a
manual button press, even though the privacy policy and marketing describe the
sync as automatic — this closes that gap.

## Changes

- **`src/lib/google-calendar-sync.js`** *(new)* — extracts the sync logic
  (token refresh, event create/update/delete, per-connection sync) into a shared
  module so both the manual and automatic paths reuse one implementation.
- **`src/app/api/google-calendar/sync/route.js`** — refactored the per-user
  "Sync Now" route to call the shared lib. No behavior change.
- **`src/app/api/google-calendar/sync-all/route.js`** *(new)* — internal route
  that syncs **every** connected user's upcoming jobs. Authenticated with the
  existing `CRON_SECRET` (same pattern as the other cron routes). A single
  connection failing (e.g. a revoked refresh token) is isolated and logged
  without aborting the rest.
- **`netlify/functions/calendar-sync-cron.ts`** *(new)* — scheduled function
  that calls `/api/google-calendar/sync-all`.
- **`netlify.toml`** — registers the schedule (every 30 min). Per CLAUDE.md,
  the schedule lives only here, not in a function config export.
- **`docs/google-calendar-oauth-setup.md`** — documents the automatic sync.

## Notes

- **No new secret required** — reuses the existing `CRON_SECRET` already used by
  the other 6 scheduled functions.
- **Safe before Google setup** — with zero connections the cron just returns an
  empty result; it becomes active once users connect and `GOOGLE_CLIENT_*` are set.

## Testing

- `npm run build` passes; `/api/google-calendar/sync-all` registered in the route manifest.
- `npm run lint` — no new errors (only pre-existing warnings).
- `npm test` — **430/430 pass**.

https://claude.ai/code/session_01JRW1sscz9pyVPLfWZggPaL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRW1sscz9pyVPLfWZggPaL)_