### PR TITLE
Keep both Prod and Sandbox Supabase projects alive in one cron run

### DIFF
--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -55,6 +55,26 @@ Site settings → Environment variables. For each variable below, set "Specific 
 
 Any var left unscoped falls through to its production value — double-check the list above covers every secret that writes to a shared external system.
 
+### Keep the sandbox Supabase from pausing
+
+Free-tier Supabase projects pause after 7 days of no real database activity. The
+`supabase-keepalive-cron` function pings **every configured project in one run**,
+so it can keep Prod and Sandbox warm together — but the sandbox only gets pinged
+if you tell it where the sandbox project lives.
+
+Add these two vars in Netlify (scope them to **production / all** — the cron runs
+in the prod deploy context, *not* the sandbox branch deploy):
+
+| Variable | Value |
+|---|---|
+| `SUPABASE_SANDBOX_URL` | sandbox project URL |
+| `SUPABASE_SANDBOX_KEY` | sandbox anon key |
+
+Without these, the cron keeps Prod alive but the sandbox project will pause after
+a week of inactivity. You can confirm both are being pinged in the Netlify
+function logs — each run logs one `Pinging production…` and one `Pinging
+sandbox…` line.
+
 ### 5. Seed Stripe test-mode products
 
 ```bash

--- a/netlify.toml
+++ b/netlify.toml
@@ -66,7 +66,9 @@
   schedule = "0 9 * * *"
 
 # Supabase Keep-Alive — runs every 3 days at 6am UTC
-# Pings Supabase to prevent free-tier project from pausing (7-day inactivity limit)
+# Pings every configured Supabase project (Prod + Sandbox) in one run with a
+# real SQL query to prevent free-tier projects from pausing (7-day inactivity
+# limit). Set SUPABASE_SANDBOX_URL / SUPABASE_SANDBOX_KEY to include sandbox.
 [functions."supabase-keepalive-cron"]
   schedule = "0 6 */3 * *"
 

--- a/netlify/functions/supabase-keepalive-cron.ts
+++ b/netlify/functions/supabase-keepalive-cron.ts
@@ -1,5 +1,5 @@
 // Netlify Scheduled Function: Supabase Keep-Alive
-// Runs an actual database query every 3 days to prevent the free-tier project
+// Runs an actual database query every 3 days to prevent free-tier projects
 // from being paused due to inactivity (Supabase pauses after 7 days).
 //
 // IMPORTANT: Supabase determines inactivity based on real database queries,
@@ -8,53 +8,54 @@
 // performs a lightweight SELECT against a real table to generate genuine
 // database activity.
 //
-// TARGETING: The keep-alive must always hit the PRODUCTION project. It is
-// deliberately decoupled from NEXT_PUBLIC_SUPABASE_URL — that var is the
-// app's runtime pointer and can drift to a Sandbox project during testing,
-// which would let Prod pause while Sandbox stays warm. Set
-// SUPABASE_KEEPALIVE_URL / SUPABASE_KEEPALIVE_KEY to pin this to Prod. If
-// those are unset it falls back to the NEXT_PUBLIC_* vars for compatibility.
+// TARGETING: This keep-alive pings EVERY configured project in a single run,
+// so both Production and Sandbox stay warm regardless of which Netlify deploy
+// context the cron happens to fire in.
+//
+//   - Production: SUPABASE_KEEPALIVE_URL / SUPABASE_KEEPALIVE_KEY
+//     (falls back to NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY
+//      for backwards compatibility). Pinning the dedicated vars keeps Prod from
+//      drifting if NEXT_PUBLIC_* is ever repointed at Sandbox during testing.
+//   - Sandbox: SUPABASE_SANDBOX_URL / SUPABASE_SANDBOX_KEY (optional — the
+//     sandbox target is simply skipped if these are unset).
 
-export default async function handler() {
-  const supabaseUrl =
-    process.env.SUPABASE_KEEPALIVE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseKey =
-    process.env.SUPABASE_KEEPALIVE_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+type Target = {
+  label: string;
+  url: string;
+  key: string;
+  source: string;
+};
 
-  if (!supabaseUrl || !supabaseKey) {
-    console.error('[Supabase Keep-Alive] Missing environment variables');
-    return new Response(JSON.stringify({ error: 'Missing Supabase config' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
+type TargetResult = {
+  label: string;
+  host: string;
+  ok: boolean;
+  status?: number;
+  error?: string;
+};
 
-  // Log which project host is actually being kept alive so the target can be
-  // verified from Netlify function logs without guessing.
-  let targetHost = supabaseUrl;
+async function pingTarget(target: Target): Promise<TargetResult> {
+  let host = target.url;
   try {
-    targetHost = new URL(supabaseUrl).host;
+    host = new URL(target.url).host;
   } catch {
     // keep raw value if it isn't a parseable URL
   }
-  const usingDedicatedTarget = Boolean(process.env.SUPABASE_KEEPALIVE_URL);
+
   console.log(
-    `[Supabase Keep-Alive] Target host: ${targetHost} (source: ${
-      usingDedicatedTarget ? 'SUPABASE_KEEPALIVE_URL' : 'NEXT_PUBLIC_SUPABASE_URL'
-    })`
+    `[Supabase Keep-Alive] Pinging ${target.label} host: ${host} (source: ${target.source})`
   );
 
   try {
     // Lightweight SELECT against a core table. This forces PostgREST to
     // execute real SQL against the database, which counts as activity.
     const response = await fetch(
-      `${supabaseUrl}/rest/v1/companies?select=id&limit=1`,
+      `${target.url}/rest/v1/companies?select=id&limit=1`,
       {
         method: 'GET',
         headers: {
-          'apikey': supabaseKey,
-          'Authorization': `Bearer ${supabaseKey}`,
+          'apikey': target.key,
+          'Authorization': `Bearer ${target.key}`,
           'Accept': 'application/json',
         },
       }
@@ -63,30 +64,79 @@ export default async function handler() {
     if (!response.ok) {
       const body = await response.text();
       console.error(
-        `[Supabase Keep-Alive] Query failed for ${targetHost}: ${response.status} ${body}`
+        `[Supabase Keep-Alive] Query failed for ${target.label} (${host}): ${response.status} ${body}`
       );
-      return new Response(
-        JSON.stringify({ error: 'Keep-alive query failed', status: response.status }),
-        { status: 502, headers: { 'Content-Type': 'application/json' } }
-      );
+      return { label: target.label, host, ok: false, status: response.status };
     }
 
     console.log(
-      `[Supabase Keep-Alive] DB query OK for ${targetHost}: ${response.status}`
+      `[Supabase Keep-Alive] DB query OK for ${target.label} (${host}): ${response.status}`
     );
-
-    return new Response(
-      JSON.stringify({ success: true, status: response.status, host: targetHost }),
-      {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    return { label: target.label, host, ok: true, status: response.status };
   } catch (error) {
-    console.error('[Supabase Keep-Alive] Error:', error);
-    return new Response(JSON.stringify({ error: 'Keep-alive ping failed' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
+    console.error(
+      `[Supabase Keep-Alive] Error pinging ${target.label} (${host}):`,
+      error
+    );
+    return {
+      label: target.label,
+      host,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export default async function handler() {
+  const targets: Target[] = [];
+
+  // Production target (dedicated vars preferred, NEXT_PUBLIC_* fallback).
+  const prodUrl =
+    process.env.SUPABASE_KEEPALIVE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const prodKey =
+    process.env.SUPABASE_KEEPALIVE_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (prodUrl && prodKey) {
+    targets.push({
+      label: 'production',
+      url: prodUrl,
+      key: prodKey,
+      source: process.env.SUPABASE_KEEPALIVE_URL
+        ? 'SUPABASE_KEEPALIVE_URL'
+        : 'NEXT_PUBLIC_SUPABASE_URL',
     });
   }
+
+  // Sandbox target (optional).
+  const sandboxUrl = process.env.SUPABASE_SANDBOX_URL;
+  const sandboxKey = process.env.SUPABASE_SANDBOX_KEY;
+  if (sandboxUrl && sandboxKey) {
+    targets.push({
+      label: 'sandbox',
+      url: sandboxUrl,
+      key: sandboxKey,
+      source: 'SUPABASE_SANDBOX_URL',
+    });
+  }
+
+  if (targets.length === 0) {
+    console.error('[Supabase Keep-Alive] No targets configured');
+    return new Response(
+      JSON.stringify({ error: 'Missing Supabase config' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  const results = await Promise.all(targets.map(pingTarget));
+  const allOk = results.every((r) => r.ok);
+
+  return new Response(
+    JSON.stringify({ success: allOk, results }),
+    {
+      // 502 if any target failed so the failure surfaces in Netlify logs,
+      // but all targets are always attempted regardless of one another.
+      status: allOk ? 200 : 502,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
 }


### PR DESCRIPTION
## Why

The `supabase-keepalive-cron` function only ever pinged the **production** project, so the **sandbox** Supabase project hit its 7-day inactivity limit and paused. The keepalive was deliberately decoupled from the sandbox to protect Prod, but that left the sandbox with nothing keeping it warm.

## What changed

- **`netlify/functions/supabase-keepalive-cron.ts`** — refactored to ping **every configured project in a single run** (in parallel), instead of just one. Each target is logged separately and the run returns 502 if any target fails, while still always attempting every target.
  - **Production:** `SUPABASE_KEEPALIVE_URL` / `SUPABASE_KEEPALIVE_KEY`, falling back to `NEXT_PUBLIC_SUPABASE_*` (unchanged behavior).
  - **Sandbox:** new optional `SUPABASE_SANDBOX_URL` / `SUPABASE_SANDBOX_KEY`. Skipped silently if unset.
- **`netlify.toml`** — updated the cron comment to reflect multi-project targeting.
- **`docs/SANDBOX.md`** — added a "Keep the sandbox Supabase from pausing" section documenting the new env vars and where to scope them.

## Required env vars (set in Netlify)

`SUPABASE_SANDBOX_URL` and `SUPABASE_SANDBOX_KEY`, scoped to **all / production** contexts (the cron runs in the prod deploy context, not the sandbox branch deploy). Without these, the cron keeps only Prod alive.

## Verification

- `npm run build` ✅
- `npm test` — 430/430 ✅
- `npm run lint` ✅ (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016uPxiFJp6cRbkceB8S5jBf)_