### PR TITLE
fix(sms): remove non-existent app. subdomain to match registered brand URL

### DIFF
--- a/src/app/sms/page.tsx
+++ b/src/app/sms/page.tsx
@@ -115,7 +115,7 @@ export default function SmsPage() {
                 loading="lazy"
               />
               <figcaption className="text-xs text-[#5c5c70] mt-3 text-center">
-                Account holders sign in at <strong>app.tooltimepro.com</strong> and are taken to the Dashboard.
+                Account holders sign in at <strong>tooltimepro.com</strong> and are taken to the Dashboard.
                 The <em>Settings</em> link is in the left navigation sidebar.
               </figcaption>
             </figure>


### PR DESCRIPTION
Twilio's latest rejection: *"The campaign submission has been reviewed and rejected because the provided website URL does not match the Brand and Campaign registered."*

## Root cause

The brand "Minty Pink" is registered with website `https://tooltimepro.com`. Our public-facing 2FA walk-through at `/sms#two-factor-authentication` referenced `app.tooltimepro.com` in Step 1's caption — but that subdomain doesn't exist (the production dashboard is at `tooltimepro.com/dashboard`, confirmed by the URL bar in the user's screenshots).

When the TCR reviewer visits the campaign's evidence URL and sees `app.tooltimepro.com` referenced, the automated/manual check flags the mismatch against the registered brand URL.

## Fix

`src/app/sms/page.tsx` Step 1 caption: `app.tooltimepro.com` → `tooltimepro.com`.

## Not changed (intentional)

API route fallback defaults (`portal/route.ts`, `quickbooks/*/route.ts`, `google-calendar/*/route.js`, `jenny-actions/route.ts`) still default to `https://app.tooltimepro.com` when env vars are unset. These are server-side internals used for OAuth callbacks and portal links — not visible to TCR reviewers, and touching them risks breaking integrations.

Also not changed: `tooltimepro/index.html` (static marketing HTML — not deployed; the Next.js app serves the apex).

## After merge

The public walk-through references only `tooltimepro.com` everywhere reviewers will look. Brand URL match check should clear.

User should also remove any `app.` reference from their Twilio consent description text before resubmitting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vata9Ccd4x4uduWEuGyhWc)_