### PR TITLE
Fix off-by-one date on Jobs list (UTC parsing)

### DIFF
--- a/src/app/dashboard/jobs/page.tsx
+++ b/src/app/dashboard/jobs/page.tsx
@@ -377,7 +377,7 @@ function JobsContent() {
                   </td>
                   <td className="px-6 py-4">
                     <p className="text-sm text-gray-900">
-                      {job.scheduled_date ? new Date(job.scheduled_date).toLocaleDateString() : 'Unscheduled'}
+                      {job.scheduled_date ? new Date(job.scheduled_date + 'T00:00:00').toLocaleDateString() : 'Unscheduled'}
                     </p>
                     <p className="text-sm text-gray-500">
                       {job.scheduled_time_start || ''} {job.scheduled_time_end ? `- ${job.scheduled_time_end}` : ''}


### PR DESCRIPTION
## Problem

On the Jobs list, a job scheduled for **6/19** displayed as **6/18**, but the Edit screen showed **6/19** correctly.

## Cause

The list rendered the date with `new Date(job.scheduled_date)`. `scheduled_date` is a bare `YYYY-MM-DD` string, which JS parses as **UTC midnight**; `.toLocaleDateString()` then converts to the user's local timezone (behind UTC), shifting the displayed date back one day. The Edit screen binds the raw string into a date input, so it showed the correct day — hence the mismatch.

## Fix

Append `'T00:00:00'` so the value parses as **local** midnight:

```js
new Date(job.scheduled_date + 'T00:00:00').toLocaleDateString()
```

This matches the convention already used elsewhere in the app (`OverdueJobsAlert`, `booking`, `recurring-jobs`).

## Verification
- `npm run build` ✅
- `npm test` ✅ 430/430
- Also going to `sandbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHXnXXG3tNA1Mm5STvHg6z)_