### PR TITLE
Fix Route Optimizer geocoding for incomplete/whitespace addresses

### DIFF
--- a/src/__tests__/lib/geocoding.test.ts
+++ b/src/__tests__/lib/geocoding.test.ts
@@ -1,4 +1,4 @@
-import { clearGeocodeCache, seedGeocodeCache } from '@/lib/geocoding';
+import { clearGeocodeCache, seedGeocodeCache, buildAddressQuery } from '@/lib/geocoding';
 
 // We test the cache/seed functions synchronously; actual geocoding
 // requires network access, so we test the API integration logic separately.
@@ -35,6 +35,38 @@ describe('geocoding', () => {
       // After normalization: "123 main st" should match "123 main st"
       // Note: the seed normalizes too, so this should match
       expect(result).toEqual({ lat: 39.78, lng: -89.65 });
+    });
+  });
+
+  describe('buildAddressQuery', () => {
+    it('joins parts with comma + space', () => {
+      expect(buildAddressQuery('1048 Farley Ave', 'Mountain View', 'CA')).toBe(
+        '1048 Farley Ave, Mountain View, CA'
+      );
+    });
+
+    it('trims trailing/leading whitespace on each part (no stray comma spacing)', () => {
+      // Regression: a trailing space in the stored address previously produced
+      // "1048 Farley Ave , mountain view" (note the space before the comma).
+      expect(buildAddressQuery('1048 Farley Ave ', 'mountain view')).toBe(
+        '1048 Farley Ave, mountain view'
+      );
+    });
+
+    it('collapses internal whitespace', () => {
+      expect(buildAddressQuery('1048   Farley   Ave', 'Mountain  View')).toBe(
+        '1048 Farley Ave, Mountain View'
+      );
+    });
+
+    it('drops empty, whitespace-only, null, and undefined parts', () => {
+      expect(buildAddressQuery('123 Main St', '', '   ', null, undefined, 'Springfield')).toBe(
+        '123 Main St, Springfield'
+      );
+    });
+
+    it('returns an empty string when no usable parts are provided', () => {
+      expect(buildAddressQuery(null, undefined, '  ')).toBe('');
     });
   });
 

--- a/src/app/api/routes/optimize/route.ts
+++ b/src/app/api/routes/optimize/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { optimizeRoute, optimizeMultiWorkerRoutes, RoutePoint, RouteOptions } from '@/lib/route-optimization';
-import { geocodeAddress } from '@/lib/geocoding';
+import { geocodeJobAddress, buildAddressQuery } from '@/lib/geocoding';
 
 interface JobInput {
   id: string;
   address: string | null;
   city: string | null;
+  state?: string | null;
+  zip?: string | null;
   lat?: number | null;
   lng?: number | null;
   scheduledTime?: string | null;
@@ -79,19 +81,29 @@ export async function POST(request: NextRequest) {
       }
 
       if (lat == null || lng == null) {
-        const fullAddress = [job.address, job.city].filter(Boolean).join(', ');
+        const fullAddress = buildAddressQuery(job.address, job.city, job.state, job.zip);
         if (!fullAddress) {
           geocodeErrors.push(`Job ${job.id}: No address provided`);
           continue;
         }
 
-        const coords = await geocodeAddress(fullAddress);
-        if (!coords) {
+        const geocoded = await geocodeJobAddress({
+          address: job.address,
+          city: job.city,
+          state: job.state,
+          zip: job.zip,
+        });
+        if (!geocoded) {
           geocodeErrors.push(`Job ${job.id}: Could not geocode "${fullAddress}"`);
           continue;
         }
-        lat = coords.lat;
-        lng = coords.lng;
+        lat = geocoded.coords.lat;
+        lng = geocoded.coords.lng;
+        if (geocoded.approximate) {
+          geocodeErrors.push(
+            `Job ${job.id}: Used approximate location "${geocoded.query}" (could not pinpoint "${fullAddress}")`
+          );
+        }
       }
 
       points.push({

--- a/src/app/dashboard/route-optimizer/page.tsx
+++ b/src/app/dashboard/route-optimizer/page.tsx
@@ -31,6 +31,8 @@ interface RouteJob {
   title: string;
   address: string | null;
   city: string | null;
+  state: string | null;
+  zip: string | null;
   scheduled_date: string;
   scheduled_time_start: string | null;
   scheduled_time_end: string | null;
@@ -351,7 +353,7 @@ export default function RouteOptimizerPage() {
     const { data, error } = await supabase
       .from('jobs')
       .select(`
-        id, title, address, city, scheduled_date, scheduled_time_start, scheduled_time_end, status, total_amount,
+        id, title, address, city, state, zip, scheduled_date, scheduled_time_start, scheduled_time_end, status, total_amount,
         customer:customers(name),
         assigned_users:job_assignments(user:users(full_name))
       `)
@@ -393,6 +395,8 @@ export default function RouteOptimizerPage() {
             id: j.id,
             address: j.address,
             city: j.city,
+            state: j.state,
+            zip: j.zip,
             lat: j.lat,
             lng: j.lng,
             scheduledTime: j.scheduled_time_start,

--- a/src/lib/geocoding.ts
+++ b/src/lib/geocoding.ts
@@ -23,6 +23,20 @@ function normalizeAddress(address: string): string {
   return address.trim().toLowerCase().replace(/\s+/g, ' ');
 }
 
+/**
+ * Build a clean, geocodable address string from structured parts.
+ * Trims each part, drops empty/whitespace-only parts, and collapses
+ * internal whitespace so we never produce artifacts like
+ * "1048 Farley Ave , mountain view" (note the stray space before the comma)
+ * when a stored field has trailing/leading whitespace.
+ */
+export function buildAddressQuery(...parts: Array<string | null | undefined>): string {
+  return parts
+    .map((p) => (p ?? '').trim().replace(/\s+/g, ' '))
+    .filter((p) => p.length > 0)
+    .join(', ');
+}
+
 async function throttle(): Promise<void> {
   const now = Date.now();
   const elapsed = now - lastRequestTime;
@@ -96,6 +110,45 @@ export async function geocodeAddress(address: string): Promise<GeoCoordinates | 
     failureCacheTimestamps.set(key, Date.now());
     return null;
   }
+}
+
+/**
+ * Geocode a job from its structured address parts, degrading gracefully.
+ *
+ * Tries the most specific query first (street + city), then falls back to
+ * progressively coarser queries (e.g. city only). This keeps the route
+ * optimizer usable when a job has an incomplete address (missing state/zip),
+ * placing it at the city center rather than dropping it entirely.
+ *
+ * Returns the coordinates plus the query that actually resolved, and whether
+ * it was an approximate (fallback) match, so callers can surface a warning.
+ */
+export async function geocodeJobAddress(
+  parts: { address?: string | null; city?: string | null; state?: string | null; zip?: string | null }
+): Promise<{ coords: GeoCoordinates; query: string; approximate: boolean } | null> {
+  const { address, city, state, zip } = parts;
+
+  // Ordered from most to least specific. Later entries are approximate.
+  const candidates: Array<{ query: string; approximate: boolean }> = [
+    { query: buildAddressQuery(address, city, state, zip), approximate: false },
+    { query: buildAddressQuery(address, city, state), approximate: false },
+    { query: buildAddressQuery(city, state, zip), approximate: true },
+    { query: buildAddressQuery(city, state), approximate: true },
+    { query: buildAddressQuery(city), approximate: true },
+  ];
+
+  const tried = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate.query || tried.has(candidate.query)) continue;
+    tried.add(candidate.query);
+
+    const coords = await geocodeAddress(candidate.query);
+    if (coords) {
+      return { coords, query: candidate.query, approximate: candidate.approximate };
+    }
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
The Route Optimizer failed to geocode jobs like "1048 Farley Ave , mountain view" for two reasons:

1. Address parts were joined without trimming, so a trailing space in a stored field produced artifacts like "Ave , city" (stray space before the comma) that confuse the geocoder.
2. The page never sent the job's state/zip, so incomplete street addresses (no state) often failed Nominatim outright, aborting the whole run.

Changes:
- Add buildAddressQuery() to construct clean, trimmed address strings
- Add geocodeJobAddress() with graceful fallback: tries street+city+state+zip first, then degrades to city-level so a job is placed approximately rather than dropped; approximate matches are surfaced as warnings
- Select and forward state + zip from the route-optimizer page
- Add regression tests for buildAddressQuery


Claude-Session: https://claude.ai/code/session_0186e2ruMrttLk8FCKhB6zGg