### PR TITLE
Admin: grant full beta access to existing accounts by email

### DIFF
--- a/database/grant_beta_testers.sql
+++ b/database/grant_beta_testers.sql
@@ -1,0 +1,46 @@
+-- Grant full beta-tester access to specific accounts.
+--
+-- What this does (mirrors the admin "toggle_beta_tester" action in
+-- src/app/api/admin/companies/[id]/actions/route.ts):
+--   • is_beta_tester = true  -> hasFeatureAccess() returns true for EVERY
+--     feature/add-on, worker limit becomes Infinity, website page limit 99,
+--     and TrialExpiredGate always passes through (see src/lib/plan-features.ts
+--     and src/hooks/usePlanGating.ts).
+--   • plan = 'elite'         -> highest tier, so anything that reads the raw
+--     plan value also shows full access.
+--   • trial_ends_at +1 year  -> trial never expires during the beta.
+--
+-- Beta access is stored on the COMPANY, not the individual user, so we resolve
+-- each email to its company via the users table (and also match the company's
+-- own email column, in case the owner email lives there).
+--
+-- Idempotent: safe to re-run. Run in the Supabase SQL Editor (Prod project).
+
+UPDATE companies c
+SET
+  is_beta_tester  = true,
+  plan            = 'elite',
+  trial_ends_at   = now() + interval '365 days',
+  trial_starts_at = COALESCE(c.trial_starts_at, now()),
+  beta_notes      = COALESCE(c.beta_notes, 'Beta tester — granted full access')
+WHERE
+  lower(c.email) IN (
+    'missmv@gmail.com',
+    'justinkirksey@hotmail.com',
+    'sandbox-test@tooltimepro.com'
+  )
+  OR c.id IN (
+    SELECT u.company_id
+    FROM users u
+    WHERE lower(u.email) IN (
+      'missmv@gmail.com',
+      'justinkirksey@hotmail.com',
+      'sandbox-test@tooltimepro.com'
+    )
+  );
+
+-- Verify the result:
+SELECT c.id, c.name, c.email, c.plan, c.is_beta_tester, c.trial_ends_at
+FROM companies c
+WHERE c.is_beta_tester = true
+ORDER BY c.email;

--- a/src/app/admin/companies/page.tsx
+++ b/src/app/admin/companies/page.tsx
@@ -12,6 +12,7 @@ import {
   ArrowUpDown,
   Plus,
   X,
+  UserCheck,
 } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 
@@ -121,6 +122,45 @@ export default function AdminCompaniesPage() {
     }
   };
 
+  // Grant Existing (by email) modal state
+  const [showGrantModal, setShowGrantModal] = useState(false);
+  const [grantForm, setGrantForm] = useState({ email: '', beta_notes: '' });
+  const [grantLoading, setGrantLoading] = useState(false);
+  const [grantError, setGrantError] = useState('');
+  const [grantSuccess, setGrantSuccess] = useState('');
+
+  const handleGrantExisting = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setGrantLoading(true);
+    setGrantError('');
+    setGrantSuccess('');
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const res = await fetch('/api/admin/companies/grant-beta', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session?.access_token || ''}`,
+        },
+        body: JSON.stringify(grantForm),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setGrantError(data.error || 'Failed to grant access');
+        return;
+      }
+
+      setGrantSuccess(data.message || 'Access granted.');
+      setGrantForm({ email: '', beta_notes: '' });
+      fetchCompanies();
+    } catch (err) {
+      setGrantError(err instanceof Error ? err.message : 'Failed to grant access');
+    } finally {
+      setGrantLoading(false);
+    }
+  };
+
   // Debounced search
   const [searchInput, setSearchInput] = useState('');
   useEffect(() => {
@@ -154,14 +194,102 @@ export default function AdminCompaniesPage() {
           <h1 className="text-2xl font-bold text-white">Companies</h1>
           <p className="text-gray-400 mt-1">Manage all ToolTime Pro customer companies</p>
         </div>
-        <button
-          onClick={() => setShowAddModal(true)}
-          className="flex items-center gap-2 px-4 py-2.5 bg-green-600 hover:bg-green-500 text-white rounded-lg font-medium transition-colors"
-        >
-          <Plus size={18} />
-          Add Beta Tester
-        </button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setShowGrantModal(true)}
+            className="flex items-center gap-2 px-4 py-2.5 bg-purple-600 hover:bg-purple-500 text-white rounded-lg font-medium transition-colors"
+          >
+            <UserCheck size={18} />
+            Grant Existing
+          </button>
+          <button
+            onClick={() => setShowAddModal(true)}
+            className="flex items-center gap-2 px-4 py-2.5 bg-green-600 hover:bg-green-500 text-white rounded-lg font-medium transition-colors"
+          >
+            <Plus size={18} />
+            Add Beta Tester
+          </button>
+        </div>
       </div>
+
+      {/* Grant Existing (by email) Modal */}
+      {showGrantModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+          <div className="bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md mx-4 p-6">
+            <div className="flex items-center justify-between mb-6">
+              <h2 className="text-lg font-bold text-white">Grant Beta Access</h2>
+              <button
+                onClick={() => { setShowGrantModal(false); setGrantError(''); setGrantSuccess(''); }}
+                className="text-gray-400 hover:text-white transition-colors"
+              >
+                <X size={20} />
+              </button>
+            </div>
+
+            <p className="text-sm text-gray-400 mb-4">
+              Upgrade an account that has <strong>already signed up</strong> to full beta access.
+              Enter the email they registered with.
+            </p>
+
+            {grantError && (
+              <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">
+                {grantError}
+              </div>
+            )}
+            {grantSuccess && (
+              <div className="mb-4 p-3 bg-green-500/10 border border-green-500/20 rounded-lg text-green-400 text-sm">
+                {grantSuccess}
+              </div>
+            )}
+
+            <form onSubmit={handleGrantExisting} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1">Account Email *</label>
+                <input
+                  type="email"
+                  required
+                  value={grantForm.email}
+                  onChange={(e) => setGrantForm({ ...grantForm, email: e.target.value })}
+                  placeholder="e.g. someone@gmail.com"
+                  className="w-full px-3 py-2.5 bg-gray-700 border border-gray-600 rounded-lg text-gray-200 placeholder-gray-500 focus:outline-none focus:border-purple-500 focus:ring-1 focus:ring-purple-500"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1">Notes</label>
+                <textarea
+                  value={grantForm.beta_notes}
+                  onChange={(e) => setGrantForm({ ...grantForm, beta_notes: e.target.value })}
+                  placeholder="Optional notes about this beta tester..."
+                  rows={2}
+                  className="w-full px-3 py-2.5 bg-gray-700 border border-gray-600 rounded-lg text-gray-200 placeholder-gray-500 focus:outline-none focus:border-purple-500 focus:ring-1 focus:ring-purple-500 resize-none"
+                />
+              </div>
+
+              <div className="bg-purple-500/10 border border-purple-500/20 rounded-lg p-3 text-sm text-purple-300">
+                Sets <strong>Elite plan</strong>, <strong>beta tester</strong> status, all features, and a <strong>1-year trial</strong> on their existing company.
+              </div>
+
+              <div className="flex gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={() => { setShowGrantModal(false); setGrantError(''); setGrantSuccess(''); }}
+                  className="flex-1 px-4 py-2.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded-lg font-medium transition-colors"
+                >
+                  Close
+                </button>
+                <button
+                  type="submit"
+                  disabled={grantLoading}
+                  className="flex-1 px-4 py-2.5 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg font-medium transition-colors"
+                >
+                  {grantLoading ? 'Granting...' : 'Grant Access'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
 
       {/* Add Beta Tester Modal */}
       {showAddModal && (

--- a/src/app/api/admin/companies/grant-beta/route.ts
+++ b/src/app/api/admin/companies/grant-beta/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server';
+import { verifyPlatformAdmin, getAdminClient } from '@/lib/platform-admin';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/admin/companies/grant-beta
+ * Grants full beta-tester access to an EXISTING account, resolved by email.
+ *
+ * Unlike POST /api/admin/companies (which creates a brand-new company), this
+ * finds the company an already-signed-up user belongs to and upgrades it.
+ * Mirrors the "toggle_beta_tester" enable path: is_beta_tester=true,
+ * plan='elite', and a 1-year trial so access never expires during the beta.
+ *
+ * Body:
+ *   email      - the account email to grant access to (required)
+ *   beta_notes - optional note stored on the company
+ */
+export async function POST(request: Request) {
+  const admin = await verifyPlatformAdmin(request);
+  if (!admin) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+  }
+
+  try {
+    const supabase = getAdminClient();
+    const body = await request.json();
+
+    const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+    if (!email) {
+      return NextResponse.json({ error: 'Email is required' }, { status: 400 });
+    }
+
+    // Resolve the company: first by the company's own email, then by any user
+    // who signed up with this email (the user may differ from the company email).
+    let companyId: string | null = null;
+
+    const { data: byCompanyEmail } = await supabase
+      .from('companies')
+      .select('id')
+      .ilike('email', email)
+      .maybeSingle();
+
+    if (byCompanyEmail?.id) {
+      companyId = byCompanyEmail.id;
+    } else {
+      const { data: byUser } = await supabase
+        .from('users')
+        .select('company_id')
+        .ilike('email', email)
+        .not('company_id', 'is', null)
+        .maybeSingle();
+      companyId = byUser?.company_id ?? null;
+    }
+
+    if (!companyId) {
+      return NextResponse.json(
+        { error: 'No account found for this email. They must sign up first, then try again.' },
+        { status: 404 }
+      );
+    }
+
+    const { data: company, error: fetchError } = await supabase
+      .from('companies')
+      .select('*')
+      .eq('id', companyId)
+      .single();
+
+    if (fetchError || !company) {
+      return NextResponse.json({ error: 'Company not found' }, { status: 404 });
+    }
+
+    const trialEnd = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+
+    const { data: updated, error } = await supabase
+      .from('companies')
+      .update({
+        is_beta_tester: true,
+        plan: 'elite',
+        trial_ends_at: trialEnd.toISOString(),
+        trial_starts_at: company.trial_starts_at || new Date().toISOString(),
+        beta_notes: company.beta_notes || body.beta_notes || 'Beta tester — granted full access',
+      })
+      .eq('id', companyId)
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      company: updated,
+      message: `Granted full beta access to ${updated.name || email} — Elite plan, all features, 1-year trial.`,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary

Adds a way to grant **full beta-tester access to accounts that have already signed up**, resolved by email. Previously the admin console could only **create a brand-new** beta company — there was no path to upgrade an existing account.

Beta access is the single switch that unlocks everything: `is_beta_tester = true` makes `hasFeatureAccess()` return true for every feature/add-on, sets unlimited workers, 99 website pages, and bypasses the trial-expired gate (`src/lib/plan-features.ts`, `src/hooks/usePlanGating.ts`).

## Changes

- **`POST /api/admin/companies/grant-beta`** — resolves a company by its own email or by any user who signed up with the given email, then sets `is_beta_tester=true`, `plan='elite'`, and a 1-year trial. Reuses the existing platform-admin auth (`verifyPlatformAdmin`) and mirrors the "enable beta" logic from the per-company `toggle_beta_tester` action. Returns a clear 404 if no account exists for that email yet.
- **Admin → Companies UI** — adds a **"Grant Existing"** button + modal (email + optional notes) alongside the existing "Add Beta Tester" flow.
- **`database/grant_beta_testers.sql`** — idempotent SQL fallback to grant the same access directly in the Supabase SQL Editor (covers missmv@, justinkirksey@, sandbox-test@).

## Verification

- `npm run build` — passes; new route compiles at `/api/admin/companies/grant-beta`
- `npm test` — 430/430 pass
- `npm run lint` — no new errors (pre-existing warnings only)

## Notes

- An account must already exist (have a `users`/`companies` row) for the grant to find it.
- Seeing the admin console requires platform-admin access (`PLATFORM_ADMIN_EMAILS` env var or the `platform_admins` table) — beta status alone does not grant admin access.

https://claude.ai/code/session_01JpvsaJRWiSi8ffpNgjkxYu

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpvsaJRWiSi8ffpNgjkxYu)_