### PR TITLE
Surface real job-delete API error instead of masking it

### DIFF
--- a/src/app/dashboard/jobs/page.tsx
+++ b/src/app/dashboard/jobs/page.tsx
@@ -203,6 +203,9 @@ function JobsContent() {
     }
 
     // ---------- ATTEMPT 1: Server-side API (bypasses RLS) ----------
+    // The direct client delete cannot succeed under RLS, so the server-side
+    // admin route is the real path. If it RESPONDS with an error we surface
+    // that error verbatim — falling back to the client would only hide it.
     try {
       const { data: { session } } = await supabase.auth.getSession()
       const token = session?.access_token
@@ -224,13 +227,17 @@ function JobsContent() {
           return
         }
 
+        // The API answered but couldn't delete — show the real reason.
         console.error('[deleteJob] API failed:', result.error, result.details, 'Log:', result.log)
+        alert(`Could not delete job: ${result.error || `HTTP ${res.status}`}${result.details ? `\n\nDetails: ${result.details}` : ''}`)
+        return
       }
     } catch (apiErr) {
       console.warn('[deleteJob] API unreachable:', apiErr, '- falling back to direct delete')
     }
 
     // ---------- ATTEMPT 2: Direct Supabase client fallback ----------
+    // Only reached when the API was unreachable or there was no session token.
     // A DELETE blocked by RLS affects 0 rows but returns NO error, so verify
     // the row is actually gone before treating it as a success.
     const { data: deleted, error } = await supabase


### PR DESCRIPTION
## Follow-up to #590

Deleting a job in production still failed, showing "Could not delete this job — it may be blocked by a database security policy." That message comes from the **fallback** path added in #590: it means the server-side `/api/jobs/delete` call did **not** succeed, so the code fell through to a direct client delete (which RLS always blocks) and the real API error was hidden in the console.

## Change

`deleteJob` now surfaces the actual server-side error verbatim instead of masking it:
- If `/api/jobs/delete` **responds** with an error, show `result.error` (+ `details`) in the alert and stop — no pointless fallback to a client delete that can't succeed under RLS.
- The direct-delete fallback now runs **only** when the API is genuinely unreachable or there's no session token.

This converts the opaque "blocked by security policy" message into the precise cause (e.g. missing `SUPABASE_SERVICE_ROLE_KEY`, auth failure, FK/trigger error) so we can fix the actual root issue.

## Verification
- `npm run build` ✅
- `npm test` ✅ 430/430
- Also pushed to `sandbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHXnXXG3tNA1Mm5STvHg6z)_