### PR TITLE
Prevent caching of job list API responses

### DIFF
--- a/src/app/api/jobs/list/route.ts
+++ b/src/app/api/jobs/list/route.ts
@@ -3,6 +3,12 @@ import { createClient } from '@supabase/supabase-js'
 
 export const dynamic = 'force-dynamic'
 
+// Prevent the browser/CDN from caching list responses. Because the "All" tab
+// and the status tabs hit different URLs (e.g. `/api/jobs/list` vs
+// `/api/jobs/list?filter=scheduled`), a cached empty "All" response would make
+// newly created jobs appear under a status tab but not under "All".
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store, max-age=0' }
+
 export async function GET(request: NextRequest) {
   try {
     const authHeader = request.headers.get('Authorization')
@@ -69,7 +75,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (!jobs || jobs.length === 0) {
-      return NextResponse.json({ jobs: [] })
+      return NextResponse.json({ jobs: [] }, { headers: NO_STORE_HEADERS })
     }
 
     // Fetch ALL assignments for these jobs separately (avoids any PostgREST join issues)
@@ -105,7 +111,7 @@ export async function GET(request: NextRequest) {
         .map(a => ({ user: { id: a.user_id, full_name: userMap[a.user_id] || 'Unknown' } })),
     }))
 
-    return NextResponse.json({ jobs: jobsWithAssignments })
+    return NextResponse.json({ jobs: jobsWithAssignments }, { headers: NO_STORE_HEADERS })
   } catch (err) {
     return NextResponse.json(
       { error: 'Unexpected error', details: err instanceof Error ? err.message : 'Unknown' },

--- a/src/app/dashboard/jobs/page.tsx
+++ b/src/app/dashboard/jobs/page.tsx
@@ -71,6 +71,7 @@ function JobsContent() {
 
                 const res = await fetch(`/api/jobs/list${qs ? `?${qs}` : ''}`, {
           headers: { Authorization: `Bearer ${token}` },
+          cache: 'no-store',
         })
 
         if (res.ok) {


### PR DESCRIPTION
## Summary
Fixes a caching issue where empty job list responses were being cached, causing newly created jobs to appear under status-filtered tabs but not under the "All" tab.

## Key Changes
- Added `NO_STORE_HEADERS` constant to the jobs list API route with `Cache-Control: no-store, max-age=0`
- Applied these headers to both empty and populated job list responses in the API route
- Added `cache: 'no-store'` option to the fetch call in the jobs dashboard page to prevent client-side caching

## Implementation Details
The issue occurred because the "All" tab and status-filtered tabs hit different URLs (e.g., `/api/jobs/list` vs `/api/jobs/list?filter=scheduled`). When an empty "All" response was cached by the browser/CDN, newly created jobs would appear under their respective status tabs but not in the "All" view. By explicitly disabling caching on both the server (via response headers) and client (via fetch options), each request now fetches fresh data.

https://claude.ai/code/session_014Xqk5k74GxnJ5fhibkyXcn