### PR TITLE
fix(marketing): point dead app.tooltimepro.com links to www (fixes OAuth verification)

### DIFF
--- a/tooltimepro/index.html
+++ b/tooltimepro/index.html
@@ -1163,7 +1163,7 @@
                         <div style="display:flex;align-items:baseline;justify-content:center;gap:0.5rem;margin-bottom:0.75rem;">
                             <span style="font-size:1.5rem;font-weight:800;color:#111;">$15</span><span style="font-size:0.85rem;color:#666;">/mo</span>
                         </div>
-                        <a href="https://app.tooltimepro.com/auth/signup?plan=booking_only" style="display:inline-block;background:#f97316;color:#fff;font-weight:700;padding:0.6rem 1.5rem;border-radius:0.5rem;text-decoration:none;font-size:0.9rem;">Get Started</a>
+                        <a href="https://www.tooltimepro.com/auth/signup?plan=booking_only" style="display:inline-block;background:#f97316;color:#fff;font-weight:700;padding:0.6rem 1.5rem;border-radius:0.5rem;text-decoration:none;font-size:0.9rem;">Get Started</a>
                     </div>
                     <div style="background:#fff;border:2px solid #e5e7eb;border-radius:1rem;padding:1.75rem;text-align:center;">
                         <div style="font-size:1.75rem;margin-bottom:0.5rem;">🧾</div>
@@ -1172,7 +1172,7 @@
                         <div style="display:flex;align-items:baseline;justify-content:center;gap:0.5rem;margin-bottom:0.75rem;">
                             <span style="font-size:1.5rem;font-weight:800;color:#111;">$15</span><span style="font-size:0.85rem;color:#666;">/mo</span>
                         </div>
-                        <a href="https://app.tooltimepro.com/auth/signup?plan=invoicing_only" style="display:inline-block;background:#f97316;color:#fff;font-weight:700;padding:0.6rem 1.5rem;border-radius:0.5rem;text-decoration:none;font-size:0.9rem;">Get Started</a>
+                        <a href="https://www.tooltimepro.com/auth/signup?plan=invoicing_only" style="display:inline-block;background:#f97316;color:#fff;font-weight:700;padding:0.6rem 1.5rem;border-radius:0.5rem;text-decoration:none;font-size:0.9rem;">Get Started</a>
                     </div>
                 </div>
             </div>
@@ -1268,7 +1268,7 @@
                 <div class="footer-links"><h4>Platform</h4><a href="#jenny">Jenny AI</a><a href="#features">Features</a><a href="#demos">Demos</a><a href="#hr">HR & Compliance</a><a href="#pricing">Pricing</a></div>
                 <div class="footer-links"><h4>Try Demos</h4><a href="chatbot.html">Jenny ToolTime Assistant</a><a href="quote.html">Smart Quoting</a><a href="reviews.html">Review Machine</a><a href="dashboard.html">Dashboard</a><a href="scheduler.html">Booking</a><a href="worker.html">Worker App</a></div>
                 <div class="footer-links"><h4>More Features</h4><a href="dashboard.html">Dispatch Board</a><a href="dashboard.html">Route Optimization</a><a href="dashboard.html">QuickBooks Sync</a><a href="dashboard.html">Customer Portal Pro</a><a href="hr-compliance.html">ToolTime Shield</a><a href="website.html">Website Builder</a></div>
-                <div class="footer-links"><h4 data-i18n="footer_company">Company</h4><a href="#" data-i18n="footer_about">About Us</a><a href="#contact" data-i18n="footer_contact">Contact</a><a href="https://app.tooltimepro.com/privacy" data-i18n="footer_privacy">Privacy Policy</a><a href="https://app.tooltimepro.com/terms" data-i18n="footer_terms">Terms of Service</a></div>
+                <div class="footer-links"><h4 data-i18n="footer_company">Company</h4><a href="#" data-i18n="footer_about">About Us</a><a href="#contact" data-i18n="footer_contact">Contact</a><a href="https://www.tooltimepro.com/privacy" data-i18n="footer_privacy">Privacy Policy</a><a href="https://www.tooltimepro.com/terms" data-i18n="footer_terms">Terms of Service</a></div>
             </div>
             <div class="footer-bottom"><p data-i18n="footer_copyright">© 2026 ToolTime Pro. All rights reserved. Built with 💛 for service pros who hate software.</p></div>
         </div>
@@ -1331,7 +1331,7 @@
             });
             if (addOns.length) params.set('addons', addOns.join(','));
             window.location.href =
-                'https://app.tooltimepro.com/auth/signup?' + params.toString();
+                'https://www.tooltimepro.com/auth/signup?' + params.toString();
         }
 
         document.querySelectorAll('a[href^="#"]').forEach(a=>{a.addEventListener('click',function(e){e.preventDefault();const t=document.querySelector(this.getAttribute('href'));t&&(t.scrollIntoView({behavior:'smooth',block:'start'}),document.getElementById('navLinks').classList.remove('active'))})});


### PR DESCRIPTION
## Summary

Fixes Google OAuth verification failures and a broken signup flow caused by dead
`app.tooltimepro.com` links on the static marketing site.

## Background

Google's OAuth verification flagged two branding issues:
- *"Your home page URL does not include a link to your privacy policy."*
- *"Your privacy policy URL `https://app.tooltimepro.com/privacy` is unresponsive."*

Root cause: `app.tooltimepro.com` does not resolve (verified — HTTP 000). The live
app is at **`www.tooltimepro.com`** (`NEXT_PUBLIC_APP_URL`). The marketing site
(`tooltimepro/index.html`) still linked to the dead `app.` domain in four places:
the footer **Privacy Policy** + **Terms** links, and the two **Get Started** signup
CTAs — so the privacy link Google checks was broken, and customers clicking
"Get Started" hit a dead domain.

## Change

`tooltimepro/index.html` — replace all `https://app.tooltimepro.com` with
`https://www.tooltimepro.com` (4 occurrences).

This makes the home page link to a working privacy policy (resolving both
verification issues) and fixes the signup CTAs.

## Notes

- The Next.js app home (`src/app/page.tsx`) already links to `/privacy` correctly — no change needed there.
- After merge, the marketing site must be redeployed before re-requesting Google verification.

https://claude.ai/code/session_01JRW1sscz9pyVPLfWZggPaL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRW1sscz9pyVPLfWZggPaL)_