### PR TITLE
Fix job deletion silently failing due to RLS

### DIFF
--- a/src/app/api/jobs/delete/route.ts
+++ b/src/app/api/jobs/delete/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const log: string[] = []
+  try {
+    const body = await request.json()
+    const { jobId } = body
+    log.push(`Received: jobId=${jobId}`)
+
+    if (!jobId) {
+      return NextResponse.json({ error: 'Missing jobId', log }, { status: 400 })
+    }
+
+    const authHeader = request.headers.get('Authorization')
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: 'No auth token provided', log }, { status: 401 })
+    }
+
+    const token = authHeader.replace('Bearer ', '')
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      return NextResponse.json({ error: 'Server env vars not configured', log }, { status: 500 })
+    }
+
+    const adminClient = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+
+    // Verify caller identity
+    const { data: authData, error: authError } = await adminClient.auth.getUser(token)
+    if (authError || !authData?.user) {
+      log.push(`Auth error: ${authError?.message || 'no user returned'}`)
+      return NextResponse.json({ error: 'Invalid auth token', log }, { status: 401 })
+    }
+    const callerId = authData.user.id
+
+    // Verify company membership
+    const { data: callerProfile, error: profileError } = await adminClient
+      .from('users')
+      .select('id, company_id')
+      .eq('id', callerId)
+      .single()
+
+    if (profileError || !callerProfile?.company_id) {
+      log.push(`Profile error: ${profileError?.message || 'no profile found'}`)
+      return NextResponse.json({ error: 'User profile not found in database', log }, { status: 403 })
+    }
+
+    // Verify job exists and belongs to caller's company
+    const { data: existingJob, error: fetchJobErr } = await adminClient
+      .from('jobs')
+      .select('id, company_id')
+      .eq('id', jobId)
+      .single()
+
+    if (fetchJobErr || !existingJob) {
+      log.push(`Fetch job error: ${fetchJobErr?.message || 'not found'}`)
+      return NextResponse.json({ error: 'Job not found', log }, { status: 404 })
+    }
+
+    if (existingJob.company_id !== callerProfile.company_id) {
+      return NextResponse.json({ error: 'Job belongs to another company', log }, { status: 403 })
+    }
+
+    // Delete the job (related rows cascade via ON DELETE CASCADE / SET NULL)
+    const { error: deleteError } = await adminClient
+      .from('jobs')
+      .delete()
+      .eq('id', jobId)
+
+    if (deleteError) {
+      log.push(`Delete job error: ${deleteError.message} (code: ${deleteError.code})`)
+      return NextResponse.json(
+        { error: 'Failed to delete job', details: deleteError.message, log },
+        { status: 500 }
+      )
+    }
+
+    log.push(`Job deleted: ${jobId}`)
+    return NextResponse.json({ success: true, jobId, log })
+  } catch (err) {
+    log.push(`Exception: ${err instanceof Error ? err.message : String(err)}`)
+    return NextResponse.json(
+      { error: 'Unexpected server error', details: err instanceof Error ? err.message : 'Unknown', log },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/dashboard/jobs/page.tsx
+++ b/src/app/dashboard/jobs/page.tsx
@@ -202,11 +202,55 @@ function JobsContent() {
       return
     }
 
-    const { error } = await supabase.from('jobs').delete().eq('id', jobId)
+    // ---------- ATTEMPT 1: Server-side API (bypasses RLS) ----------
+    try {
+      const { data: { session } } = await supabase.auth.getSession()
+      const token = session?.access_token
+
+      if (token) {
+        const res = await fetch('/api/jobs/delete', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ jobId }),
+        })
+
+        const result = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+
+        if (res.ok && result.success) {
+          if (companyId) fetchJobs(companyId)
+          return
+        }
+
+        console.error('[deleteJob] API failed:', result.error, result.details, 'Log:', result.log)
+      }
+    } catch (apiErr) {
+      console.warn('[deleteJob] API unreachable:', apiErr, '- falling back to direct delete')
+    }
+
+    // ---------- ATTEMPT 2: Direct Supabase client fallback ----------
+    // A DELETE blocked by RLS affects 0 rows but returns NO error, so verify
+    // the row is actually gone before treating it as a success.
+    const { data: deleted, error } = await supabase
+      .from('jobs')
+      .delete()
+      .eq('id', jobId)
+      .select('id')
+
     if (error) {
-      alert('Failed to delete job. Please try again.')
+      console.error('[deleteJob] Direct delete failed:', error)
+      alert(`Failed to delete job: ${error.message}`)
       return
     }
+
+    if (!deleted || deleted.length === 0) {
+      console.error('[deleteJob] Direct delete removed 0 rows (likely blocked by RLS)')
+      alert('Could not delete this job — it may be blocked by a database security policy. Please contact support.')
+      return
+    }
+
     if (companyId) fetchJobs(companyId)
   }
 


### PR DESCRIPTION
## Problem

Deleting a job from the Jobs page did nothing — no error, the job just stayed. The delete handler called Supabase directly from the client:

```js
const { error } = await supabase.from('jobs').delete().eq('id', jobId)
```

Under Supabase **row-level security**, a `DELETE` that matches no rows returns **no error** — it simply deletes nothing. The `jobs` RLS policy is:

```sql
FOR ALL USING (company_id = (SELECT company_id FROM users WHERE id = auth.uid()))
```

When that subquery doesn't resolve for the client session, the delete affects 0 rows, `error` is `null`, the "Failed to delete" alert never fires, and the row remains — exactly the reported symptom. This is the same RLS limitation that's why job **save** and **list** already route through a server-side admin client.

## Fix

1. **New route `src/app/api/jobs/delete/route.ts`** — mirrors the existing `/api/jobs/save` pattern: verifies the caller's token, confirms the job belongs to their company, then deletes via the service-role client (which RLS doesn't block). Related rows clean up through the existing `ON DELETE CASCADE` foreign keys.
2. **Updated `deleteJob`** in `src/app/dashboard/jobs/page.tsx` to call the API first, with a direct-delete fallback that now uses `.select('id')` to detect a 0-row (RLS-blocked) delete and surface a clear error instead of silently doing nothing.

## Verification
- `npm run build` ✅ (`/api/jobs/delete` present in route manifest)
- `npm test` ✅ 430/430 pass
- `npm run lint` ✅ no new errors

The same fix has also been pushed to the `sandbox` branch for testing in the sandbox environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHXnXXG3tNA1Mm5STvHg6z)_