### PR TITLE
Fix job_assignments RLS policy rejecting worker assignment inserts

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -654,7 +654,14 @@ CREATE POLICY "Invoices belong to company" ON invoices
 
 -- Job assignments: users can manage assignments for jobs in their company
 CREATE POLICY "Job assignments for company jobs" ON job_assignments
-    FOR ALL USING (
+    FOR ALL
+    USING (
+        job_id IN (
+            SELECT j.id FROM jobs j
+            WHERE j.company_id = (SELECT company_id FROM users WHERE id = auth.uid())
+        )
+    )
+    WITH CHECK (
         job_id IN (
             SELECT j.id FROM jobs j
             WHERE j.company_id = (SELECT company_id FROM users WHERE id = auth.uid())

--- a/supabase/migrations/20260620000000_fix_job_assignments_rls.sql
+++ b/supabase/migrations/20260620000000_fix_job_assignments_rls.sql
@@ -1,0 +1,25 @@
+-- Migration: Fix job_assignments RLS policy for INSERT operations
+-- The existing FOR ALL USING(...) policy fails on INSERT because
+-- it lacks an explicit WITH CHECK clause. In Postgres, INSERT/UPDATE
+-- rows are validated against WITH CHECK; when it is absent on a
+-- permissive FOR ALL policy, the new row is rejected with:
+--   "new row violates row-level security policy for table job_assignments"
+-- Adding WITH CHECK ensures new rows are validated against the same
+-- company-ownership check used for reads (mirrors the invoice_items fix).
+
+DROP POLICY IF EXISTS "Job assignments for company jobs" ON job_assignments;
+
+CREATE POLICY "Job assignments for company jobs" ON job_assignments
+    FOR ALL
+    USING (
+        job_id IN (
+            SELECT j.id FROM jobs j
+            WHERE j.company_id = (SELECT company_id FROM users WHERE id = auth.uid())
+        )
+    )
+    WITH CHECK (
+        job_id IN (
+            SELECT j.id FROM jobs j
+            WHERE j.company_id = (SELECT company_id FROM users WHERE id = auth.uid())
+        )
+    );


### PR DESCRIPTION
## Problem

Saving a job with an assigned worker failed with:

> Job saved but worker assignment failed: new row violates row-level security policy for table "job_assignments"

The job itself saved, but the worker assignment was rejected by the database.

## Root cause

The `"Job assignments for company jobs"` RLS policy was defined as `FOR ALL` with a `USING` clause but **no `WITH CHECK` clause**. In Postgres, INSERT/UPDATE rows are validated against `WITH CHECK`; when it's absent on a permissive `FOR ALL` policy, every insert is rejected. This is the identical bug previously fixed for `invoice_items` (`supabase/migrations/20260411000001_fix_invoice_items_rls.sql`).

## Fix

Add a matching `WITH CHECK` clause so new rows are validated against the same company-ownership check used for reads:

- **New migration** `supabase/migrations/20260620000000_fix_job_assignments_rls.sql` — drops and recreates the policy with both `USING` and `WITH CHECK` (fixes existing databases).
- **`database/schema.sql`** — updated the canonical policy so fresh setups are correct.

No data is touched — only the access policy is swapped.

## Testing

- Migration SQL run and verified in the sandbox Supabase project; assigning a worker to a job now saves without the RLS error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HU3S1RZc94uYPSWgQD45xn)_