### PR TITLE
Harden keepalive base URL to fix sandbox PGRST125 invalid-path 404

### DIFF
--- a/netlify/functions/supabase-keepalive-cron.ts
+++ b/netlify/functions/supabase-keepalive-cron.ts
@@ -34,10 +34,22 @@ type TargetResult = {
   error?: string;
 };
 
+// Normalize a configured base URL so a stray trailing slash, surrounding
+// whitespace, or an accidental "/rest/v1" suffix can't produce a malformed
+// request path (PostgREST rejects "//rest/v1/..." with a 404 PGRST125).
+function normalizeBaseUrl(raw: string): string {
+  return raw
+    .trim()
+    .replace(/\/+$/, '')        // drop trailing slash(es)
+    .replace(/\/rest\/v1$/, ''); // drop an accidental REST path suffix
+}
+
 async function pingTarget(target: Target): Promise<TargetResult> {
-  let host = target.url;
+  const baseUrl = normalizeBaseUrl(target.url);
+
+  let host = baseUrl;
   try {
-    host = new URL(target.url).host;
+    host = new URL(baseUrl).host;
   } catch {
     // keep raw value if it isn't a parseable URL
   }
@@ -50,7 +62,7 @@ async function pingTarget(target: Target): Promise<TargetResult> {
     // Lightweight SELECT against a core table. This forces PostgREST to
     // execute real SQL against the database, which counts as activity.
     const response = await fetch(
-      `${target.url}/rest/v1/companies?select=id&limit=1`,
+      `${baseUrl}/rest/v1/companies?select=id&limit=1`,
       {
         method: 'GET',
         headers: {


### PR DESCRIPTION
## Why

After wiring up the sandbox keepalive (#586), the sandbox ping returned `404 {"code":"PGRST125"}`. `PGRST125` is PostgREST's **"invalid URL path"** error — not a missing table. The `companies` table exists in the sandbox; the request *path* was malformed.

Root cause: a trailing slash (or accidental `/rest/v1` suffix) in the configured `SUPABASE_SANDBOX_URL` value produces `https://…supabase.co//rest/v1/companies`, and PostgREST rejects the double-slash path with PGRST125.

## What changed

`netlify/functions/supabase-keepalive-cron.ts` — added `normalizeBaseUrl()` which trims whitespace, strips trailing slashes, and strips an accidental `/rest/v1` suffix before building the query path. Applied to every target, so both prod and sandbox are robust to env-var formatting.

## Verification

- `npm run build` ✅

After merge + deploy, the sandbox keepalive log line should read `DB query OK for sandbox … 200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016uPxiFJp6cRbkceB8S5jBf)_