### PR TITLE
Fix off-by-one date on customer portal pages (UTC parsing)

### DIFF
--- a/src/app/portal/appointments/page.tsx
+++ b/src/app/portal/appointments/page.tsx
@@ -133,7 +133,7 @@ export default function PortalAppointments() {
                 <div className="mt-3 space-y-1.5">
                   <div className="flex items-center gap-2 text-sm text-gray-600">
                     <Calendar className="w-4 h-4 text-gray-400" />
-                    {new Date(job.scheduled_date).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}
+                    {new Date(job.scheduled_date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}
                   </div>
                   {job.scheduled_time_start && (
                     <div className="flex items-center gap-2 text-sm text-gray-600">
@@ -174,7 +174,7 @@ export default function PortalAppointments() {
                 <div>
                   <p className="font-medium text-gray-800 text-sm">{job.title}</p>
                   <p className="text-xs text-gray-400">
-                    {new Date(job.scheduled_date).toLocaleDateString()}
+                    {new Date(job.scheduled_date + 'T00:00:00').toLocaleDateString()}
                   </p>
                 </div>
                 <div className="flex items-center gap-3">
@@ -209,7 +209,7 @@ export default function PortalAppointments() {
                 </div>
 
                 <p className="text-sm text-gray-500 mb-4">
-                  {t('rescheduleDescription')} <strong>{rescheduleJob.title}</strong> ({t('rescheduleCurrently', { date: new Date(rescheduleJob.scheduled_date).toLocaleDateString() })}).
+                  {t('rescheduleDescription')} <strong>{rescheduleJob.title}</strong> ({t('rescheduleCurrently', { date: new Date(rescheduleJob.scheduled_date + 'T00:00:00').toLocaleDateString() })}).
                 </p>
 
                 <div className="space-y-3">

--- a/src/app/portal/history/page.tsx
+++ b/src/app/portal/history/page.tsx
@@ -65,7 +65,7 @@ export default function PortalHistory() {
   // Group by year
   const grouped = new Map<string, HistoryJob[]>();
   for (const job of filtered) {
-    const year = new Date(job.scheduled_date).getFullYear().toString();
+    const year = new Date(job.scheduled_date + 'T00:00:00').getFullYear().toString();
     const list = grouped.get(year) || [];
     list.push(job);
     grouped.set(year, list);
@@ -169,7 +169,7 @@ export default function PortalHistory() {
                           <div className="flex items-center gap-3 mt-2">
                             <span className="text-xs text-gray-400 flex items-center gap-1">
                               <Calendar className="w-3 h-3" />
-                              {new Date(job.scheduled_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                              {new Date(job.scheduled_date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
                             </span>
                             <span className={`px-2 py-0.5 rounded text-xs font-medium ${config.color}`}>
                               {config.label}

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -101,7 +101,7 @@ export default function PortalDashboard() {
               <div className="flex-1">
                 <p className="font-medium text-gray-900">{job.title}</p>
                 <p className="text-sm text-gray-500">
-                  {new Date(job.scheduled_date).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+                  {new Date(job.scheduled_date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
                   {job.scheduled_time_start && ` at ${job.scheduled_time_start}`}
                 </p>
               </div>

--- a/src/app/portal/photos/page.tsx
+++ b/src/app/portal/photos/page.tsx
@@ -93,7 +93,7 @@ export default function PortalPhotos() {
                     <div className="flex items-center gap-2 mt-1">
                       <Calendar className="w-3.5 h-3.5 text-gray-400" />
                       <span className="text-xs text-gray-500">
-                        {new Date(job.scheduled_date).toLocaleDateString()}
+                        {new Date(job.scheduled_date + 'T00:00:00').toLocaleDateString()}
                       </span>
                       <span className="text-xs text-gray-400">{job.photos.length} {t('photos')}</span>
                     </div>

--- a/src/app/portal/tracker/page.tsx
+++ b/src/app/portal/tracker/page.tsx
@@ -104,7 +104,7 @@ export default function PortalTracker() {
                   <div className="mt-4 space-y-2">
                     <div className="flex items-center gap-2 text-sm text-gray-600">
                       <Calendar className="w-4 h-4 text-gray-400" />
-                      {new Date(job.scheduled_date).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
+                      {new Date(job.scheduled_date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
                       {job.scheduled_time_start && ` at ${job.scheduled_time_start}`}
                       {job.scheduled_time_end && ` — ${job.scheduled_time_end}`}
                     </div>


### PR DESCRIPTION
## Follow-up to #593

Applies the same UTC off-by-one date fix to the **customer portal** pages. They rendered `scheduled_date` with `new Date(job.scheduled_date)`, which parses a bare `YYYY-MM-DD` as UTC midnight and shifts the displayed day back one for users behind UTC.

## Changed

Appended `'T00:00:00'` (local-midnight parse) in:
- `portal/page.tsx` — upcoming appointment date
- `portal/appointments/page.tsx` — upcoming + past dates, reschedule modal
- `portal/tracker/page.tsx` — scheduled date
- `portal/photos/page.tsx` — job date
- `portal/history/page.tsx` — displayed date **and** the year used for grouping (so a Jan 1 job no longer lands in the prior year)

## Verification
- `npm run build` ✅
- `npm test` ✅ 430/430
- Also pushed to `sandbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHXnXXG3tNA1Mm5STvHg6z)_