### PR TITLE
Skill- and certification-aware multi-worker route optimization

### DIFF
--- a/src/__tests__/lib/worker-assignment.test.ts
+++ b/src/__tests__/lib/worker-assignment.test.ts
@@ -1,0 +1,164 @@
+import {
+  isWorkerEligibleForJob,
+  assignJobsToWorkers,
+  AssignableWorker,
+  SkilledJob,
+  ServiceMeta,
+} from '@/lib/worker-assignment';
+
+const ROUTE_DATE = '2026-06-22';
+
+function services(...metas: ServiceMeta[]): Map<string, ServiceMeta> {
+  return new Map(metas.map((m) => [m.id, m]));
+}
+
+function job(id: string, lat: number, lng: number, requiredServiceId?: string | null): SkilledJob {
+  return { id, lat, lng, requiredServiceId };
+}
+
+describe('isWorkerEligibleForJob', () => {
+  const svc = services(
+    { id: 'lawn', requiresLicense: false, name: 'Lawn Mowing' },
+    { id: 'pest', requiresLicense: true, name: 'Pesticide Application' }
+  );
+
+  it('allows any worker when the job has no required service', () => {
+    const worker: AssignableWorker = { id: 'w1', capabilities: [] };
+    expect(isWorkerEligibleForJob(worker, job('j1', 0, 0, null), svc, ROUTE_DATE)).toBe(true);
+  });
+
+  it('rejects a worker who lacks the required skill', () => {
+    const worker: AssignableWorker = { id: 'w1', capabilities: [{ serviceId: 'lawn' }] };
+    expect(isWorkerEligibleForJob(worker, job('j1', 0, 0, 'pest'), svc, ROUTE_DATE)).toBe(false);
+  });
+
+  it('allows a worker with a non-licensed skill', () => {
+    const worker: AssignableWorker = { id: 'w1', capabilities: [{ serviceId: 'lawn' }] };
+    expect(isWorkerEligibleForJob(worker, job('j1', 0, 0, 'lawn'), svc, ROUTE_DATE)).toBe(true);
+  });
+
+  it('rejects a licensed job when the worker has the skill but no certification on file', () => {
+    const worker: AssignableWorker = { id: 'w1', capabilities: [{ serviceId: 'pest' }] };
+    expect(isWorkerEligibleForJob(worker, job('j1', 0, 0, 'pest'), svc, ROUTE_DATE)).toBe(false);
+  });
+
+  it('rejects a licensed job when the certification is expired', () => {
+    const worker: AssignableWorker = {
+      id: 'w1',
+      capabilities: [{ serviceId: 'pest', certExpiry: '2026-01-10' }],
+    };
+    expect(isWorkerEligibleForJob(worker, job('j1', 0, 0, 'pest'), svc, ROUTE_DATE)).toBe(false);
+  });
+
+  it('allows a licensed job when the certification is still valid', () => {
+    const worker: AssignableWorker = {
+      id: 'w1',
+      capabilities: [{ serviceId: 'pest', certExpiry: '2026-09-01' }],
+    };
+    expect(isWorkerEligibleForJob(worker, job('j1', 0, 0, 'pest'), svc, ROUTE_DATE)).toBe(true);
+  });
+
+  it('treats a certification expiring on the route date as still valid', () => {
+    const worker: AssignableWorker = {
+      id: 'w1',
+      capabilities: [{ serviceId: 'pest', certExpiry: ROUTE_DATE }],
+    };
+    expect(isWorkerEligibleForJob(worker, job('j1', 0, 0, 'pest'), svc, ROUTE_DATE)).toBe(true);
+  });
+});
+
+describe('assignJobsToWorkers', () => {
+  const svc = services(
+    { id: 'lawn', requiresLicense: false, name: 'Lawn Mowing' },
+    { id: 'pest', requiresLicense: true, name: 'Pesticide Application' }
+  );
+
+  it('routes a licensed job only to the qualified, non-expired worker', () => {
+    const maria: AssignableWorker = {
+      id: 'maria',
+      capabilities: [{ serviceId: 'lawn' }, { serviceId: 'pest', certExpiry: '2026-09-01' }],
+    };
+    const bob: AssignableWorker = {
+      id: 'bob',
+      capabilities: [{ serviceId: 'lawn' }, { serviceId: 'pest', certExpiry: '2026-01-10' }], // expired
+    };
+
+    const jobs = [job('pest1', 0, 0, 'pest'), job('lawn1', 1, 1, 'lawn')];
+    const { assignments, unassigned } = assignJobsToWorkers(jobs, [maria, bob], svc, ROUTE_DATE);
+
+    expect(unassigned).toHaveLength(0);
+    // The pesticide job must go to Maria (Bob's cert is expired).
+    expect(assignments.get('maria')!.map((j) => j.id)).toContain('pest1');
+    expect(assignments.get('bob')!.map((j) => j.id)).not.toContain('pest1');
+  });
+
+  it('flags a job no worker can cover, with a skill reason', () => {
+    const bob: AssignableWorker = { id: 'bob', capabilities: [{ serviceId: 'lawn' }] };
+    const jobs = [job('pest1', 0, 0, 'pest')];
+
+    const { unassigned } = assignJobsToWorkers(jobs, [bob], svc, ROUTE_DATE);
+
+    expect(unassigned).toHaveLength(1);
+    expect(unassigned[0].reason).toMatch(/Pesticide Application/);
+    expect(unassigned[0].reason).toMatch(/skill/i);
+  });
+
+  it('flags a license reason when workers have the skill but all certs are expired', () => {
+    const bob: AssignableWorker = {
+      id: 'bob',
+      capabilities: [{ serviceId: 'pest', certExpiry: '2026-01-10' }],
+    };
+    const jobs = [job('pest1', 0, 0, 'pest')];
+
+    const { unassigned } = assignJobsToWorkers(jobs, [bob], svc, ROUTE_DATE);
+
+    expect(unassigned).toHaveLength(1);
+    expect(unassigned[0].reason).toMatch(/certification|license/i);
+  });
+
+  it('balances unconstrained jobs across workers', () => {
+    const a: AssignableWorker = { id: 'a', capabilities: [{ serviceId: 'lawn' }] };
+    const b: AssignableWorker = { id: 'b', capabilities: [{ serviceId: 'lawn' }] };
+    const jobs = [
+      job('j1', 0, 0, 'lawn'),
+      job('j2', 0, 0, 'lawn'),
+      job('j3', 0, 0, 'lawn'),
+      job('j4', 0, 0, 'lawn'),
+    ];
+
+    const { assignments, unassigned } = assignJobsToWorkers(jobs, [a, b], svc, ROUTE_DATE);
+
+    expect(unassigned).toHaveLength(0);
+    expect(assignments.get('a')!.length).toBe(2);
+    expect(assignments.get('b')!.length).toBe(2);
+  });
+
+  it('returns all jobs as unassigned when there are no workers', () => {
+    const jobs = [job('j1', 0, 0, 'lawn'), job('j2', 0, 0, null)];
+    const { assignments, unassigned } = assignJobsToWorkers(jobs, [], svc, ROUTE_DATE);
+
+    expect(assignments.size).toBe(0);
+    expect(unassigned).toHaveLength(2);
+  });
+
+  it('prefers the geographically nearer eligible worker on ties', () => {
+    // Both qualified and equally loaded after their first job; the second
+    // lawn job near worker B's stop should go to B.
+    const a: AssignableWorker = { id: 'a', capabilities: [{ serviceId: 'lawn' }] };
+    const b: AssignableWorker = { id: 'b', capabilities: [{ serviceId: 'lawn' }] };
+    const jobs = [
+      job('far', 0, 0, 'lawn'),
+      job('nearB', 10, 10, 'lawn'),
+      job('alsoNearB', 10.01, 10.01, 'lawn'),
+    ];
+
+    const { assignments } = assignJobsToWorkers(jobs, [a, b], svc, ROUTE_DATE);
+
+    // Whichever worker took 'nearB' should also get 'alsoNearB' (proximity tie-break),
+    // and the two near jobs should land with the same worker.
+    const aIds = assignments.get('a')!.map((j) => j.id);
+    const bIds = assignments.get('b')!.map((j) => j.id);
+    const ownerOfNearB = aIds.includes('nearB') ? aIds : bIds;
+    expect(ownerOfNearB).toContain('alsoNearB');
+  });
+});

--- a/src/app/api/routes/optimize/route.ts
+++ b/src/app/api/routes/optimize/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { optimizeRoute, optimizeMultiWorkerRoutes, RoutePoint, RouteOptions } from '@/lib/route-optimization';
+import { optimizeRoute, optimizeMultiWorkerRoutes, RoutePoint, RouteOptions, OptimizedRoute } from '@/lib/route-optimization';
 import { geocodeJobAddress, buildAddressQuery } from '@/lib/geocoding';
+import {
+  assignJobsToWorkers,
+  AssignableWorker,
+  WorkerCapability,
+  ServiceMeta,
+  SkilledJob,
+} from '@/lib/worker-assignment';
 
 interface JobInput {
   id: string;
@@ -9,6 +16,7 @@ interface JobInput {
   city: string | null;
   state?: string | null;
   zip?: string | null;
+  requiredServiceId?: string | null;
   lat?: number | null;
   lng?: number | null;
   scheduledTime?: string | null;
@@ -43,6 +51,33 @@ function isValidCoordinate(lat: number, lng: number): boolean {
   );
 }
 
+/**
+ * Collapse several per-worker routes into one aggregate result shaped like a
+ * single OptimizedRoute, so the existing map / savings / route-order UI keeps
+ * working while multi-worker details are carried separately.
+ */
+function combineRoutes(routes: OptimizedRoute[]): OptimizedRoute {
+  const sum = (key: keyof OptimizedRoute) =>
+    routes.reduce((s, r) => s + (r[key] as number), 0);
+  const round1 = (n: number) => Math.round(n * 10) / 10;
+  const totalDistanceMiles = round1(sum('totalDistanceMiles'));
+  const originalDistanceMiles = round1(sum('originalDistanceMiles'));
+  const milesSaved = round1(sum('milesSaved'));
+
+  return {
+    orderedPoints: routes.flatMap((r) => r.orderedPoints),
+    totalDistanceMiles,
+    originalDistanceMiles,
+    totalDriveTimeMinutes: Math.round(sum('totalDriveTimeMinutes')),
+    originalDriveTimeMinutes: Math.round(sum('originalDriveTimeMinutes')),
+    milesSaved,
+    timeSavedMinutes: Math.round(sum('timeSavedMinutes')),
+    fuelSaved: Math.round(sum('fuelSaved') * 100) / 100,
+    percentImprovement: originalDistanceMiles > 0 ? Math.round((milesSaved / originalDistanceMiles) * 100) : 0,
+    distanceMatrix: [],
+  };
+}
+
 export async function POST(request: NextRequest) {
   try {
     // Authenticate the request
@@ -52,12 +87,18 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { jobs, startLocation, settings, workerCount } = body as {
+    const { jobs, startLocation, settings, workerCount, workers, routeDate } = body as {
       jobs: JobInput[];
       startLocation?: { lat: number; lng: number; label?: string };
       settings?: { avgSpeedMph?: number; fuelCostPerMile?: number; roadFactor?: number; timeWindowEnabled?: boolean; startTimeMinutes?: number };
       workerCount?: number;
+      workers?: { id: string; label?: string }[];
+      routeDate?: string;
     };
+
+    // Map of job id -> required service, for skill-aware assignment.
+    const requiredServiceByJob = new Map<string, string | null>();
+    for (const j of jobs || []) requiredServiceByJob.set(j.id, j.requiredServiceId ?? null);
 
     if (!jobs || !Array.isArray(jobs) || jobs.length === 0) {
       return NextResponse.json({ error: 'No jobs provided' }, { status: 400 });
@@ -150,6 +191,95 @@ export async function POST(request: NextRequest) {
       enforceTimeWindows: settings.timeWindowEnabled ?? false,
       startTimeMinutes: settings.startTimeMinutes,
     } : undefined;
+
+    // Skill-aware multi-worker mode: assign jobs to specific selected workers,
+    // honoring required skills and (for licensed services) certification expiry.
+    if (workers && workers.length > 0) {
+      const supabaseAdmin = getSupabaseAdmin();
+
+      // Resolve caller's company to scope service/skill lookups.
+      const { data: caller } = await supabaseAdmin
+        .from('users')
+        .select('company_id')
+        .eq('id', user.id)
+        .single();
+      const companyId = caller?.company_id;
+
+      // Which services require a license?
+      const servicesMeta = new Map<string, ServiceMeta>();
+      if (companyId) {
+        const { data: svc } = await supabaseAdmin
+          .from('services')
+          .select('id, name, requires_license')
+          .eq('company_id', companyId);
+        for (const s of svc || []) {
+          servicesMeta.set(s.id, { id: s.id, name: s.name, requiresLicense: s.requires_license });
+        }
+      }
+
+      // Each selected worker's capabilities.
+      const workerIds = workers.map((w) => w.id);
+      const { data: skillRows } = await supabaseAdmin
+        .from('worker_skills')
+        .select('user_id, service_id, cert_expiry')
+        .in('user_id', workerIds);
+
+      const capsByWorker = new Map<string, WorkerCapability[]>();
+      for (const w of workers) capsByWorker.set(w.id, []);
+      for (const row of skillRows || []) {
+        capsByWorker.get(row.user_id)?.push({ serviceId: row.service_id, certExpiry: row.cert_expiry });
+      }
+      const assignableWorkers: AssignableWorker[] = workers.map((w) => ({
+        id: w.id,
+        label: w.label,
+        capabilities: capsByWorker.get(w.id) || [],
+      }));
+
+      // Job points (excluding the office start) tagged with their required service.
+      const jobPoints = validStartLocation ? points.slice(1) : points;
+      const skilledJobs: SkilledJob[] = jobPoints.map((p) => ({
+        ...p,
+        requiredServiceId: requiredServiceByJob.get(p.id) ?? null,
+      }));
+
+      const routeDateStr = routeDate || new Date().toISOString().split('T')[0];
+      const { assignments, unassigned } = assignJobsToWorkers(
+        skilledJobs,
+        assignableWorkers,
+        servicesMeta,
+        routeDateStr
+      );
+
+      // Optimize each worker's assigned stops (starting from the office if given).
+      const workerRoutes = assignableWorkers
+        .map((w) => {
+          const assigned = assignments.get(w.id) || [];
+          if (assigned.length === 0) return null;
+          let routePoints: RoutePoint[] = assigned;
+          let fixedIdx: number | undefined;
+          if (validStartLocation) {
+            routePoints = [points[0], ...assigned];
+            fixedIdx = 0;
+          }
+          const r = optimizeRoute(routePoints, fixedIdx, routeOptions);
+          return { workerId: w.id, workerLabel: w.label || w.id, jobCount: assigned.length, ...r };
+        })
+        .filter((r): r is NonNullable<typeof r> => r !== null);
+
+      const combined = combineRoutes(workerRoutes);
+      const unassignedJobs = unassigned.map((u) => ({
+        id: u.job.id,
+        label: u.job.label || u.job.id,
+        reason: u.reason,
+      }));
+
+      return NextResponse.json({
+        ...combined,
+        workerRoutes,
+        unassignedJobs: unassignedJobs.length > 0 ? unassignedJobs : undefined,
+        geocodeErrors: geocodeErrors.length > 0 ? geocodeErrors : undefined,
+      });
+    }
 
     // Multi-worker mode
     if (workerCount && workerCount > 1) {

--- a/src/app/dashboard/jobs/page.tsx
+++ b/src/app/dashboard/jobs/page.tsx
@@ -20,6 +20,7 @@ interface Job {
   priority: string
   total_amount: number
   quote_id: string | null
+  required_service_id: string | null
   customer: { id: string; name: string } | null
   assigned_users: { user: { id: string; full_name: string } }[]
 }
@@ -474,8 +475,25 @@ function JobModal({ job, companyId, customers, workers, quotes, initialQuoteId, 
     priority: job?.priority || 'normal',
     price: job?.total_amount?.toString() || initialQuote?.total?.toString() || '',
     assigned_worker_id: job?.assigned_users?.[0]?.user?.id || '',
+    required_service_id: job?.required_service_id || '',
   })
+  const [services, setServices] = useState<{ id: string; name: string; requires_license: boolean }[]>([])
   const [saving, setSaving] = useState(false)
+
+  // Load the company's active services so a job can declare which skill it needs.
+  useEffect(() => {
+    let cancelled = false
+    supabase
+      .from('services')
+      .select('id, name, requires_license')
+      .eq('company_id', companyId)
+      .eq('is_active', true)
+      .order('name')
+      .then(({ data }) => {
+        if (!cancelled) setServices(data || [])
+      })
+    return () => { cancelled = true }
+  }, [companyId])
   const [errors, setErrors] = useState<{ address?: string; scheduled_date?: string; scheduled_time_start?: string }>({})
 
   const validateForm = (): boolean => {
@@ -566,6 +584,7 @@ function JobModal({ job, companyId, customers, workers, quotes, initialQuoteId, 
       scheduled_time_end: formData.scheduled_time_end || null,
       priority: formData.priority,
       total_amount: formData.price ? Number(formData.price) : null,
+      required_service_id: formData.required_service_id || null,
       company_id: companyId,
       status: job?.status || 'scheduled',
     }
@@ -871,6 +890,27 @@ function JobModal({ job, companyId, customers, workers, quotes, initialQuoteId, 
               />
             </div>
           </div>
+
+          {services.length > 0 && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Required Skill / Service</label>
+              <select
+                value={formData.required_service_id}
+                onChange={(e) => setFormData({ ...formData, required_service_id: e.target.value })}
+                className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="">Any worker (no special skill)</option>
+                {services.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}{s.requires_license ? ' (license required)' : ''}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-gray-500 mt-1">
+                The Route Optimizer will only assign this job to a worker qualified for the selected service.
+              </p>
+            </div>
+          )}
 
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>

--- a/src/app/dashboard/route-optimizer/page.tsx
+++ b/src/app/dashboard/route-optimizer/page.tsx
@@ -33,6 +33,7 @@ interface RouteJob {
   city: string | null;
   state: string | null;
   zip: string | null;
+  required_service_id: string | null;
   scheduled_date: string;
   scheduled_time_start: string | null;
   scheduled_time_end: string | null;
@@ -55,6 +56,8 @@ interface OptimizationResult {
   fuelSaved: number;
   percentImprovement: number;
   geocodeErrors?: string[];
+  workerRoutes?: Array<{ workerId: string; workerLabel: string; jobCount: number; totalDistanceMiles: number; milesSaved: number }>;
+  unassignedJobs?: Array<{ id: string; label: string; reason: string }>;
 }
 
 interface RouteSettings {
@@ -252,6 +255,8 @@ export default function RouteOptimizerPage() {
   // Multi-worker state
   const [workerCount, setWorkerCount] = useState(1);
   const [showMultiWorker, setShowMultiWorker] = useState(false);
+  const [fieldWorkers, setFieldWorkers] = useState<{ id: string; full_name: string }[]>([]);
+  const [selectedWorkerIds, setSelectedWorkerIds] = useState<string[]>([]);
 
   // Fetch settings on mount
   useEffect(() => {
@@ -353,7 +358,7 @@ export default function RouteOptimizerPage() {
     const { data, error } = await supabase
       .from('jobs')
       .select(`
-        id, title, address, city, state, zip, scheduled_date, scheduled_time_start, scheduled_time_end, status, total_amount,
+        id, title, address, city, state, zip, required_service_id, scheduled_date, scheduled_time_start, scheduled_time_end, status, total_amount,
         customer:customers(name),
         assigned_users:job_assignments(user:users(full_name))
       `)
@@ -378,6 +383,19 @@ export default function RouteOptimizerPage() {
     }
   }, [companyId, selectedDate, fetchJobs]);
 
+  // Load active field workers for skill-aware multi-worker assignment.
+  useEffect(() => {
+    if (!companyId) return;
+    supabase
+      .from('users')
+      .select('id, full_name, role')
+      .eq('company_id', companyId)
+      .eq('is_active', true)
+      .in('role', ['worker', 'worker_admin'])
+      .order('full_name')
+      .then(({ data }) => setFieldWorkers((data || []).map((w) => ({ id: w.id, full_name: w.full_name }))));
+  }, [companyId]);
+
   const handleOptimize = async () => {
     setIsOptimizing(true);
     setOptimizeError(null);
@@ -397,6 +415,7 @@ export default function RouteOptimizerPage() {
             city: j.city,
             state: j.state,
             zip: j.zip,
+            requiredServiceId: j.required_service_id,
             lat: j.lat,
             lng: j.lng,
             scheduledTime: j.scheduled_time_start,
@@ -410,7 +429,18 @@ export default function RouteOptimizerPage() {
             roadFactor: settings.road_factor,
             timeWindowEnabled: settings.time_window_enabled,
           },
-          ...(workerCount > 1 ? { workerCount } : {}),
+          routeDate: selectedDate,
+          // Skill-aware assignment when specific workers are selected;
+          // otherwise fall back to count-based geographic splitting.
+          ...(selectedWorkerIds.length > 0
+            ? {
+                workers: fieldWorkers
+                  .filter((w) => selectedWorkerIds.includes(w.id))
+                  .map((w) => ({ id: w.id, label: w.full_name })),
+              }
+            : workerCount > 1
+            ? { workerCount }
+            : {}),
           ...(settings.office_lat && settings.office_lng ? {
             startLocation: { lat: settings.office_lat, lng: settings.office_lng, label: settings.office_address || 'Office' },
           } : {}),
@@ -674,21 +704,55 @@ export default function RouteOptimizerPage() {
           <p className="text-sm text-gray-500 mb-3">
             {t('multiWorker.description')}
           </p>
-          <div className="flex items-center gap-3">
-            <label className="text-sm font-medium text-gray-700">{t('multiWorker.numberOfWorkers')}</label>
-            <input
-              type="number"
-              value={workerCount}
-              onChange={(e) => setWorkerCount(Math.max(1, Math.min(10, Number(e.target.value) || 1)))}
-              className="w-20 px-3 py-2 border rounded-lg text-center"
-              min={1}
-              max={10}
-            />
-          </div>
-          {workerCount > 1 && (
-            <p className="text-xs text-[#f5a623] mt-2 font-medium">
-              {t('multiWorker.splitNotice', { count: workerCount })}
-            </p>
+          {fieldWorkers.length > 0 ? (
+            <>
+              <p className="text-sm font-medium text-gray-700 mb-2">
+                Select who&apos;s working today — jobs are assigned by skill &amp; certification:
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {fieldWorkers.map((w) => {
+                  const checked = selectedWorkerIds.includes(w.id);
+                  return (
+                    <label
+                      key={w.id}
+                      className={`flex items-center gap-2 px-3 py-2 border rounded-lg cursor-pointer transition-colors ${
+                        checked ? 'border-[#1a1a2e] bg-gray-50' : 'border-gray-200 hover:bg-gray-50'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() =>
+                          setSelectedWorkerIds((prev) =>
+                            prev.includes(w.id) ? prev.filter((id) => id !== w.id) : [...prev, w.id]
+                          )
+                        }
+                        className="w-4 h-4"
+                      />
+                      <span className="text-sm text-gray-800">{w.full_name}</span>
+                    </label>
+                  );
+                })}
+              </div>
+              {selectedWorkerIds.length > 0 && (
+                <p className="text-xs text-[#f5a623] mt-3 font-medium">
+                  Splitting jobs across {selectedWorkerIds.length} worker{selectedWorkerIds.length !== 1 ? 's' : ''}.
+                  Jobs requiring a skill go only to qualified, certified workers — anything no one can cover is flagged below.
+                </p>
+              )}
+            </>
+          ) : (
+            <div className="flex items-center gap-3">
+              <label className="text-sm font-medium text-gray-700">{t('multiWorker.numberOfWorkers')}</label>
+              <input
+                type="number"
+                value={workerCount}
+                onChange={(e) => setWorkerCount(Math.max(1, Math.min(10, Number(e.target.value) || 1)))}
+                className="w-20 px-3 py-2 border rounded-lg text-center"
+                min={1}
+                max={10}
+              />
+            </div>
           )}
         </div>
       )}
@@ -760,6 +824,52 @@ export default function RouteOptimizerPage() {
               <li key={i}>{err}</li>
             ))}
           </ul>
+        </div>
+      )}
+
+      {/* Unassignable jobs — no qualified/certified worker available */}
+      {optimizedResult?.unassignedJobs && optimizedResult.unassignedJobs.length > 0 && (
+        <div className="mb-6 bg-red-50 border border-red-200 rounded-xl p-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
+            <div>
+              <p className="text-sm font-semibold text-red-800">
+                {optimizedResult.unassignedJobs.length} job{optimizedResult.unassignedJobs.length !== 1 ? 's' : ''} couldn&apos;t be assigned
+              </p>
+              <ul className="text-sm text-red-700 mt-1 space-y-1">
+                {optimizedResult.unassignedJobs.map((u) => (
+                  <li key={u.id}>
+                    <span className="font-medium">{u.label}</span> — {u.reason}
+                  </li>
+                ))}
+              </ul>
+              <p className="text-xs text-red-500 mt-2">
+                Assign the required skill (and a valid certification) to a worker under Team → Skills,
+                add another qualified worker to today&apos;s crew, or change the job&apos;s required service.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Per-worker route breakdown */}
+      {optimizedResult?.workerRoutes && optimizedResult.workerRoutes.length > 0 && (
+        <div className="mb-6 bg-white border border-gray-200 rounded-xl p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <Users className="w-5 h-5 text-[#1a1a2e]" />
+            <h3 className="font-semibold text-gray-900">Route assignments by worker</h3>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {optimizedResult.workerRoutes.map((wr) => (
+              <div key={wr.workerId} className="border border-gray-100 rounded-lg p-3 bg-gray-50">
+                <p className="font-medium text-gray-900">{wr.workerLabel}</p>
+                <p className="text-sm text-gray-600 mt-1">
+                  {wr.jobCount} stop{wr.jobCount !== 1 ? 's' : ''} · {wr.totalDistanceMiles} mi
+                  {wr.milesSaved > 0 && <span className="text-green-600"> · saves {wr.milesSaved} mi</span>}
+                </p>
+              </div>
+            ))}
+          </div>
         </div>
       )}
 

--- a/src/app/dashboard/services/page.tsx
+++ b/src/app/dashboard/services/page.tsx
@@ -12,6 +12,7 @@ interface Service {
   default_price: number | null
   duration_minutes: number
   is_active: boolean
+  requires_license: boolean
   created_at: string
 }
 
@@ -27,6 +28,7 @@ export default function ServicesPage() {
     price: '',
     duration_minutes: 60,
     is_active: true,
+    requires_license: false,
   })
 
   const router = useRouter()
@@ -76,6 +78,7 @@ export default function ServicesPage() {
         price: service.default_price?.toString() || '',
         duration_minutes: service.duration_minutes || 60,
         is_active: service.is_active,
+        requires_license: service.requires_license ?? false,
       })
     } else {
       setEditingService(null)
@@ -85,6 +88,7 @@ export default function ServicesPage() {
         price: '',
         duration_minutes: 60,
         is_active: true,
+        requires_license: false,
       })
     }
     setShowModal(true)
@@ -107,6 +111,7 @@ export default function ServicesPage() {
       default_price: formData.price ? parseFloat(formData.price) : null,
       duration_minutes: formData.duration_minutes,
       is_active: formData.is_active,
+      requires_license: formData.requires_license,
     }
 
     if (editingService) {
@@ -252,6 +257,11 @@ export default function ServicesPage() {
                       <p className={`font-medium ${service.is_active ? 'text-gray-900' : 'text-gray-400'}`}>
                         {service.name}
                       </p>
+                      {service.requires_license && (
+                        <span className="inline-flex items-center gap-1 mt-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                          🪪 License required
+                        </span>
+                      )}
                       {service.description && (
                         <p className="text-sm text-gray-500 truncate max-w-xs">
                           {service.description}
@@ -410,6 +420,24 @@ export default function ServicesPage() {
                   />
                   <span className="text-sm text-gray-700">
                     Active (show on booking page)
+                  </span>
+                </label>
+              </div>
+
+              <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <label className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={formData.requires_license}
+                    onChange={(e) => setFormData({ ...formData, requires_license: e.target.checked })}
+                    className="w-4 h-4 mt-0.5 text-amber-600 border-gray-300 rounded focus:ring-amber-500"
+                  />
+                  <span className="text-sm text-gray-700">
+                    <span className="font-medium">Requires a license / certification</span>
+                    <span className="block text-xs text-gray-500 mt-0.5">
+                      Only workers with a valid, non-expired certification for this service
+                      can be assigned these jobs by the Route Optimizer.
+                    </span>
                   </span>
                 </label>
               </div>

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -38,7 +38,8 @@ import {
   CheckCircle,
   Trash2,
   ShieldCheck,
-  MapPin
+  MapPin,
+  Wrench
 } from 'lucide-react'
 
 // Generate a random secure temporary password
@@ -213,6 +214,8 @@ export default function TeamPage() {
   const [editingCert, setEditingCert] = useState<WorkerCertification | null>(null)
   const [selectedWorkerForNote, setSelectedWorkerForNote] = useState<TeamMember | null>(null)
   const [selectedWorkerForCert, setSelectedWorkerForCert] = useState<TeamMember | null>(null)
+  const [showSkillsModal, setShowSkillsModal] = useState(false)
+  const [selectedWorkerForSkills, setSelectedWorkerForSkills] = useState<TeamMember | null>(null)
   const [expandedMembers, setExpandedMembers] = useState<Set<string>>(new Set())
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<TeamMember | null>(null)
   const [deleting, setDeleting] = useState(false)
@@ -675,6 +678,19 @@ export default function TeamPage() {
                             </button>
                           </>
                         )}
+                        {canManageTeam && isFieldWorker(member.role) && (
+                          <button
+                            onClick={() => {
+                              setSelectedWorkerForSkills(member)
+                              setShowSkillsModal(true)
+                            }}
+                            className="px-3 py-1.5 text-sm border border-navy-500 text-navy-600 rounded-lg hover:bg-navy-50 flex items-center gap-1 transition-colors"
+                            title="Manage which services this worker can perform"
+                          >
+                            <Wrench size={14} />
+                            Skills
+                          </button>
+                        )}
                         {canManageTeam && (
                           <button
                             onClick={() => {
@@ -946,6 +962,22 @@ export default function TeamPage() {
           onSave={() => {
             setEditingNote(null)
             if (companyId) fetchWorkerNotes(companyId)
+          }}
+        />
+      )}
+
+      {/* Worker Skills Modal */}
+      {showSkillsModal && selectedWorkerForSkills && (
+        <WorkerSkillsModal
+          worker={selectedWorkerForSkills}
+          companyId={companyId!}
+          onClose={() => {
+            setShowSkillsModal(false)
+            setSelectedWorkerForSkills(null)
+          }}
+          onSave={() => {
+            setShowSkillsModal(false)
+            setSelectedWorkerForSkills(null)
           }}
         />
       )}
@@ -1444,6 +1476,240 @@ function TeamMemberModal({ member, companyId, callerRole, onClose, onSave }: {
             </button>
           </div>
         </form>
+      </div>
+    </div>
+  )
+}
+
+// Worker Skills Modal — assign which services a worker can perform.
+// For services flagged "requires_license", a non-expired certification date is required.
+interface SkillService {
+  id: string
+  name: string
+  requires_license: boolean
+}
+
+interface SkillSelection {
+  checked: boolean
+  certExpiry: string // YYYY-MM-DD, only used for licensed services
+}
+
+function WorkerSkillsModal({ worker, companyId, onClose, onSave }: {
+  worker: TeamMember
+  companyId: string
+  onClose: () => void
+  onSave: () => void
+}) {
+  const [services, setServices] = useState<SkillService[]>([])
+  const [selections, setSelections] = useState<Record<string, SkillSelection>>({})
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const today = new Date().toISOString().split('T')[0]
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      const [servicesRes, skillsRes] = await Promise.all([
+        supabase
+          .from('services')
+          .select('id, name, requires_license')
+          .eq('company_id', companyId)
+          .eq('is_active', true)
+          .order('name'),
+        supabase
+          .from('worker_skills')
+          .select('service_id, cert_expiry')
+          .eq('user_id', worker.id),
+      ])
+
+      if (cancelled) return
+
+      const svcList = (servicesRes.data || []) as SkillService[]
+      setServices(svcList)
+
+      const existing: Record<string, SkillSelection> = {}
+      for (const svc of svcList) {
+        existing[svc.id] = { checked: false, certExpiry: '' }
+      }
+      for (const row of skillsRes.data || []) {
+        existing[(row as { service_id: string }).service_id] = {
+          checked: true,
+          certExpiry: (row as { cert_expiry: string | null }).cert_expiry || '',
+        }
+      }
+      setSelections(existing)
+      setLoading(false)
+    }
+    load()
+    return () => { cancelled = true }
+  }, [companyId, worker.id])
+
+  const toggle = (serviceId: string) => {
+    setSelections((prev) => ({
+      ...prev,
+      [serviceId]: { ...prev[serviceId], checked: !prev[serviceId]?.checked },
+    }))
+  }
+
+  const setExpiry = (serviceId: string, value: string) => {
+    setSelections((prev) => ({
+      ...prev,
+      [serviceId]: { ...prev[serviceId], certExpiry: value },
+    }))
+  }
+
+  const handleSave = async () => {
+    setError(null)
+
+    // Validate: licensed + selected services need a (non-expired) cert date.
+    for (const svc of services) {
+      const sel = selections[svc.id]
+      if (svc.requires_license && sel?.checked) {
+        if (!sel.certExpiry) {
+          setError(`"${svc.name}" requires a certification expiry date.`)
+          return
+        }
+      }
+    }
+
+    setSaving(true)
+
+    // Replace this worker's skills with the current selection.
+    const { error: delErr } = await supabase
+      .from('worker_skills')
+      .delete()
+      .eq('user_id', worker.id)
+
+    if (delErr) {
+      setError(delErr.message)
+      setSaving(false)
+      return
+    }
+
+    const rows = services
+      .filter((svc) => selections[svc.id]?.checked)
+      .map((svc) => ({
+        company_id: companyId,
+        user_id: worker.id,
+        service_id: svc.id,
+        cert_expiry: svc.requires_license ? selections[svc.id].certExpiry : null,
+      }))
+
+    if (rows.length > 0) {
+      const { error: insErr } = await supabase.from('worker_skills').insert(rows)
+      if (insErr) {
+        setError(insErr.message)
+        setSaving(false)
+        return
+      }
+    }
+
+    setSaving(false)
+    onSave()
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-xl max-w-lg w-full p-6 max-h-[90vh] overflow-y-auto shadow-dropdown">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-xl font-bold text-navy-500 flex items-center gap-2">
+            <Wrench size={20} /> Skills &amp; Services
+          </h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X size={20} />
+          </button>
+        </div>
+        <p className="text-sm text-gray-500 mb-4">
+          Select the services <strong>{worker.full_name}</strong> is qualified to perform. The
+          Route Optimizer will only assign matching jobs — and for licensed services, only when
+          the certification is still valid.
+        </p>
+
+        {loading ? (
+          <div className="py-10 flex justify-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-navy-500"></div>
+          </div>
+        ) : services.length === 0 ? (
+          <div className="bg-gray-50 border border-gray-200 rounded-lg p-6 text-center">
+            <p className="text-sm text-gray-600">
+              No active services yet. Add services under{' '}
+              <Link href="/dashboard/services" className="text-navy-600 underline">
+                Services
+              </Link>{' '}
+              first, then assign them here.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {services.map((svc) => {
+              const sel = selections[svc.id] || { checked: false, certExpiry: '' }
+              const expired = svc.requires_license && sel.checked && sel.certExpiry && sel.certExpiry < today
+              return (
+                <div
+                  key={svc.id}
+                  className={`border rounded-lg p-3 ${sel.checked ? 'border-navy-200 bg-navy-50/40' : 'border-gray-200'}`}
+                >
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={sel.checked}
+                      onChange={() => toggle(svc.id)}
+                      className="w-4 h-4 text-navy-500 border-gray-300 rounded focus:ring-navy-500"
+                    />
+                    <span className="text-sm font-medium text-gray-800">{svc.name}</span>
+                    {svc.requires_license && (
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                        🪪 License
+                      </span>
+                    )}
+                  </label>
+                  {svc.requires_license && sel.checked && (
+                    <div className="mt-2 pl-6">
+                      <label className="block text-xs font-medium text-gray-600 mb-1">
+                        Certification expires
+                      </label>
+                      <input
+                        type="date"
+                        value={sel.certExpiry}
+                        onChange={(e) => setExpiry(svc.id, e.target.value)}
+                        className={`px-3 py-1.5 border rounded-lg text-sm focus:ring-2 focus:ring-navy-500 focus:border-transparent ${
+                          expired ? 'border-red-400 text-red-600' : 'border-gray-200'
+                        }`}
+                      />
+                      {expired && (
+                        <p className="text-xs text-red-600 mt-1 flex items-center gap-1">
+                          <AlertTriangle size={12} /> Expired — worker won&apos;t be eligible for these jobs.
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {error && <p className="text-sm text-red-600 mt-3">{error}</p>}
+
+        <div className="flex gap-3 pt-5">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 px-4 py-2 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving || loading || services.length === 0}
+            className="flex-1 px-4 py-2 bg-navy-500 text-white rounded-lg hover:bg-navy-600 disabled:opacity-50 transition-colors"
+          >
+            {saving ? 'Saving...' : 'Save Skills'}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/src/lib/worker-assignment.ts
+++ b/src/lib/worker-assignment.ts
@@ -1,0 +1,205 @@
+/**
+ * Skill-constrained worker assignment.
+ *
+ * Decides which worker should handle which job, respecting:
+ *   - skill/service qualifications (a worker can only take jobs they're trained for)
+ *   - certifications/licenses with expiry (an expired license disqualifies a worker)
+ *   - workload balance (spread jobs so no one worker is overloaded)
+ *   - geography (prefer the worker whose existing stops are nearest)
+ *
+ * Jobs that no qualified worker can cover are returned separately, with a
+ * human-readable reason, so they're surfaced loudly instead of misassigned.
+ *
+ * This module is pure (no DB / network) so it can be unit-tested directly and
+ * reused by the route optimizer.
+ */
+
+import { RoutePoint } from './route-optimization';
+
+export interface ServiceMeta {
+  id: string;
+  /** Whether this service requires a non-expired certification to perform. */
+  requiresLicense: boolean;
+  /** Display name, used to build readable "uncoverable" reasons. */
+  name?: string;
+}
+
+export interface WorkerCapability {
+  serviceId: string;
+  /**
+   * Certification expiry date as `YYYY-MM-DD`. Only meaningful for services
+   * where `requiresLicense` is true. `null`/omitted means no certification on
+   * file — which makes the worker ineligible for licensed services.
+   */
+  certExpiry?: string | null;
+}
+
+export interface AssignableWorker {
+  id: string;
+  label?: string;
+  capabilities: WorkerCapability[];
+}
+
+export interface SkilledJob extends RoutePoint {
+  /**
+   * The service this job requires. `null`/omitted means no special skill is
+   * needed and any worker may be assigned.
+   */
+  requiredServiceId?: string | null;
+}
+
+export interface UnassignedJob {
+  job: SkilledJob;
+  reason: string;
+}
+
+export interface AssignmentResult {
+  /** Map of worker id -> jobs assigned to that worker, in no particular order. */
+  assignments: Map<string, SkilledJob[]>;
+  /** Jobs that no eligible worker could cover, each with a readable reason. */
+  unassigned: UnassignedJob[];
+}
+
+/**
+ * Whether a worker is qualified to perform a given job on a given date.
+ *
+ * @param routeDate The date the job runs, as `YYYY-MM-DD`. Used to evaluate
+ *                  certification expiry (a cert expiring before this date is
+ *                  treated as expired).
+ */
+export function isWorkerEligibleForJob(
+  worker: AssignableWorker,
+  job: SkilledJob,
+  services: Map<string, ServiceMeta>,
+  routeDate: string
+): boolean {
+  const requiredId = job.requiredServiceId;
+  // No requirement — anyone can do it.
+  if (!requiredId) return true;
+
+  const capability = worker.capabilities.find((c) => c.serviceId === requiredId);
+  if (!capability) return false;
+
+  const service = services.get(requiredId);
+  if (service?.requiresLicense) {
+    // Licensed service: must have a certification that hasn't expired.
+    if (!capability.certExpiry) return false;
+    // `YYYY-MM-DD` strings compare correctly lexicographically.
+    if (capability.certExpiry < routeDate) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Build a readable reason explaining why no worker could take a job.
+ * Distinguishes "nobody has the skill" from "the license is missing/expired".
+ */
+function buildUnassignedReason(
+  job: SkilledJob,
+  workers: AssignableWorker[],
+  services: Map<string, ServiceMeta>,
+  routeDate: string
+): string {
+  const requiredId = job.requiredServiceId;
+  if (!requiredId) {
+    // Should not happen (a job with no requirement is always assignable if any
+    // worker exists), but handle defensively.
+    return 'No workers available';
+  }
+
+  const service = services.get(requiredId);
+  const serviceName = service?.name || 'this service';
+
+  const haveSkill = workers.some((w) =>
+    w.capabilities.some((c) => c.serviceId === requiredId)
+  );
+
+  if (!haveSkill) {
+    return `No available worker has the "${serviceName}" skill`;
+  }
+
+  // Someone has the skill but all failed eligibility — must be a license issue.
+  if (service?.requiresLicense) {
+    return `"${serviceName}" requires a valid certification — no available worker has a current one`;
+  }
+
+  return `No available worker can cover "${serviceName}"`;
+}
+
+function distance(a: { lat: number; lng: number }, b: { lat: number; lng: number }): number {
+  const dLat = a.lat - b.lat;
+  const dLng = a.lng - b.lng;
+  return Math.sqrt(dLat * dLat + dLng * dLng);
+}
+
+/**
+ * Assign jobs to workers under skill constraints, balancing workload and
+ * preferring geographic proximity.
+ *
+ * Strategy: most-constrained-first. Jobs with the fewest eligible workers are
+ * placed first (the licensed/specialist jobs), so they aren't crowded out by
+ * general work. Among a job's eligible workers we pick the least-loaded, and
+ * break ties by proximity to that worker's existing stops.
+ */
+export function assignJobsToWorkers(
+  jobs: SkilledJob[],
+  workers: AssignableWorker[],
+  services: Map<string, ServiceMeta>,
+  routeDate: string
+): AssignmentResult {
+  const assignments = new Map<string, SkilledJob[]>();
+  for (const w of workers) assignments.set(w.id, []);
+
+  const unassigned: UnassignedJob[] = [];
+
+  if (workers.length === 0) {
+    return { assignments, unassigned: jobs.map((job) => ({ job, reason: 'No workers available' })) };
+  }
+
+  // Precompute eligible workers per job.
+  const eligibilityByJob = new Map<string, AssignableWorker[]>();
+  for (const job of jobs) {
+    const eligible = workers.filter((w) => isWorkerEligibleForJob(w, job, services, routeDate));
+    eligibilityByJob.set(job.id, eligible);
+  }
+
+  // Most-constrained-first ordering. Stable: ties keep original order.
+  const ordered = [...jobs].sort(
+    (a, b) =>
+      (eligibilityByJob.get(a.id)!.length) - (eligibilityByJob.get(b.id)!.length)
+  );
+
+  for (const job of ordered) {
+    const eligible = eligibilityByJob.get(job.id)!;
+    if (eligible.length === 0) {
+      unassigned.push({ job, reason: buildUnassignedReason(job, workers, services, routeDate) });
+      continue;
+    }
+
+    // Pick the least-loaded eligible worker; tie-break by geographic proximity
+    // to the jobs they already hold.
+    let best: AssignableWorker | null = null;
+    let bestLoad = Infinity;
+    let bestProximity = Infinity;
+
+    for (const w of eligible) {
+      const current = assignments.get(w.id)!;
+      const load = current.length;
+      const proximity =
+        current.length === 0
+          ? 0
+          : Math.min(...current.map((j) => distance(job, j)));
+
+      if (load < bestLoad || (load === bestLoad && proximity < bestProximity)) {
+        best = w;
+        bestLoad = load;
+        bestProximity = proximity;
+      }
+    }
+
+    assignments.get(best!.id)!.push(job);
+  }
+
+  return { assignments, unassigned };
+}

--- a/supabase/migrations/20260620000000_add_worker_skills.sql
+++ b/supabase/migrations/20260620000000_add_worker_skills.sql
@@ -3,48 +3,16 @@
 -- who are qualified (and, for licensed services, hold a non-expired certification).
 --
 -- Adds:
---   1. services         — per-company catalog of service types
+--   1. services.requires_license — flag existing service types as licensed
 --   2. worker_skills     — which workers can perform which services (+ cert expiry)
 --   3. jobs.required_service_id — the service a job requires (null = anyone can do it)
+--
+-- NOTE: `services` already exists (per-company catalog with name, description,
+-- default_price, duration_minutes, is_active). We extend it rather than redefine
+-- it, so the existing /dashboard/services page keeps working.
 
--- 1. services — company-defined catalog of service types
-CREATE TABLE IF NOT EXISTS services (
-  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
-  company_id uuid NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
-  name text NOT NULL,
-  description text,
-  -- When true, a worker must hold a non-expired certification (worker_skills.cert_expiry)
-  -- to be eligible for jobs requiring this service.
-  requires_license boolean NOT NULL DEFAULT false,
-  active boolean NOT NULL DEFAULT true,
-  created_at timestamptz DEFAULT now(),
-  updated_at timestamptz DEFAULT now(),
-  UNIQUE (company_id, name)
-);
-
-CREATE INDEX IF NOT EXISTS idx_services_company_id ON services(company_id);
-
-ALTER TABLE services ENABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS "Users can view services for their company" ON services;
-CREATE POLICY "Users can view services for their company"
-  ON services FOR SELECT
-  USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
-
-DROP POLICY IF EXISTS "Users can insert services for their company" ON services;
-CREATE POLICY "Users can insert services for their company"
-  ON services FOR INSERT
-  WITH CHECK (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
-
-DROP POLICY IF EXISTS "Users can update services for their company" ON services;
-CREATE POLICY "Users can update services for their company"
-  ON services FOR UPDATE
-  USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
-
-DROP POLICY IF EXISTS "Users can delete services for their company" ON services;
-CREATE POLICY "Users can delete services for their company"
-  ON services FOR DELETE
-  USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
+-- 1. Flag services that require a non-expired certification to perform.
+ALTER TABLE services ADD COLUMN IF NOT EXISTS requires_license boolean NOT NULL DEFAULT false;
 
 -- 2. worker_skills — capabilities held by each worker
 CREATE TABLE IF NOT EXISTS worker_skills (
@@ -88,18 +56,3 @@ CREATE POLICY "Users can delete worker skills for their company"
 -- 3. jobs.required_service_id — the service a job needs (null = no special skill)
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS required_service_id uuid REFERENCES services(id) ON DELETE SET NULL;
 CREATE INDEX IF NOT EXISTS idx_jobs_required_service_id ON jobs(required_service_id);
-
--- Updated_at trigger for services
-CREATE OR REPLACE FUNCTION update_services_updated_at()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = now();
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-DROP TRIGGER IF EXISTS set_services_updated_at ON services;
-CREATE TRIGGER set_services_updated_at
-  BEFORE UPDATE ON services
-  FOR EACH ROW
-  EXECUTE FUNCTION update_services_updated_at();

--- a/supabase/migrations/20260620000000_add_worker_skills.sql
+++ b/supabase/migrations/20260620000000_add_worker_skills.sql
@@ -1,0 +1,105 @@
+-- Worker Skills & Service Catalog
+-- Enables skill-constrained route assignment: jobs are only assigned to workers
+-- who are qualified (and, for licensed services, hold a non-expired certification).
+--
+-- Adds:
+--   1. services         — per-company catalog of service types
+--   2. worker_skills     — which workers can perform which services (+ cert expiry)
+--   3. jobs.required_service_id — the service a job requires (null = anyone can do it)
+
+-- 1. services — company-defined catalog of service types
+CREATE TABLE IF NOT EXISTS services (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  company_id uuid NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  description text,
+  -- When true, a worker must hold a non-expired certification (worker_skills.cert_expiry)
+  -- to be eligible for jobs requiring this service.
+  requires_license boolean NOT NULL DEFAULT false,
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE (company_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_services_company_id ON services(company_id);
+
+ALTER TABLE services ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view services for their company" ON services;
+CREATE POLICY "Users can view services for their company"
+  ON services FOR SELECT
+  USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
+
+DROP POLICY IF EXISTS "Users can insert services for their company" ON services;
+CREATE POLICY "Users can insert services for their company"
+  ON services FOR INSERT
+  WITH CHECK (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
+
+DROP POLICY IF EXISTS "Users can update services for their company" ON services;
+CREATE POLICY "Users can update services for their company"
+  ON services FOR UPDATE
+  USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
+
+DROP POLICY IF EXISTS "Users can delete services for their company" ON services;
+CREATE POLICY "Users can delete services for their company"
+  ON services FOR DELETE
+  USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
+
+-- 2. worker_skills — capabilities held by each worker
+CREATE TABLE IF NOT EXISTS worker_skills (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  company_id uuid NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  service_id uuid NOT NULL REFERENCES services(id) ON DELETE CASCADE,
+  -- For licensed services: the date the worker's certification expires.
+  -- NULL means no certification on file (worker is NOT eligible for licensed services).
+  cert_expiry date,
+  created_at timestamptz DEFAULT now(),
+  UNIQUE (user_id, service_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_worker_skills_company_id ON worker_skills(company_id);
+CREATE INDEX IF NOT EXISTS idx_worker_skills_user_id ON worker_skills(user_id);
+CREATE INDEX IF NOT EXISTS idx_worker_skills_service_id ON worker_skills(service_id);
+
+ALTER TABLE worker_skills ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view worker skills for their company" ON worker_skills;
+CREATE POLICY "Users can view worker skills for their company"
+  ON worker_skills FOR SELECT
+  USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
+
+DROP POLICY IF EXISTS "Users can insert worker skills for their company" ON worker_skills;
+CREATE POLICY "Users can insert worker skills for their company"
+  ON worker_skills FOR INSERT
+  WITH CHECK (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
+
+DROP POLICY IF EXISTS "Users can update worker skills for their company" ON worker_skills;
+CREATE POLICY "Users can update worker skills for their company"
+  ON worker_skills FOR UPDATE
+  USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
+
+DROP POLICY IF EXISTS "Users can delete worker skills for their company" ON worker_skills;
+CREATE POLICY "Users can delete worker skills for their company"
+  ON worker_skills FOR DELETE
+  USING (company_id IN (SELECT company_id FROM users WHERE id = auth.uid()));
+
+-- 3. jobs.required_service_id — the service a job needs (null = no special skill)
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS required_service_id uuid REFERENCES services(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_jobs_required_service_id ON jobs(required_service_id);
+
+-- Updated_at trigger for services
+CREATE OR REPLACE FUNCTION update_services_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_services_updated_at ON services;
+CREATE TRIGGER set_services_updated_at
+  BEFORE UPDATE ON services
+  FOR EACH ROW
+  EXECUTE FUNCTION update_services_updated_at();


### PR DESCRIPTION
## Overview

Adds **skill- and certification-aware multi-worker route optimization**. The Route Optimizer previously split jobs across workers by geography alone — it could hand a job to someone not qualified or licensed to do it. This PR makes assignment honor each worker's skills and license expiry, and loudly flags any job no qualified worker can cover. (Also includes the earlier geocoding accuracy fix for incomplete/whitespace addresses.)

## How it works, end to end

1. **Services** (`/dashboard/services`) gain a **"Requires a license / certification"** flag.
2. **Team → Skills** lets you assign which services each field worker can perform, with a **certification expiry date** for licensed ones (expired = ineligible).
3. **Job form** gains a **"Required Skill / Service"** dropdown (`jobs.required_service_id`, default = any worker).
4. **Route Optimizer** multi-worker panel lets you **pick who's on shift today**, then assigns each job only to a qualified, currently-certified worker, optimizes each worker's route, shows a **per-worker breakdown**, and lists any **uncoverable jobs with the reason** (e.g. *"Pesticide Application requires a valid certification — no available worker has a current one"*).

## Changes

**Data**
- `supabase/migrations/20260620000000_add_worker_skills.sql` — adds `services.requires_license`, the `worker_skills` table (with `cert_expiry`), and `jobs.required_service_id`. Extends the existing `services` table rather than redefining it; company-scoped with RLS.

**Engine**
- `src/lib/worker-assignment.ts` — pure, tested eligibility + assignment logic (skill match, cert-expiry gating, workload balance, geographic tie-break, uncoverable-job reasons). 13 unit tests.

**Endpoint**
- `src/app/api/routes/optimize/route.ts` — skill-aware assignment when specific workers are selected (loads skills/services server-side), returns per-worker routes + aggregate result + `unassignedJobs`. Falls back to count-based geographic splitting otherwise.

**UI**
- Services page, Team page (Skills modal), job form, and Route Optimizer page (worker picker, uncoverable-jobs warning, per-worker breakdown).

**Geocoding fix (carried in this branch)**
- `buildAddressQuery` + `geocodeJobAddress` with city-level fallback; page forwards `state`/`zip`.

## Testing

- `npm run build` ✓
- `npm test` → **448 passed** (was 435; +13 assignment tests) ✓
- `npm run lint` → no new errors ✓

## Deploy note

Run the new migration on Supabase before/with deploy so the columns and `worker_skills` table exist in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0186e2ruMrttLk8FCKhB6zGg)_