### PR TITLE
feat(jenny-pro): turn missed calls and texts into booked jobs, bilingual

### DIFF
--- a/database/migrations/038_jenny_sms_booking_agent.sql
+++ b/database/migrations/038_jenny_sms_booking_agent.sql
@@ -1,0 +1,16 @@
+-- Jenny Pro booking agent: track conversation language and the booking it produced.
+-- The conversational SMS/voice agent records which appointment (job) it created
+-- so the dashboard can show real "Bookings Made" numbers, and which language the
+-- customer is using so Jenny stays consistent across a thread.
+
+ALTER TABLE jenny_sms_conversations
+  ADD COLUMN IF NOT EXISTS language VARCHAR(10) DEFAULT 'en',          -- en, es
+  ADD COLUMN IF NOT EXISTS booking_id UUID REFERENCES jobs(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS last_intent VARCHAR(30);                    -- booking, question, emergency, other
+
+CREATE INDEX IF NOT EXISTS idx_jenny_sms_conv_booking ON jenny_sms_conversations(booking_id);
+
+-- Operator notification preference: how the contractor wants to be notified,
+-- independent of the language the customer is using with Jenny.
+ALTER TABLE jenny_pro_settings
+  ADD COLUMN IF NOT EXISTS operator_language VARCHAR(10) DEFAULT 'en'; -- en, es

--- a/docs/jenny-pro-booking-agent.md
+++ b/docs/jenny-pro-booking-agent.md
@@ -1,0 +1,107 @@
+# Jenny Pro — Booking Agent (Missed Call / Text → Booked Job)
+
+Jenny Pro turns an inbound **text or missed call** into a **booked job on the
+calendar**, bilingual (English + Spanish, auto-detected per customer), and
+notifies the operator. This doc maps the full flow and how to wire it up.
+
+## The flow at a glance
+
+```
+                 ┌──────────────────────────── TEXT PATH ───────────────────────────┐
+ Customer texts ─┤ Twilio → POST /api/jenny-pro/sms-webhook                          │
+                 │   1. log message + thread (jenny_sms_conversations / _messages)   │
+                 │   2. STOP / START / HELP compliance                               │
+                 │   3. emergency keywords → escalate to operator (no booking)       │
+                 │   4. runJennyAgent() → bilingual reply (Claude, OpenAI fallback)  │
+                 │   5. when name+service+date+time known & auto_booking on:          │
+                 │        createBooking() → job + customer + lead                     │
+                 │        notify operator (in-app + SMS)                              │
+                 │   6. reply via TwiML <Message>                                     │
+                 └───────────────────────────────────────────────────────────────────┘
+
+                 ┌──────────────────────────── CALL PATH ───────────────────────────┐
+ Customer calls ─┤ Twilio → POST /api/jenny-pro/voice                                │
+                 │   • has owner #? <Dial> owner, timeout 18s → /voice/after-dial    │
+                 │       └ missed → text the caller (seeds the TEXT PATH) + log +    │
+                 │         notify operator                                           │
+                 │   • no owner #? → /voice/gather  (AI speech receptionist)         │
+                 │       └ speech → runJennyAgent(channel:'voice') → <Say> + <Gather> │
+                 │         loop → createBooking() when ready → confirm by voice       │
+                 └───────────────────────────────────────────────────────────────────┘
+```
+
+## Key modules
+
+| File | Responsibility |
+| --- | --- |
+| `src/lib/booking-core.js` | `createBooking()` — shared job/customer/lead creation. Used by web bookings, SMS, and voice. |
+| `src/lib/jenny-sms-agent.js` | `runJennyAgent()` — the bilingual conversational brain (Claude primary). Returns `{ reply, language, intent, readyToBook, booking, emergency }`. Channel-agnostic. |
+| `src/lib/jenny-language.js` | Language auto-detection, EN/ES string bundles, STOP/START/HELP classification. |
+| `src/lib/jenny-voice.js` | TwiML builders + voice conversation threading. |
+| `src/lib/jenny-notify.js` | Operator notifications (in-app + SMS). |
+| `src/app/api/jenny-pro/sms-webhook/route.js` | Inbound SMS handler. |
+| `src/app/api/jenny-pro/voice/route.js` | Inbound call handler (ring owner, else AI). |
+| `src/app/api/jenny-pro/voice/after-dial/route.js` | Missed-call → text-back. |
+| `src/app/api/jenny-pro/voice/gather/route.js` | Conversational speech receptionist. |
+
+## Spanish-first behavior
+
+- **Customer language** (`jenny_pro_settings.language`): `both` (default,
+  auto-detects EN/ES and mirrors the customer), `es` (always Spanish), or `en`.
+- **Operator language** (`jenny_pro_settings.operator_language`): the language
+  of the contractor's own booking / missed-call alerts — independent of the
+  customer's language.
+- Emergency keywords are matched in **both** English and Spanish.
+
+## Auto-booking
+
+Controlled by `jenny_pro_settings.auto_booking` (default `true`). When on, Jenny
+books as soon as she has name + service + date + time, then notifies the
+operator. When off, she still collects everything and replies, but does not
+create the job (operator confirms manually).
+
+## Operator setup (Twilio)
+
+Set these env vars (already documented in `.env.example`):
+
+```
+ANTHROPIC_API_KEY=...          # Jenny's brain (OpenAI fallback: OPENAI_API_KEY)
+TWILIO_ACCOUNT_SID=...
+TWILIO_AUTH_TOKEN=...
+TWILIO_PHONE_NUMBER=...         # the business number
+TWILIO_MESSAGING_SERVICE_SID=... # A2P 10DLC campaign (preferred for sends)
+```
+
+On the Twilio phone number, set the webhooks:
+
+| Trigger | Webhook (POST) |
+| --- | --- |
+| **A Message Comes In** | `https://<domain>/api/jenny-pro/sms-webhook` |
+| **A Call Comes In** | `https://<domain>/api/jenny-pro/voice` |
+
+The voice sub-routes (`/voice/after-dial`, `/voice/gather`) are invoked by
+Twilio automatically via the TwiML returned by `/voice`.
+
+Then in **Dashboard → Jenny Pro → Settings**, set the on-call/escalation number,
+customer language, your notification language, emergency keywords, and the
+auto-book toggle.
+
+## Database
+
+Migration `038_jenny_sms_booking_agent.sql` adds:
+- `jenny_sms_conversations.language`, `.booking_id`, `.last_intent`
+- `jenny_pro_settings.operator_language`
+
+(The `jenny_sms_conversations`, `jenny_sms_messages`, `jenny_voice_calls`, and
+`jenny_pro_settings` tables come from `021_jenny_pro_sms_conversations.sql`.)
+
+## Notes / limitations
+
+- Single-tenant number routing: the webhook maps `TWILIO_PHONE_NUMBER` to the
+  first company. A `phone_numbers` table would make this multi-tenant.
+- The voice receptionist uses Twilio `<Gather input="speech">` + Amazon Polly
+  voices (`Polly.Joanna` EN, `Polly.Lupe` ES). It needs a provisioned Twilio
+  **Voice** number and live phone testing to validate end-to-end.
+- Customers who text first are treated as having initiated contact (TwiML reply
+  is a direct response). Outbound marketing still respects `sms_consent` + STOP.
+```

--- a/src/__tests__/api/jenny-sms-webhook.test.js
+++ b/src/__tests__/api/jenny-sms-webhook.test.js
@@ -1,0 +1,188 @@
+/**
+ * @jest-environment node
+ */
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockAiComplete = jest.fn();
+jest.mock('@/lib/ai-client', () => ({
+  aiComplete: (...args) => mockAiComplete(...args),
+  parseAIJson: jest.requireActual('@/lib/ai-client').parseAIJson,
+}));
+
+jest.mock('@/lib/twilio', () => ({
+  sendSMS: jest.fn().mockResolvedValue({ success: true, messageId: 'SM1' }),
+}));
+
+// Records every insert so tests can assert side effects.
+let inserts = {};
+let existingConversation = null;
+let settingsRow = { auto_booking: true, language: 'both', operator_language: 'en' };
+
+function recordInsert(table, payload) {
+  inserts[table] = inserts[table] || [];
+  inserts[table].push(payload);
+}
+
+function builder(table) {
+  const obj = {};
+  const passthrough = ['select', 'eq', 'neq', 'or', 'ilike', 'order', 'update'];
+  passthrough.forEach((m) => {
+    obj[m] = jest.fn(() => obj);
+  });
+  obj.insert = jest.fn((payload) => {
+    recordInsert(table, payload);
+    return obj;
+  });
+  obj.limit = jest.fn(() => obj);
+  obj.maybeSingle = jest.fn(() => Promise.resolve(maybeSingleResult(table)));
+  obj.single = jest.fn(() => Promise.resolve(singleResult(table)));
+  // Awaiting the builder directly (e.g. companies.select().limit(1))
+  obj.then = (resolve) => resolve(awaitResult(table));
+  return obj;
+}
+
+function awaitResult(table) {
+  if (table === 'companies') return { data: [{ id: 'comp-1' }], error: null };
+  if (table === 'users') return { data: [{ id: 'user-1' }], error: null };
+  if (table === 'jobs') return { data: [], error: null }; // availability check
+  return { data: [], error: null };
+}
+
+function maybeSingleResult(table) {
+  if (table === 'jenny_pro_settings') return { data: settingsRow };
+  if (table === 'jenny_sms_conversations') return { data: existingConversation };
+  if (table === 'customers') return { data: null };
+  return { data: null };
+}
+
+function singleResult(table) {
+  if (table === 'jenny_sms_conversations') return { data: { id: 'conv-1' }, error: null };
+  if (table === 'customers') return { data: { id: 'cust-1' }, error: null };
+  if (table === 'jobs') return { data: { id: 'job-1' }, error: null };
+  if (table === 'companies') return { data: { name: 'Green Co' }, error: null };
+  return { data: null, error: null };
+}
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ from: jest.fn((table) => builder(table)) })),
+}));
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+process.env.TWILIO_PHONE_NUMBER = '+15550001111';
+
+const { POST } = require('@/app/api/jenny-pro/sms-webhook/route');
+
+function smsRequest({ from = '+15559998888', body = 'hello', to = '+15550001111' } = {}) {
+  const params = new URLSearchParams({ From: from, Body: body, To: to, MessageSid: 'SMtest' });
+  return new Request('http://localhost/api/jenny-pro/sms-webhook', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+}
+
+describe('/api/jenny-pro/sms-webhook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    inserts = {};
+    existingConversation = null;
+    settingsRow = { auto_booking: true, language: 'both', operator_language: 'en' };
+  });
+
+  it('honors STOP without booking or AI', async () => {
+    const res = await POST(smsRequest({ body: 'STOP' }));
+    const xml = await res.text();
+    expect(res.status).toBe(200);
+    expect(xml).toBe('<Response></Response>');
+    expect(mockAiComplete).not.toHaveBeenCalled();
+    expect(inserts.jobs).toBeUndefined();
+  });
+
+  it('replies conversationally when not ready to book', async () => {
+    mockAiComplete.mockResolvedValue({
+      content: JSON.stringify({
+        reply: 'Sure! What day works for you?',
+        language: 'en',
+        intent: 'booking',
+        ready_to_book: false,
+        booking: null,
+      }),
+    });
+
+    const res = await POST(smsRequest({ body: 'I need lawn care' }));
+    const xml = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(xml).toContain('<Message>');
+    expect(xml).toContain('What day works for you');
+    expect(inserts.jobs).toBeUndefined(); // no booking yet
+  });
+
+  it('auto-books when Jenny has all the details', async () => {
+    mockAiComplete.mockResolvedValue({
+      content: JSON.stringify({
+        reply: "You're booked for Lawn Care on Thursday at 9 AM!",
+        language: 'en',
+        intent: 'booking',
+        ready_to_book: true,
+        booking: {
+          customerName: 'Sarah',
+          serviceName: 'Lawn Care',
+          scheduledDate: '2026-07-02',
+          scheduledTimeStart: '09:00',
+          notes: 'half acre',
+        },
+      }),
+    });
+
+    const res = await POST(smsRequest({ body: 'Sarah, lawn care Thursday 9am' }));
+    const xml = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(xml).toContain('booked for Lawn Care');
+    // A job (booking) and a lead should have been created.
+    expect(inserts.jobs && inserts.jobs.length).toBeGreaterThan(0);
+    expect(inserts.leads && inserts.leads.length).toBeGreaterThan(0);
+    // Operator notified in-app.
+    expect(inserts.notifications && inserts.notifications.length).toBeGreaterThan(0);
+  });
+
+  it('escalates an emergency instead of booking', async () => {
+    const res = await POST(smsRequest({ body: 'EMERGENCY there is a flood!' }));
+    const xml = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(xml).toContain('<Message>');
+    expect(mockAiComplete).not.toHaveBeenCalled();
+    expect(inserts.jobs).toBeUndefined();
+    // Operator gets an urgent notification.
+    expect(inserts.notifications && inserts.notifications.length).toBeGreaterThan(0);
+  });
+
+  it('does not book when auto_booking is disabled', async () => {
+    settingsRow = { auto_booking: false, language: 'both', operator_language: 'en' };
+    mockAiComplete.mockResolvedValue({
+      content: JSON.stringify({
+        reply: 'Got it, let me check with the owner and confirm.',
+        language: 'en',
+        intent: 'booking',
+        ready_to_book: true,
+        booking: {
+          customerName: 'Sarah',
+          serviceName: 'Lawn Care',
+          scheduledDate: '2026-07-02',
+          scheduledTimeStart: '09:00',
+        },
+      }),
+    });
+
+    const res = await POST(smsRequest({ body: 'Sarah lawn care thursday 9am' }));
+    const xml = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(xml).toContain('<Message>');
+    expect(inserts.jobs).toBeUndefined(); // auto_booking off → no job created
+  });
+});

--- a/src/__tests__/lib/booking-core.test.js
+++ b/src/__tests__/lib/booking-core.test.js
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment node
+ */
+
+const { createBooking, calculateEndTime } = require('@/lib/booking-core');
+
+// Minimal chainable Supabase stub driven by per-table handlers.
+function makeSupabase({ existingJobs = [], existingCustomer = null, newJobId = 'job-1', newCustomerId = 'cust-1', companyName = 'Test Co' } = {}) {
+  let jobCalls = 0;
+  return {
+    from(table) {
+      if (table === 'jobs') {
+        jobCalls++;
+        const obj = {};
+        obj.select = jest.fn(() => obj);
+        obj.insert = jest.fn(() => obj);
+        obj.eq = jest.fn(() => obj);
+        obj.neq = jest.fn(() => (jobCalls === 1 ? { data: existingJobs, error: null } : obj));
+        obj.single = jest.fn(() => ({ data: { id: newJobId }, error: null }));
+        return obj;
+      }
+      if (table === 'customers') {
+        const obj = {};
+        obj.select = jest.fn(() => obj);
+        obj.insert = jest.fn(() => obj);
+        obj.update = jest.fn(() => obj);
+        obj.eq = jest.fn(() => obj);
+        obj.single = jest.fn(() => ({ data: existingCustomer || { id: newCustomerId }, error: null }));
+        return obj;
+      }
+      if (table === 'leads') {
+        return { insert: jest.fn(() => ({ data: null, error: null })) };
+      }
+      if (table === 'companies') {
+        const obj = {};
+        obj.select = jest.fn(() => obj);
+        obj.eq = jest.fn(() => obj);
+        obj.single = jest.fn(() => ({ data: { name: companyName }, error: null }));
+        return obj;
+      }
+      return { select: jest.fn(() => ({ data: null, error: null })) };
+    },
+  };
+}
+
+const validParams = {
+  companyId: 'company-1',
+  serviceName: 'Lawn Mowing',
+  scheduledDate: '2026-07-01',
+  scheduledTimeStart: '10:00',
+  customerName: 'Jane Doe',
+  customerPhone: '5551234567',
+};
+
+describe('booking-core', () => {
+  describe('calculateEndTime', () => {
+    it('adds the duration to the start time', () => {
+      expect(calculateEndTime('10:00', 90)).toBe('11:30');
+    });
+    it('defaults to 60 minutes when duration missing', () => {
+      expect(calculateEndTime('09:00')).toBe('10:00');
+    });
+  });
+
+  describe('createBooking', () => {
+    it('returns 400 when required fields are missing', async () => {
+      const res = await createBooking(makeSupabase(), { companyId: 'c1' });
+      expect(res.ok).toBe(false);
+      expect(res.status).toBe(400);
+    });
+
+    it('creates a booking and returns details', async () => {
+      const res = await createBooking(makeSupabase(), validParams);
+      expect(res.ok).toBe(true);
+      expect(res.booking.service).toBe('Lawn Mowing');
+      expect(res.booking.time).toBe('10:00');
+      expect(res.leadCreated).toBe(true);
+      expect(res.companyName).toBe('Test Co');
+    });
+
+    it('rejects a conflicting slot when autoAdvance is false', async () => {
+      const res = await createBooking(
+        makeSupabase({ existingJobs: [{ scheduled_time_start: '10:00' }] }),
+        validParams
+      );
+      expect(res.ok).toBe(false);
+      expect(res.status).toBe(409);
+    });
+
+    it('auto-advances past a conflict when autoAdvance is true', async () => {
+      const res = await createBooking(
+        makeSupabase({ existingJobs: [{ scheduled_time_start: '10:00' }] }),
+        { ...validParams, autoAdvance: true }
+      );
+      expect(res.ok).toBe(true);
+      expect(res.booking.time).not.toBe('10:00');
+    });
+
+    it('treats "booked via Jenny AI" notes as flexible', async () => {
+      const res = await createBooking(
+        makeSupabase({ existingJobs: [{ scheduled_time_start: '10:00' }] }),
+        { ...validParams, notes: 'booked via Jenny AI SMS' }
+      );
+      expect(res.ok).toBe(true);
+      expect(res.booking.time).not.toBe('10:00');
+    });
+  });
+});

--- a/src/__tests__/lib/jenny-language.test.js
+++ b/src/__tests__/lib/jenny-language.test.js
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+
+const {
+  detectLanguage,
+  resolveReplyLanguage,
+  classifyKeyword,
+  t,
+} = require('@/lib/jenny-language');
+
+describe('jenny-language', () => {
+  describe('detectLanguage', () => {
+    it('detects Spanish from accented characters', () => {
+      expect(detectLanguage('¿Cuánto cuesta el servicio?')).toBe('es');
+    });
+
+    it('detects Spanish from common words', () => {
+      expect(detectLanguage('hola necesito una cita para mañana')).toBe('es');
+    });
+
+    it('defaults to English for plain English text', () => {
+      expect(detectLanguage('Hi, I need a quote for lawn mowing')).toBe('en');
+    });
+
+    it('defaults to English on empty input', () => {
+      expect(detectLanguage('')).toBe('en');
+    });
+  });
+
+  describe('resolveReplyLanguage', () => {
+    it('forces English when company setting is en', () => {
+      expect(resolveReplyLanguage('es', 'en')).toBe('en');
+    });
+
+    it('forces Spanish when company setting is es', () => {
+      expect(resolveReplyLanguage('en', 'es')).toBe('es');
+    });
+
+    it('mirrors the customer when setting is both', () => {
+      expect(resolveReplyLanguage('es', 'both')).toBe('es');
+      expect(resolveReplyLanguage('en', 'both')).toBe('en');
+    });
+
+    it('mirrors the customer when setting is undefined', () => {
+      expect(resolveReplyLanguage('es')).toBe('es');
+    });
+  });
+
+  describe('classifyKeyword', () => {
+    it('recognizes STOP variants', () => {
+      expect(classifyKeyword('STOP')).toBe('stop');
+      expect(classifyKeyword('unsubscribe')).toBe('stop');
+      expect(classifyKeyword('baja')).toBe('stop');
+    });
+
+    it('recognizes START and HELP', () => {
+      expect(classifyKeyword('start')).toBe('start');
+      expect(classifyKeyword('HELP')).toBe('help');
+      expect(classifyKeyword('ayuda')).toBe('help');
+    });
+
+    it('returns null for ordinary messages', () => {
+      expect(classifyKeyword('I need a plumber tomorrow')).toBeNull();
+    });
+  });
+
+  describe('t (string bundles)', () => {
+    it('returns Spanish strings for es', () => {
+      expect(t('es').missedCallText('Mi Compañía')).toContain('Lamentamos');
+    });
+
+    it('returns English strings for en', () => {
+      expect(t('en').missedCallText('My Co')).toContain('Sorry we missed');
+    });
+
+    it('builds a localized booking confirmation', () => {
+      const msg = t('es').bookingConfirmed({
+        name: 'Ana', service: 'Jardinería', date: 'lun, jun 22', time: '9:00 AM', company: 'Verde',
+      });
+      expect(msg).toContain('Ana');
+      expect(msg).toContain('Verde');
+    });
+  });
+});

--- a/src/__tests__/lib/jenny-sms-agent.test.js
+++ b/src/__tests__/lib/jenny-sms-agent.test.js
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment node
+ */
+
+// Mock the AI client so we control Jenny's "thinking".
+const mockAiComplete = jest.fn();
+jest.mock('@/lib/ai-client', () => ({
+  aiComplete: (...args) => mockAiComplete(...args),
+  parseAIJson: jest.requireActual('@/lib/ai-client').parseAIJson,
+}));
+
+const { runJennyAgent } = require('@/lib/jenny-sms-agent');
+
+// Supabase stub returning a company + services.
+function makeSupabase() {
+  return {
+    from(table) {
+      const obj = {};
+      obj.select = jest.fn(() => obj);
+      obj.eq = jest.fn(() => obj);
+      obj.limit = jest.fn(() => {
+        if (table === 'services') return { data: [{ name: 'Lawn Care', default_price: 60, duration_minutes: 60 }] };
+        return obj;
+      });
+      obj.single = jest.fn(() => ({ data: { name: 'Green Co', business_type: 'landscaping' } }));
+      return obj;
+    },
+  };
+}
+
+describe('runJennyAgent', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('short-circuits to an emergency escalation without calling the AI', async () => {
+    const res = await runJennyAgent({
+      supabase: makeSupabase(),
+      companyId: 'c1',
+      settings: { emergency_keywords: ['flood'] },
+      message: 'Help there is a flood in my kitchen',
+    });
+    expect(res.emergency).toBe(true);
+    expect(res.intent).toBe('emergency');
+    expect(res.readyToBook).toBe(false);
+    expect(mockAiComplete).not.toHaveBeenCalled();
+  });
+
+  it('returns a conversational reply when not ready to book', async () => {
+    mockAiComplete.mockResolvedValue({
+      content: JSON.stringify({
+        reply: 'Sure! What day works for you?',
+        language: 'en',
+        intent: 'booking',
+        ready_to_book: false,
+        booking: null,
+      }),
+    });
+
+    const res = await runJennyAgent({
+      supabase: makeSupabase(),
+      companyId: 'c1',
+      settings: { language: 'both' },
+      message: 'I need lawn care',
+    });
+
+    expect(res.readyToBook).toBe(false);
+    expect(res.booking).toBeNull();
+    expect(res.reply).toContain('What day');
+  });
+
+  it('marks ready_to_book only when all required fields are present', async () => {
+    mockAiComplete.mockResolvedValue({
+      content: JSON.stringify({
+        reply: 'Booked! Lawn Care on 2026-07-02 at 9 AM.',
+        language: 'en',
+        intent: 'booking',
+        ready_to_book: true,
+        booking: {
+          customerName: 'Sarah',
+          serviceName: 'Lawn Care',
+          scheduledDate: '2026-07-02',
+          scheduledTimeStart: '09:00',
+          notes: 'half acre',
+        },
+      }),
+    });
+
+    const res = await runJennyAgent({
+      supabase: makeSupabase(),
+      companyId: 'c1',
+      settings: {},
+      message: 'Sarah, lawn care tomorrow at 9am',
+    });
+
+    expect(res.readyToBook).toBe(true);
+    expect(res.booking.customerName).toBe('Sarah');
+  });
+
+  it('does NOT mark ready when the model omits a required field', async () => {
+    mockAiComplete.mockResolvedValue({
+      content: JSON.stringify({
+        reply: 'What time?',
+        language: 'en',
+        intent: 'booking',
+        ready_to_book: true, // model claims ready...
+        booking: { customerName: 'Sarah', serviceName: 'Lawn Care', scheduledDate: '2026-07-02' }, // ...but no time
+      }),
+    });
+
+    const res = await runJennyAgent({
+      supabase: makeSupabase(),
+      companyId: 'c1',
+      settings: {},
+      message: 'lawn care',
+    });
+
+    expect(res.readyToBook).toBe(false);
+    expect(res.booking).toBeNull();
+  });
+
+  it('replies in Spanish when the customer writes Spanish', async () => {
+    mockAiComplete.mockResolvedValue({
+      content: JSON.stringify({
+        reply: '¡Claro! ¿Qué día le gustaría?',
+        language: 'es',
+        intent: 'booking',
+        ready_to_book: false,
+        booking: null,
+      }),
+    });
+
+    const res = await runJennyAgent({
+      supabase: makeSupabase(),
+      companyId: 'c1',
+      settings: { language: 'both' },
+      message: 'Hola, necesito servicio de jardinería',
+    });
+
+    expect(res.language).toBe('es');
+  });
+
+  it('falls back gracefully when the AI throws', async () => {
+    mockAiComplete.mockRejectedValue(new Error('provider down'));
+
+    const res = await runJennyAgent({
+      supabase: makeSupabase(),
+      companyId: 'c1',
+      settings: {},
+      message: 'hello',
+    });
+
+    expect(res.readyToBook).toBe(false);
+    expect(typeof res.reply).toBe('string');
+    expect(res.reply.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/api/bookings/route.js
+++ b/src/app/api/bookings/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import Twilio from 'twilio';
+import { createBooking } from '@/lib/booking-core';
 
 // Lazy initialization for Twilio
 let twilioClient = null;
@@ -90,228 +91,28 @@ function getSupabase() {
   return supabaseInstance;
 }
 
-// Calculate end time based on start time and duration
-function calculateEndTime(startTime, durationMinutes) {
-  const [hours, minutes] = startTime.split(':').map(Number);
-  const totalMinutes = hours * 60 + minutes + durationMinutes;
-  const endHours = Math.floor(totalMinutes / 60);
-  const endMinutes = totalMinutes % 60;
-  return `${String(endHours).padStart(2, '0')}:${String(endMinutes).padStart(2, '0')}`;
-}
-
 export async function POST(request) {
   try {
     const body = await request.json();
 
-    const {
-      companyId,
-      serviceId,
-      serviceName,
-      scheduledDate,
-      scheduledTimeStart,
-      durationMinutes,
-      customerName,
-      customerEmail,
-      customerPhone,
-      customerAddress,
-      customerCity,
-      customerState,
-      customerZip,
-      notes,
-      smsConsent,
-    } = body;
-
-    // Validate required fields (email & address optional for chatbot bookings)
-    if (!companyId || !serviceName || !scheduledDate || !scheduledTimeStart || !customerName || !customerPhone) {
-      return NextResponse.json(
-        { error: 'Missing required fields' },
-        { status: 400 }
-      );
-    }
+    const { customerName, customerPhone, smsConsent, notes } = body;
 
     const supabase = getSupabase();
-    const isChatbotBooking = notes && notes.includes('booked via Jenny AI chat');
 
-    // Find an available time slot
-    // For chatbot bookings the requested time is a rough preference, so
-    // auto-advance to the next open slot instead of rejecting outright.
-    let finalDate = scheduledDate;
-    let finalTimeStart = scheduledTimeStart;
+    // Web bookings are strict about slot conflicts; chatbot/agent bookings
+    // (marked in the notes) auto-advance to the next opening.
+    const autoAdvance = !!(notes && notes.includes('booked via Jenny AI'));
 
-    // Get all booked slots for the requested date
-    const { data: existingJobs, error: checkError } = await supabase
-      .from('jobs')
-      .select('scheduled_time_start')
-      .eq('company_id', companyId)
-      .eq('scheduled_date', scheduledDate)
-      .neq('status', 'cancelled');
+    const result = await createBooking(supabase, { ...body, autoAdvance });
 
-    if (checkError) {
-      console.error('Error checking availability:', checkError);
+    if (!result.ok) {
       return NextResponse.json(
-        { error: 'Failed to check availability' },
-        { status: 500 }
+        { error: result.error },
+        { status: result.status || 500 }
       );
     }
 
-    const bookedTimes = new Set((existingJobs || []).map(j => j.scheduled_time_start));
-
-    if (bookedTimes.has(finalTimeStart)) {
-      if (!isChatbotBooking) {
-        // Non-chatbot bookings: strict — reject the conflict
-        return NextResponse.json(
-          { error: 'This time slot is no longer available. Please select a different time.' },
-          { status: 409 }
-        );
-      }
-
-      // Chatbot bookings: find the next open hourly slot (08:00–17:00)
-      const slots = [];
-      for (let h = 8; h <= 17; h++) {
-        slots.push(`${String(h).padStart(2, '0')}:00`);
-      }
-      const nextOpen = slots.find(s => !bookedTimes.has(s));
-
-      if (nextOpen) {
-        finalTimeStart = nextOpen;
-      } else {
-        // Entire day full — move to the next business day
-        const d = new Date(scheduledDate + 'T00:00:00');
-        do { d.setDate(d.getDate() + 1); } while (d.getDay() === 0 || d.getDay() === 6);
-        finalDate = d.toISOString().split('T')[0];
-        finalTimeStart = '09:00';
-      }
-    }
-
-    // Calculate end time
-    const scheduledTimeEnd = calculateEndTime(finalTimeStart, durationMinutes || 60);
-
-    // Check if customer already exists (by email if available, otherwise by phone)
-    let customerId = null;
-    let existingCustomerQuery = supabase
-      .from('customers')
-      .select('id')
-      .eq('company_id', companyId);
-
-    if (customerEmail) {
-      existingCustomerQuery = existingCustomerQuery.eq('email', customerEmail);
-    } else {
-      existingCustomerQuery = existingCustomerQuery.eq('phone', customerPhone);
-    }
-
-    const { data: existingCustomer } = await existingCustomerQuery.single();
-
-    if (existingCustomer) {
-      customerId = existingCustomer.id;
-
-      // Update customer info (only set fields that are provided)
-      const updateData = { name: customerName, phone: customerPhone, updated_at: new Date().toISOString() };
-      if (customerAddress) updateData.address = customerAddress;
-      if (customerCity) updateData.city = customerCity;
-      if (customerState) updateData.state = customerState;
-      if (customerZip) updateData.zip = customerZip;
-      if (smsConsent) {
-        updateData.sms_consent = true;
-        updateData.sms_consent_date = new Date().toISOString();
-      }
-
-      await supabase
-        .from('customers')
-        .update(updateData)
-        .eq('id', customerId);
-    } else {
-      // Create new customer
-      const newCustomerRow = {
-          company_id: companyId,
-          name: customerName,
-          phone: customerPhone,
-          source: 'online_booking',
-          sms_consent: !!smsConsent,
-          sms_consent_date: smsConsent ? new Date().toISOString() : null,
-        };
-      if (customerEmail) newCustomerRow.email = customerEmail;
-      if (customerAddress) newCustomerRow.address = customerAddress;
-      if (customerCity) newCustomerRow.city = customerCity;
-      if (customerState) newCustomerRow.state = customerState;
-      if (customerZip) newCustomerRow.zip = customerZip;
-
-      const { data: newCustomer, error: customerError } = await supabase
-        .from('customers')
-        .insert(newCustomerRow)
-        .select('id')
-        .single();
-
-      if (customerError) {
-        console.error('Error creating customer:', customerError);
-        return NextResponse.json(
-          { error: 'Failed to create customer record' },
-          { status: 500 }
-        );
-      }
-
-      customerId = newCustomer.id;
-    }
-
-    // Create the job (booking)
-    const jobRow = {
-        company_id: companyId,
-        customer_id: customerId,
-        title: serviceName,
-        description: notes || `Online booking for ${serviceName}`,
-        scheduled_date: finalDate,
-        scheduled_time_start: finalTimeStart,
-        scheduled_time_end: scheduledTimeEnd,
-        status: 'scheduled',
-        priority: 'normal',
-        notes: notes || null,
-      };
-    if (customerAddress) jobRow.address = customerAddress;
-    if (customerCity) jobRow.city = customerCity;
-    if (customerState) jobRow.state = customerState;
-    if (customerZip) jobRow.zip = customerZip;
-
-    const { data: job, error: jobError } = await supabase
-      .from('jobs')
-      .insert(jobRow)
-      .select()
-      .single();
-
-    if (jobError) {
-      console.error('Error creating job:', jobError);
-      return NextResponse.json(
-        { error: 'Failed to create booking' },
-        { status: 500 }
-      );
-    }
-
-    // Run lead creation and company name fetch in parallel (independent queries)
-    const [leadResult, companyResult] = await Promise.all([
-      supabase
-        .from('leads')
-        .insert({
-          company_id: companyId,
-          customer_id: customerId,
-          name: customerName,
-          email: customerEmail || null,
-          phone: customerPhone,
-          address: customerAddress || null,
-          service_requested: serviceName,
-          message: notes || `Booked ${serviceName} for ${finalDate}`,
-          source: 'online_booking',
-          status: 'new',
-        }),
-      supabase
-        .from('companies')
-        .select('name')
-        .eq('id', companyId)
-        .single(),
-    ]);
-
-    if (leadResult.error) {
-      console.error('Lead insert error:', leadResult.error);
-    }
-
-    const companyName = companyResult.data?.name || 'Our team';
+    const { booking, companyName, leadCreated } = result;
 
     // Only send SMS if customer consented
     let smsResult = { sent: false, reason: 'no_consent' };
@@ -319,9 +120,9 @@ export async function POST(request) {
       smsResult = await sendConfirmationSMS({
         to: customerPhone,
         customerName,
-        serviceName,
-        date: finalDate,
-        time: finalTimeStart,
+        serviceName: booking.service,
+        date: booking.date,
+        time: booking.time,
         companyName,
       });
     }
@@ -329,13 +130,13 @@ export async function POST(request) {
     return NextResponse.json({
       success: true,
       booking: {
-        id: job.id,
-        service: serviceName,
-        date: finalDate,
-        time: finalTimeStart,
-        customer: customerName,
+        id: booking.id,
+        service: booking.service,
+        date: booking.date,
+        time: booking.time,
+        customer: booking.customer,
       },
-      leadCreated: !leadResult.error,
+      leadCreated,
       smsStatus: smsResult.sent ? 'sent' : 'not_sent',
       smsDetail: smsResult.sent ? undefined : (smsResult.reason || smsResult.error),
     });

--- a/src/app/api/jenny-pro/settings/route.js
+++ b/src/app/api/jenny-pro/settings/route.js
@@ -66,6 +66,7 @@ export async function POST(request) {
     emergency_keywords,
     escalation_phone,
     language,
+    operator_language,
     auto_booking,
   } = body;
 
@@ -79,6 +80,7 @@ export async function POST(request) {
         emergency_keywords,
         escalation_phone,
         language,
+        operator_language,
         auto_booking,
         updated_at: new Date().toISOString(),
       },

--- a/src/app/api/jenny-pro/sms-webhook/route.js
+++ b/src/app/api/jenny-pro/sms-webhook/route.js
@@ -1,5 +1,8 @@
-import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { runJennyAgent } from '@/lib/jenny-sms-agent';
+import { createBooking } from '@/lib/booking-core';
+import { classifyKeyword, detectLanguage, resolveReplyLanguage, t } from '@/lib/jenny-language';
+import { notifyOperatorInApp, notifyOperatorSMS } from '@/lib/jenny-notify';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,71 +20,96 @@ function getSupabase() {
   return supabaseInstance;
 }
 
+function escapeXml(str) {
+  return String(str || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function twiml(message) {
+  const body = message
+    ? `<Response><Message>${escapeXml(message)}</Message></Response>`
+    : '<Response></Response>';
+  return new Response(body, { status: 200, headers: { 'Content-Type': 'text/xml' } });
+}
+
+// Format a YYYY-MM-DD + HH:MM for a friendly confirmation line.
+function fmtDate(dateStr) {
+  try {
+    return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
+      weekday: 'short', month: 'short', day: 'numeric',
+    });
+  } catch { return dateStr; }
+}
+function fmtTime(timeStr) {
+  const [h, m] = String(timeStr).split(':');
+  const hour = parseInt(h, 10);
+  const ampm = hour >= 12 ? 'PM' : 'AM';
+  return `${hour % 12 || 12}:${m || '00'} ${ampm}`;
+}
+
 /**
- * Twilio SMS webhook handler for Jenny Pro.
- * When a customer texts the business Twilio number, this:
- * 1. Finds or creates a conversation record
- * 2. Logs the inbound message
- * 3. Updates conversation status to needs_response
+ * Twilio SMS webhook for Jenny Pro.
  *
- * Configure as your Twilio phone number's webhook URL:
- * POST https://yourdomain.com/api/jenny-pro/sms-webhook
+ * Turns an inbound text into a booked job:
+ *  1. Logs the message and maintains a conversation thread
+ *  2. Honors STOP / START / HELP opt-out keywords (A2P 10DLC compliance)
+ *  3. Escalates emergencies to the operator instead of booking
+ *  4. Runs the AI booking agent (bilingual, auto-detects EN/ES) and replies
+ *  5. Auto-books when she has all the details (if auto_booking is on) and
+ *     notifies the operator
+ *
+ * Configure as the Twilio number's incoming-message webhook:
+ *   POST https://yourdomain.com/api/jenny-pro/sms-webhook
  */
 export async function POST(request) {
   try {
     const formData = await request.formData();
     const from = formData.get('From');
-    const body = formData.get('Body');
+    const body = (formData.get('Body') || '').toString().trim();
     const messageSid = formData.get('MessageSid');
     const to = formData.get('To');
 
-    if (!from || !body) {
-      return new Response('<Response></Response>', {
-        status: 200,
-        headers: { 'Content-Type': 'text/xml' },
-      });
-    }
+    if (!from || !body) return twiml(null);
 
     const supabase = getSupabase();
 
-    // Find the company that owns this Twilio phone number
-    // For now, look up by matching the TWILIO_PHONE_NUMBER env var
-    // In multi-tenant setup, this would query a phone_numbers table
-    const twilioNumber = process.env.TWILIO_PHONE_NUMBER;
+    // Resolve the company that owns this Twilio number.
+    // Single-tenant today (matches TWILIO_PHONE_NUMBER); a phone_numbers table
+    // would make this multi-tenant later.
     let companyId = null;
-
-    if (twilioNumber && to === twilioNumber) {
-      // Single-tenant: use the first company (or match by config)
-      const { data: companies } = await supabase
-        .from('companies')
-        .select('id')
-        .limit(1);
+    const twilioNumber = process.env.TWILIO_PHONE_NUMBER;
+    if (!twilioNumber || to === twilioNumber || !to) {
+      const { data: companies } = await supabase.from('companies').select('id').limit(1);
       if (companies?.length) companyId = companies[0].id;
     }
+    if (!companyId) return twiml(null);
 
-    if (!companyId) {
-      // Return empty TwiML — we can't route the message
-      return new Response('<Response></Response>', {
-        status: 200,
-        headers: { 'Content-Type': 'text/xml' },
-      });
-    }
+    // Load per-company Jenny Pro config.
+    const { data: settings } = await supabase
+      .from('jenny_pro_settings')
+      .select('*')
+      .eq('company_id', companyId)
+      .maybeSingle();
 
-    // Find or create conversation
+    // Find or create the active conversation for this customer.
     const { data: existing } = await supabase
       .from('jenny_sms_conversations')
-      .select('id, message_count')
+      .select('id, message_count, language')
       .eq('company_id', companyId)
       .eq('customer_phone', from)
-      .eq('status', 'active')
+      .neq('status', 'resolved')
       .order('created_at', { ascending: false })
       .limit(1)
       .maybeSingle();
 
-    let conversationId;
+    let conversationId = existing?.id || null;
+    let knownCustomer = null;
 
     if (existing) {
-      conversationId = existing.id;
       await supabase
         .from('jenny_sms_conversations')
         .update({
@@ -93,7 +121,6 @@ export async function POST(request) {
         })
         .eq('id', existing.id);
     } else {
-      // Check if we know this customer
       const cleanPhone = from.replace(/\D/g, '').slice(-10);
       const { data: customer } = await supabase
         .from('customers')
@@ -102,6 +129,7 @@ export async function POST(request) {
         .or(`phone.ilike.%${cleanPhone}%`)
         .limit(1)
         .maybeSingle();
+      knownCustomer = customer || null;
 
       const { data: newConv } = await supabase
         .from('jenny_sms_conversations')
@@ -114,34 +142,178 @@ export async function POST(request) {
           status: 'needs_response',
           message_count: 1,
           source: 'inbound',
+          language: detectLanguage(body),
         })
         .select('id')
         .single();
-
-      conversationId = newConv?.id;
+      conversationId = newConv?.id || null;
     }
 
-    // Log the message
+    // Log the inbound message.
     if (conversationId) {
       await supabase.from('jenny_sms_messages').insert({
         conversation_id: conversationId,
         direction: 'inbound',
-        body: body,
+        body,
         twilio_sid: messageSid,
         status: 'received',
       });
     }
 
-    // Return empty TwiML (no auto-reply for now — owner reviews and responds)
-    return new Response('<Response></Response>', {
-      status: 200,
-      headers: { 'Content-Type': 'text/xml' },
+    const logOutbound = async (text) => {
+      if (conversationId && text) {
+        await supabase.from('jenny_sms_messages').insert({
+          conversation_id: conversationId,
+          direction: 'outbound',
+          body: text,
+          status: 'sent',
+        });
+        await supabase
+          .from('jenny_sms_conversations')
+          .update({ last_message: text, last_message_at: new Date().toISOString() })
+          .eq('id', conversationId);
+      }
+    };
+
+    // ── Opt-out / opt-in / help keywords (compliance) ──────────────────────
+    const keyword = classifyKeyword(body);
+    const kwLang = resolveReplyLanguage(detectLanguage(body), settings?.language);
+    if (keyword === 'stop') {
+      // Mark the customer opted out; Twilio also blocks further sends.
+      const cleanPhone = from.replace(/\D/g, '').slice(-10);
+      await supabase
+        .from('customers')
+        .update({ sms_consent: false })
+        .eq('company_id', companyId)
+        .ilike('phone', `%${cleanPhone}%`);
+      // Twilio auto-responds to STOP; return empty to avoid a double reply.
+      return twiml(null);
+    }
+    if (keyword === 'start') {
+      await logOutbound(t(kwLang).optInConfirm);
+      return twiml(t(kwLang).optInConfirm);
+    }
+    if (keyword === 'help') {
+      await logOutbound(t(kwLang).help);
+      return twiml(t(kwLang).help);
+    }
+
+    // ── Run the booking agent ──────────────────────────────────────────────
+    // Build recent history for context (last ~10 messages).
+    let history = [];
+    if (conversationId) {
+      const { data: msgs } = await supabase
+        .from('jenny_sms_messages')
+        .select('direction, body, created_at')
+        .eq('conversation_id', conversationId)
+        .order('created_at', { ascending: true })
+        .limit(20);
+      // Exclude the just-logged inbound (it's passed as `message`).
+      const prior = (msgs || []).slice(0, -1).slice(-10);
+      history = prior.map((m) => ({
+        role: m.direction === 'inbound' ? 'user' : 'assistant',
+        content: m.body,
+      }));
+    }
+
+    const result = await runJennyAgent({
+      supabase,
+      companyId,
+      settings,
+      history,
+      message: body,
+      channel: 'sms',
     });
+
+    // Persist language/intent on the conversation.
+    if (conversationId) {
+      await supabase
+        .from('jenny_sms_conversations')
+        .update({ language: result.language, last_intent: result.intent })
+        .eq('id', conversationId);
+    }
+
+    // ── Emergency: escalate, don't book ────────────────────────────────────
+    if (result.emergency) {
+      await logOutbound(result.reply);
+      const opLang = settings?.operator_language || 'en';
+      await Promise.all([
+        notifyOperatorSMS(
+          settings?.escalation_phone,
+          `🚨 URGENT: ${knownCustomer?.name || from} texted: "${body.slice(0, 120)}"`
+        ),
+        notifyOperatorInApp(supabase, {
+          companyId,
+          type: 'new_lead',
+          title: opLang === 'es' ? 'Mensaje urgente' : 'Urgent message',
+          message: `${knownCustomer?.name || from}: ${body.slice(0, 140)}`,
+          link: '/dashboard/jenny-pro',
+        }),
+      ]);
+      return twiml(result.reply);
+    }
+
+    // ── Auto-book when ready (and enabled) ─────────────────────────────────
+    const autoBookingOn = !settings || settings.auto_booking !== false;
+    if (result.readyToBook && result.booking && autoBookingOn) {
+      const b = result.booking;
+      const bookingRes = await createBooking(supabase, {
+        companyId,
+        serviceName: b.serviceName,
+        scheduledDate: b.scheduledDate,
+        scheduledTimeStart: b.scheduledTimeStart,
+        durationMinutes: 60,
+        customerName: b.customerName,
+        customerPhone: from,
+        customerAddress: b.address || undefined,
+        notes: `${b.notes || ''} (booked via Jenny AI SMS)`.trim(),
+        smsConsent: true, // they texted us first — they initiated the conversation
+        source: 'jenny_sms',
+        autoAdvance: true,
+      });
+
+      if (bookingRes.ok) {
+        // Jenny's reply already confirms; mark the thread resolved + linked.
+        if (conversationId) {
+          await supabase
+            .from('jenny_sms_conversations')
+            .update({
+              status: 'resolved',
+              booking_id: bookingRes.booking.id,
+              customer_name: b.customerName,
+            })
+            .eq('id', conversationId);
+        }
+        const opLang = settings?.operator_language || 'en';
+        const when = `${fmtDate(bookingRes.booking.date)} ${fmtTime(bookingRes.booking.time)}`;
+        await Promise.all([
+          notifyOperatorSMS(
+            settings?.escalation_phone,
+            `✅ Jenny booked ${b.customerName} — ${b.serviceName}, ${when}.`
+          ),
+          notifyOperatorInApp(supabase, {
+            companyId,
+            type: 'booking_received',
+            title: opLang === 'es' ? 'Nueva cita agendada' : 'New booking',
+            message:
+              opLang === 'es'
+                ? `Jenny agendó a ${b.customerName} para ${b.serviceName} el ${when}.`
+                : `Jenny booked ${b.customerName} for ${b.serviceName} on ${when}.`,
+            link: '/dashboard/dispatch',
+          }),
+        ]);
+        await logOutbound(result.reply);
+        return twiml(result.reply);
+      }
+      // Booking failed (e.g. fully booked) — let Jenny's reply stand and flag it.
+      console.error('[sms-webhook] booking failed:', bookingRes.error);
+    }
+
+    // ── Normal conversational reply ────────────────────────────────────────
+    await logOutbound(result.reply);
+    return twiml(result.reply);
   } catch (error) {
     console.error('[Jenny Pro SMS Webhook] Error:', error);
-    return new Response('<Response></Response>', {
-      status: 200,
-      headers: { 'Content-Type': 'text/xml' },
-    });
+    return twiml(null);
   }
 }

--- a/src/app/api/jenny-pro/voice/after-dial/route.js
+++ b/src/app/api/jenny-pro/voice/after-dial/route.js
@@ -1,0 +1,95 @@
+import { getServiceSupabase, resolveCompany, buildSay, voiceResponse } from '@/lib/jenny-voice';
+import { sendSMS } from '@/lib/twilio';
+import { t } from '@/lib/jenny-language';
+import { notifyOperatorInApp } from '@/lib/jenny-notify';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Dial-action callback: fires after Jenny tried to ring the owner.
+ *
+ * If the owner answered (DialCallStatus = completed) we simply hang up.
+ * Otherwise the call was MISSED — Jenny instantly texts the caller to open an
+ * SMS booking conversation, logs the missed call, and notifies the operator.
+ * This is the "turn a missed call into a booked job" path.
+ */
+export async function POST(request) {
+  try {
+    const form = await request.formData();
+    const dialStatus = form.get('DialCallStatus');
+    const caller = form.get('From'); // original caller
+    const to = form.get('To');
+    const callSid = form.get('CallSid');
+
+    // Owner picked up — nothing more to do.
+    if (dialStatus === 'completed') {
+      return voiceResponse('<Hangup/>');
+    }
+
+    const supabase = getServiceSupabase();
+    const company = await resolveCompany(supabase, to);
+    if (!company) return voiceResponse('<Hangup/>');
+
+    const { data: settings } = await supabase
+      .from('jenny_pro_settings')
+      .select('language, operator_language')
+      .eq('company_id', company.id)
+      .maybeSingle();
+
+    const lang = settings?.language === 'es' ? 'es' : 'en';
+    const companyName = company.name || 'our team';
+
+    // Log the missed call.
+    await supabase.from('jenny_voice_calls').insert({
+      company_id: company.id,
+      caller_phone: caller,
+      call_type: 'inbound',
+      status: 'missed',
+      twilio_sid: callSid,
+    });
+
+    // Text the caller to keep the lead alive — this seeds the SMS booking flow.
+    if (caller) {
+      await sendSMS({ to: caller, body: t(lang).missedCallText(companyName) });
+
+      // Seed an SMS conversation so the inbound reply threads correctly.
+      const { data: existing } = await supabase
+        .from('jenny_sms_conversations')
+        .select('id')
+        .eq('company_id', company.id)
+        .eq('customer_phone', caller)
+        .neq('status', 'resolved')
+        .maybeSingle();
+      if (!existing) {
+        await supabase.from('jenny_sms_conversations').insert({
+          company_id: company.id,
+          customer_phone: caller,
+          customer_name: 'Missed call',
+          status: 'needs_response',
+          source: 'inbound',
+          last_message: '[missed call — auto text sent]',
+          last_message_at: new Date().toISOString(),
+          message_count: 0,
+          language: lang,
+        });
+      }
+    }
+
+    const opLang = settings?.operator_language || 'en';
+    await notifyOperatorInApp(supabase, {
+      companyId: company.id,
+      type: 'new_lead',
+      title: opLang === 'es' ? 'Llamada perdida' : 'Missed call',
+      message:
+        opLang === 'es'
+          ? `Llamada perdida de ${caller}. Jenny le envió un mensaje de texto.`
+          : `Missed call from ${caller}. Jenny texted them to follow up.`,
+      link: '/dashboard/jenny-pro',
+    });
+
+    return voiceResponse(buildSay(t(lang).voiceMissed(companyName), lang) + '<Hangup/>');
+  } catch (error) {
+    console.error('[Jenny Voice after-dial] Error:', error);
+    return voiceResponse('<Hangup/>');
+  }
+}

--- a/src/app/api/jenny-pro/voice/gather/route.js
+++ b/src/app/api/jenny-pro/voice/gather/route.js
@@ -1,0 +1,174 @@
+import {
+  getServiceSupabase,
+  resolveCompany,
+  buildSay,
+  buildGather,
+  voiceResponse,
+  getOrCreateVoiceConversation,
+} from '@/lib/jenny-voice';
+import { runJennyAgent } from '@/lib/jenny-sms-agent';
+import { createBooking } from '@/lib/booking-core';
+import { notifyOperatorInApp } from '@/lib/jenny-notify';
+
+export const dynamic = 'force-dynamic';
+
+const GATHER_URL = '/api/jenny-pro/voice/gather';
+
+/**
+ * Conversational voice receptionist (speech).
+ *
+ * Twilio posts the caller's transcribed speech (SpeechResult). Jenny runs the
+ * shared booking agent and speaks her reply, gathering again until she has
+ * enough to book — then she creates the appointment and confirms by voice.
+ */
+export async function POST(request) {
+  try {
+    const form = await request.formData();
+    const to = form.get('To');
+    const caller = form.get('From');
+    const speech = (form.get('SpeechResult') || '').toString().trim();
+
+    const supabase = getServiceSupabase();
+    const company = await resolveCompany(supabase, to);
+    if (!company) {
+      return voiceResponse(buildSay("Sorry, we can't help right now. Goodbye.", 'en'));
+    }
+
+    const { data: settings } = await supabase
+      .from('jenny_pro_settings')
+      .select('*')
+      .eq('company_id', company.id)
+      .maybeSingle();
+
+    const conv = await getOrCreateVoiceConversation(supabase, company.id, caller);
+
+    // No speech captured — (re)prompt.
+    if (!speech) {
+      const lang = settings?.language === 'es' ? 'es' : 'en';
+      const prompt =
+        lang === 'es'
+          ? '¿En qué servicio le puedo ayudar y para qué día le gustaría agendar?'
+          : 'What service can I help you with, and what day works for you?';
+      return voiceResponse(buildGather(prompt, lang, GATHER_URL));
+    }
+
+    // Log the caller's turn.
+    if (conv?.id) {
+      await supabase.from('jenny_sms_messages').insert({
+        conversation_id: conv.id,
+        direction: 'inbound',
+        body: speech,
+        status: 'received',
+      });
+    }
+
+    // Rebuild history for context.
+    let history = [];
+    if (conv?.id) {
+      const { data: msgs } = await supabase
+        .from('jenny_sms_messages')
+        .select('direction, body, created_at')
+        .eq('conversation_id', conv.id)
+        .order('created_at', { ascending: true })
+        .limit(20);
+      const prior = (msgs || []).slice(0, -1).slice(-10);
+      history = prior.map((m) => ({
+        role: m.direction === 'inbound' ? 'user' : 'assistant',
+        content: m.body,
+      }));
+    }
+
+    const result = await runJennyAgent({
+      supabase,
+      companyId: company.id,
+      settings,
+      history,
+      message: speech,
+      channel: 'voice',
+    });
+
+    const lang = result.language;
+
+    // Log Jenny's spoken reply.
+    if (conv?.id) {
+      await supabase.from('jenny_sms_messages').insert({
+        conversation_id: conv.id,
+        direction: 'outbound',
+        body: result.reply,
+        status: 'sent',
+      });
+      await supabase
+        .from('jenny_sms_conversations')
+        .update({
+          language: lang,
+          last_intent: result.intent,
+          last_message: result.reply,
+          last_message_at: new Date().toISOString(),
+          message_count: (conv.message_count || 0) + 1,
+        })
+        .eq('id', conv.id);
+    }
+
+    // Emergency — escalate by voice and end.
+    if (result.emergency) {
+      return voiceResponse(buildSay(result.reply, lang) + '<Hangup/>');
+    }
+
+    // Ready to book?
+    const autoBookingOn = !settings || settings.auto_booking !== false;
+    if (result.readyToBook && result.booking && autoBookingOn) {
+      const b = result.booking;
+      const bookingRes = await createBooking(supabase, {
+        companyId: company.id,
+        serviceName: b.serviceName,
+        scheduledDate: b.scheduledDate,
+        scheduledTimeStart: b.scheduledTimeStart,
+        durationMinutes: 60,
+        customerName: b.customerName,
+        customerPhone: caller,
+        customerAddress: b.address || undefined,
+        notes: `${b.notes || ''} (booked via Jenny AI voice)`.trim(),
+        smsConsent: false,
+        source: 'jenny_voice',
+        autoAdvance: true,
+      });
+
+      if (bookingRes.ok) {
+        if (conv?.id) {
+          await supabase
+            .from('jenny_sms_conversations')
+            .update({ status: 'resolved', booking_id: bookingRes.booking.id, customer_name: b.customerName })
+            .eq('id', conv.id);
+        }
+        await supabase
+          .from('jenny_voice_calls')
+          .update({ booking_created: true })
+          .eq('company_id', company.id)
+          .eq('caller_phone', caller)
+          .eq('booking_created', false);
+
+        const opLang = settings?.operator_language || 'en';
+        await notifyOperatorInApp(supabase, {
+          companyId: company.id,
+          type: 'booking_received',
+          title: opLang === 'es' ? 'Nueva cita (llamada)' : 'New booking (call)',
+          message:
+            opLang === 'es'
+              ? `Jenny agendó a ${b.customerName} para ${b.serviceName}.`
+              : `Jenny booked ${b.customerName} for ${b.serviceName}.`,
+          link: '/dashboard/dispatch',
+        });
+
+        const closing = lang === 'es' ? ' ¡Gracias por llamar!' : ' Thanks for calling!';
+        return voiceResponse(buildSay(result.reply + closing, lang) + '<Hangup/>');
+      }
+      console.error('[voice/gather] booking failed:', bookingRes.error);
+    }
+
+    // Keep the conversation going.
+    return voiceResponse(buildGather(result.reply, lang, GATHER_URL));
+  } catch (error) {
+    console.error('[Jenny Voice gather] Error:', error);
+    return voiceResponse(buildSay('Sorry, something went wrong. Please call again later.', 'en'));
+  }
+}

--- a/src/app/api/jenny-pro/voice/route.js
+++ b/src/app/api/jenny-pro/voice/route.js
@@ -1,0 +1,59 @@
+import { getServiceSupabase, resolveCompany, buildSay, voiceResponse } from '@/lib/jenny-voice';
+import { t } from '@/lib/jenny-language';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Primary inbound-call webhook for Jenny Pro voice.
+ *
+ * Behavior (the "missed call" half):
+ *   - If the company has an escalation/cell number, Jenny tries to connect the
+ *     caller to the owner first. If the owner doesn't pick up, /after-dial
+ *     texts the caller to keep the lead alive (missed call → booking).
+ *   - If there's no owner number, the AI receptionist answers directly.
+ *
+ * Configure as the Twilio number's "A Call Comes In" webhook:
+ *   POST https://yourdomain.com/api/jenny-pro/voice
+ */
+export async function POST(request) {
+  try {
+    const form = await request.formData();
+    const to = form.get('To');
+
+    const supabase = getServiceSupabase();
+    const company = await resolveCompany(supabase, to);
+    if (!company) {
+      return voiceResponse(buildSay("Sorry, we can't take your call right now. Please try again later.", 'en'));
+    }
+
+    const { data: settings } = await supabase
+      .from('jenny_pro_settings')
+      .select('escalation_phone, language')
+      .eq('company_id', company.id)
+      .maybeSingle();
+
+    const lang = settings?.language === 'es' ? 'es' : 'en';
+
+    // If we have the owner's number, ring them first, then fall back to Jenny.
+    if (settings?.escalation_phone) {
+      const greeting = lang === 'es'
+        ? 'Un momento, le conectamos con nuestro equipo.'
+        : 'One moment while we connect you with our team.';
+      const dial =
+        `<Dial timeout="18" action="/api/jenny-pro/voice/after-dial" method="POST">` +
+        `<Number>${settings.escalation_phone}</Number>` +
+        `</Dial>`;
+      return voiceResponse(buildSay(greeting, lang) + dial);
+    }
+
+    // No owner number — go straight to the AI receptionist.
+    const greeting = t(lang).voiceGreeting(company.name || 'our office');
+    return voiceResponse(
+      buildSay(greeting, lang) +
+        `<Redirect method="POST">/api/jenny-pro/voice/gather</Redirect>`
+    );
+  } catch (error) {
+    console.error('[Jenny Voice] Error:', error);
+    return voiceResponse(buildSay('Sorry, something went wrong. Please call again.', 'en'));
+  }
+}

--- a/src/app/dashboard/jenny-pro/page.tsx
+++ b/src/app/dashboard/jenny-pro/page.tsx
@@ -27,6 +27,7 @@ interface SMSConversation {
   status: 'active' | 'resolved' | 'needs_response';
   message_count: number;
   lead_id: string | null;
+  booking_id?: string | null;
 }
 
 interface JennyProStats {
@@ -35,6 +36,26 @@ interface JennyProStats {
   bookingsMade: number;
   avgResponseTime: string;
 }
+
+interface JennyProSettings {
+  business_hours_greeting: string;
+  after_hours_greeting: string;
+  emergency_keywords: string;
+  escalation_phone: string;
+  language: 'en' | 'es' | 'both';
+  operator_language: 'en' | 'es';
+  auto_booking: boolean;
+}
+
+const DEFAULT_SETTINGS: JennyProSettings = {
+  business_hours_greeting: '',
+  after_hours_greeting: '',
+  emergency_keywords: 'emergency, urgent, burst, leak, flood, fire, broken',
+  escalation_phone: '',
+  language: 'both',
+  operator_language: 'en',
+  auto_booking: true,
+};
 
 export default function JennyProPage() {
   const { company, dbUser } = useAuth();
@@ -58,6 +79,9 @@ function JennyProDashboard() {
     bookingsMade: 0,
     avgResponseTime: '--',
   });
+  const [settings, setSettings] = useState<JennyProSettings>(DEFAULT_SETTINGS);
+  const [savingSettings, setSavingSettings] = useState(false);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
 
   const fetchConversations = useCallback(async () => {
     if (!dbUser?.company_id) return;
@@ -75,7 +99,7 @@ function JennyProDashboard() {
         setStats({
           totalConversations: data.length,
           leadsCapture: data.filter((c: SMSConversation) => c.lead_id).length,
-          bookingsMade: 0,
+          bookingsMade: data.filter((c: { booking_id?: string | null }) => c.booking_id).length,
           avgResponseTime: data.length > 0 ? '< 30s' : '--',
         });
       }
@@ -85,9 +109,64 @@ function JennyProDashboard() {
     setLoading(false);
   }, [dbUser?.company_id]);
 
+  const fetchSettings = useCallback(async () => {
+    if (!dbUser?.company_id) return;
+    try {
+      const { data } = await supabase
+        .from('jenny_pro_settings')
+        .select('*')
+        .eq('company_id', dbUser.company_id)
+        .maybeSingle();
+      if (data) {
+        setSettings({
+          business_hours_greeting: data.business_hours_greeting || '',
+          after_hours_greeting: data.after_hours_greeting || '',
+          emergency_keywords: Array.isArray(data.emergency_keywords)
+            ? data.emergency_keywords.join(', ')
+            : (data.emergency_keywords || DEFAULT_SETTINGS.emergency_keywords),
+          escalation_phone: data.escalation_phone || '',
+          language: (data.language as JennyProSettings['language']) || 'both',
+          operator_language: (data.operator_language as JennyProSettings['operator_language']) || 'en',
+          auto_booking: data.auto_booking !== false,
+        });
+      }
+    } catch {
+      // Settings table/columns may not exist yet — keep defaults
+    }
+  }, [dbUser?.company_id]);
+
+  const saveSettings = useCallback(async () => {
+    if (!dbUser?.company_id) return;
+    setSavingSettings(true);
+    try {
+      await supabase.from('jenny_pro_settings').upsert(
+        {
+          company_id: dbUser.company_id,
+          business_hours_greeting: settings.business_hours_greeting,
+          after_hours_greeting: settings.after_hours_greeting,
+          emergency_keywords: settings.emergency_keywords
+            .split(',')
+            .map((k) => k.trim())
+            .filter(Boolean),
+          escalation_phone: settings.escalation_phone,
+          language: settings.language,
+          operator_language: settings.operator_language,
+          auto_booking: settings.auto_booking,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'company_id' }
+      );
+      setSavedAt(Date.now());
+    } catch {
+      // ignore — best effort
+    }
+    setSavingSettings(false);
+  }, [dbUser?.company_id, settings]);
+
   useEffect(() => {
     fetchConversations();
-  }, [fetchConversations]);
+    fetchSettings();
+  }, [fetchConversations, fetchSettings]);
 
   const isBetaTester = company?.is_beta_tester;
 
@@ -288,15 +367,40 @@ function JennyProDashboard() {
           <div className="bg-white rounded-xl border p-6">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Jenny Pro Settings</h3>
 
-            {/* Business Hours */}
+            {/* Auto-booking toggle */}
+            <div className="flex items-start justify-between gap-4 p-4 bg-blue-50 rounded-lg border border-blue-100 mb-4">
+              <div>
+                <p className="text-sm font-medium text-gray-900">Auto-book appointments</p>
+                <p className="text-xs text-gray-600 mt-0.5">
+                  When Jenny has the name, service, date and time, she books the job automatically
+                  and notifies you. Turn off to review every request before it&apos;s confirmed.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSettings((s) => ({ ...s, auto_booking: !s.auto_booking }))}
+                className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
+                  settings.auto_booking ? 'bg-blue-600' : 'bg-gray-300'
+                }`}
+                aria-pressed={settings.auto_booking}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                    settings.auto_booking ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+
             <div className="space-y-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Business Hours Greeting</label>
                 <textarea
                   className="w-full border rounded-lg p-3 text-sm"
                   rows={2}
-                  defaultValue={`Thank you for calling ${company?.name || 'our office'}! I'm Jenny, your AI assistant. How can I help you today?`}
-                  placeholder="Greeting for business hours calls..."
+                  value={settings.business_hours_greeting}
+                  onChange={(e) => setSettings((s) => ({ ...s, business_hours_greeting: e.target.value }))}
+                  placeholder={`Thank you for calling ${company?.name || 'our office'}! I'm Jenny, your AI assistant. How can I help you today?`}
                 />
               </div>
 
@@ -305,8 +409,9 @@ function JennyProDashboard() {
                 <textarea
                   className="w-full border rounded-lg p-3 text-sm"
                   rows={2}
-                  defaultValue={`Thank you for calling ${company?.name || 'our office'}. Our office is currently closed, but I can help with emergencies and take messages.`}
-                  placeholder="Greeting for after-hours calls..."
+                  value={settings.after_hours_greeting}
+                  onChange={(e) => setSettings((s) => ({ ...s, after_hours_greeting: e.target.value }))}
+                  placeholder={`Thank you for calling ${company?.name || 'our office'}. Our office is currently closed, but I can help with emergencies and take messages.`}
                 />
               </div>
 
@@ -315,11 +420,13 @@ function JennyProDashboard() {
                 <input
                   type="text"
                   className="w-full border rounded-lg p-3 text-sm"
-                  defaultValue="emergency, urgent, burst, leak, flood, fire, broken"
+                  value={settings.emergency_keywords}
+                  onChange={(e) => setSettings((s) => ({ ...s, emergency_keywords: e.target.value }))}
                   placeholder="Keywords that trigger emergency handling..."
                 />
                 <p className="text-xs text-gray-500 mt-1">
-                  When a caller mentions these words, Jenny escalates to your on-call number immediately.
+                  When a customer uses these words (in English or Spanish), Jenny skips booking and
+                  escalates to your on-call number immediately.
                 </p>
               </div>
 
@@ -328,28 +435,68 @@ function JennyProDashboard() {
                 <input
                   type="tel"
                   className="w-full border rounded-lg p-3 text-sm"
-                  defaultValue={company?.phone || ''}
-                  placeholder="Phone number for emergency escalation..."
+                  value={settings.escalation_phone}
+                  onChange={(e) => setSettings((s) => ({ ...s, escalation_phone: e.target.value }))}
+                  placeholder="Phone number for missed-call ring + emergency escalation..."
                 />
+                <p className="text-xs text-gray-500 mt-1">
+                  Jenny rings this number first on inbound calls. If you don&apos;t pick up, she texts the
+                  caller to keep the lead alive.
+                </p>
               </div>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Language</label>
-                <select className="w-full border rounded-lg p-3 text-sm">
-                  <option value="en">English</option>
-                  <option value="es">Spanish</option>
-                  <option value="both">Bilingual (English + Spanish)</option>
-                </select>
+              <div className="grid sm:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Customer Language</label>
+                  <select
+                    className="w-full border rounded-lg p-3 text-sm"
+                    value={settings.language}
+                    onChange={(e) =>
+                      setSettings((s) => ({ ...s, language: e.target.value as JennyProSettings['language'] }))
+                    }
+                  >
+                    <option value="both">Bilingual — auto-detect EN/ES (recommended)</option>
+                    <option value="es">Spanish only</option>
+                    <option value="en">English only</option>
+                  </select>
+                  <p className="text-xs text-gray-500 mt-1">
+                    How Jenny talks to your customers. Bilingual mirrors whichever language they text or speak.
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Your Notification Language</label>
+                  <select
+                    className="w-full border rounded-lg p-3 text-sm"
+                    value={settings.operator_language}
+                    onChange={(e) =>
+                      setSettings((s) => ({
+                        ...s,
+                        operator_language: e.target.value as JennyProSettings['operator_language'],
+                      }))
+                    }
+                  >
+                    <option value="es">Español</option>
+                    <option value="en">English</option>
+                  </select>
+                  <p className="text-xs text-gray-500 mt-1">
+                    The language for your booking and missed-call alerts.
+                  </p>
+                </div>
               </div>
             </div>
 
             <div className="mt-6 flex items-center gap-3">
-              <button className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700">
-                Save Settings
+              <button
+                onClick={saveSettings}
+                disabled={savingSettings}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+              >
+                {savingSettings ? 'Saving…' : 'Save Settings'}
               </button>
-              <p className="text-xs text-gray-500">
-                Voice settings will apply once Twilio campaign is approved.
-              </p>
+              {savedAt && !savingSettings && (
+                <p className="text-xs text-green-600">Saved ✓</p>
+              )}
             </div>
           </div>
 

--- a/src/app/demo/phone-receptionist/page.tsx
+++ b/src/app/demo/phone-receptionist/page.tsx
@@ -95,6 +95,33 @@ const demoScenarios = [
       existingCustomer: true,
     },
   },
+  {
+    id: 'spanish',
+    name: 'Cliente en Español',
+    icon: '🇲🇽',
+    description: 'Jenny books a job entirely in Spanish',
+    transcript: [
+      { speaker: 'ai', text: '¡Gracias por llamar a Jardinería Sol! Soy Jenny, la asistente virtual. ¿En qué le puedo ayudar hoy?' },
+      { speaker: 'customer', text: 'Hola, necesito que vengan a cortar el césped de mi jardín.' },
+      { speaker: 'ai', text: '¡Con mucho gusto! ¿Me puede dar su nombre, por favor?' },
+      { speaker: 'customer', text: 'Sí, soy María González.' },
+      { speaker: 'ai', text: 'Perfecto, María. ¿Y cuál es la dirección donde necesita el servicio?' },
+      { speaker: 'customer', text: 'Calle Primavera 482, en Fresno.' },
+      { speaker: 'ai', text: 'Muy bien. Tenemos disponibilidad mañana por la mañana o el jueves por la tarde. ¿Cuál le conviene más?' },
+      { speaker: 'customer', text: 'Mañana en la mañana está bien.' },
+      { speaker: 'ai', text: '¡Listo, María! Su cita para cortar el césped quedó agendada para mañana a las 9:00 AM. Le enviaré una confirmación por mensaje de texto. ¿Algo más en que le pueda ayudar?' },
+      { speaker: 'customer', text: 'No, eso es todo. ¡Muchas gracias!' },
+      { speaker: 'ai', text: '¡Gracias a usted por elegir Jardinería Sol! Nos vemos mañana. ¡Que tenga buen día!' },
+    ],
+    leadCaptured: {
+      name: 'María González',
+      phone: '555-823-4471',
+      address: 'Calle Primavera 482, Fresno',
+      service: 'Corte de Césped',
+      notes: 'Cliente en español — cita agendada para mañana 9:00 AM',
+      estimatedValue: '$65-85/visita',
+    },
+  },
 ];
 
 // Stats for the feature section - icons only, labels come from translations

--- a/src/lib/booking-core.js
+++ b/src/lib/booking-core.js
@@ -1,0 +1,235 @@
+// Shared booking core — turns a captured request into a job + customer + lead.
+//
+// Used by:
+//   - POST /api/bookings        (web + chatbot online booking)
+//   - Jenny Pro SMS agent       (text → booked job)
+//   - Jenny Pro voice receptionist (call → booked job)
+//
+// This module ONLY touches the database. Sending confirmations (SMS/voice) is
+// the caller's responsibility, so each channel can localize its own messaging.
+
+// Calculate end time based on start time and duration
+function calculateEndTime(startTime, durationMinutes) {
+  const [hours, minutes] = startTime.split(':').map(Number);
+  const totalMinutes = hours * 60 + minutes + (durationMinutes || 60);
+  const endHours = Math.floor(totalMinutes / 60);
+  const endMinutes = totalMinutes % 60;
+  return `${String(endHours).padStart(2, '0')}:${String(endMinutes).padStart(2, '0')}`;
+}
+
+/**
+ * Create a booking (job + customer + lead) for a company.
+ *
+ * @param {object} supabase - An initialized Supabase client (service role).
+ * @param {object} params
+ * @returns {Promise<{ ok: boolean, status?: number, error?: string, booking?: object, companyName?: string, customerId?: string, leadCreated?: boolean }>}
+ */
+async function createBooking(supabase, params) {
+  const {
+    companyId,
+    serviceName,
+    scheduledDate,
+    scheduledTimeStart,
+    durationMinutes,
+    customerName,
+    customerEmail,
+    customerPhone,
+    customerAddress,
+    customerCity,
+    customerState,
+    customerZip,
+    notes,
+    smsConsent,
+    source,
+    // When true, a conflicting slot auto-advances to the next opening instead
+    // of failing. Defaults to chatbot/agent behavior when the note marks it.
+    autoAdvance,
+  } = params;
+
+  if (!companyId || !serviceName || !scheduledDate || !scheduledTimeStart || !customerName || !customerPhone) {
+    return { ok: false, status: 400, error: 'Missing required fields' };
+  }
+
+  const isFlexibleBooking =
+    autoAdvance === true || (notes && notes.includes('booked via Jenny AI'));
+
+  let finalDate = scheduledDate;
+  let finalTimeStart = scheduledTimeStart;
+
+  // Get all booked slots for the requested date
+  const { data: existingJobs, error: checkError } = await supabase
+    .from('jobs')
+    .select('scheduled_time_start')
+    .eq('company_id', companyId)
+    .eq('scheduled_date', scheduledDate)
+    .neq('status', 'cancelled');
+
+  if (checkError) {
+    console.error('[booking-core] Error checking availability:', checkError);
+    return { ok: false, status: 500, error: 'Failed to check availability' };
+  }
+
+  const bookedTimes = new Set((existingJobs || []).map((j) => j.scheduled_time_start));
+
+  if (bookedTimes.has(finalTimeStart)) {
+    if (!isFlexibleBooking) {
+      return {
+        ok: false,
+        status: 409,
+        error: 'This time slot is no longer available. Please select a different time.',
+      };
+    }
+
+    // Flexible bookings: find the next open hourly slot (08:00–17:00)
+    const slots = [];
+    for (let h = 8; h <= 17; h++) {
+      slots.push(`${String(h).padStart(2, '0')}:00`);
+    }
+    const nextOpen = slots.find((s) => !bookedTimes.has(s));
+
+    if (nextOpen) {
+      finalTimeStart = nextOpen;
+    } else {
+      // Entire day full — move to the next business day
+      const d = new Date(scheduledDate + 'T00:00:00');
+      do {
+        d.setDate(d.getDate() + 1);
+      } while (d.getDay() === 0 || d.getDay() === 6);
+      finalDate = d.toISOString().split('T')[0];
+      finalTimeStart = '09:00';
+    }
+  }
+
+  const scheduledTimeEnd = calculateEndTime(finalTimeStart, durationMinutes);
+
+  // Check if customer already exists (by email if available, otherwise by phone)
+  let customerId = null;
+  let existingCustomerQuery = supabase
+    .from('customers')
+    .select('id')
+    .eq('company_id', companyId);
+
+  if (customerEmail) {
+    existingCustomerQuery = existingCustomerQuery.eq('email', customerEmail);
+  } else {
+    existingCustomerQuery = existingCustomerQuery.eq('phone', customerPhone);
+  }
+
+  const { data: existingCustomer } = await existingCustomerQuery.single();
+
+  if (existingCustomer) {
+    customerId = existingCustomer.id;
+
+    const updateData = {
+      name: customerName,
+      phone: customerPhone,
+      updated_at: new Date().toISOString(),
+    };
+    if (customerAddress) updateData.address = customerAddress;
+    if (customerCity) updateData.city = customerCity;
+    if (customerState) updateData.state = customerState;
+    if (customerZip) updateData.zip = customerZip;
+    if (smsConsent) {
+      updateData.sms_consent = true;
+      updateData.sms_consent_date = new Date().toISOString();
+    }
+
+    await supabase.from('customers').update(updateData).eq('id', customerId);
+  } else {
+    const newCustomerRow = {
+      company_id: companyId,
+      name: customerName,
+      phone: customerPhone,
+      source: source || 'online_booking',
+      sms_consent: !!smsConsent,
+      sms_consent_date: smsConsent ? new Date().toISOString() : null,
+    };
+    if (customerEmail) newCustomerRow.email = customerEmail;
+    if (customerAddress) newCustomerRow.address = customerAddress;
+    if (customerCity) newCustomerRow.city = customerCity;
+    if (customerState) newCustomerRow.state = customerState;
+    if (customerZip) newCustomerRow.zip = customerZip;
+
+    const { data: newCustomer, error: customerError } = await supabase
+      .from('customers')
+      .insert(newCustomerRow)
+      .select('id')
+      .single();
+
+    if (customerError) {
+      console.error('[booking-core] Error creating customer:', customerError);
+      return { ok: false, status: 500, error: 'Failed to create customer record' };
+    }
+
+    customerId = newCustomer.id;
+  }
+
+  // Create the job (booking)
+  const jobRow = {
+    company_id: companyId,
+    customer_id: customerId,
+    title: serviceName,
+    description: notes || `Booking for ${serviceName}`,
+    scheduled_date: finalDate,
+    scheduled_time_start: finalTimeStart,
+    scheduled_time_end: scheduledTimeEnd,
+    status: 'scheduled',
+    priority: 'normal',
+    notes: notes || null,
+  };
+  if (customerAddress) jobRow.address = customerAddress;
+  if (customerCity) jobRow.city = customerCity;
+  if (customerState) jobRow.state = customerState;
+  if (customerZip) jobRow.zip = customerZip;
+
+  const { data: job, error: jobError } = await supabase
+    .from('jobs')
+    .insert(jobRow)
+    .select()
+    .single();
+
+  if (jobError) {
+    console.error('[booking-core] Error creating job:', jobError);
+    return { ok: false, status: 500, error: 'Failed to create booking' };
+  }
+
+  // Run lead creation and company name fetch in parallel (independent queries)
+  const [leadResult, companyResult] = await Promise.all([
+    supabase.from('leads').insert({
+      company_id: companyId,
+      customer_id: customerId,
+      name: customerName,
+      email: customerEmail || null,
+      phone: customerPhone,
+      address: customerAddress || null,
+      service_requested: serviceName,
+      message: notes || `Booked ${serviceName} for ${finalDate}`,
+      source: source || 'online_booking',
+      status: 'new',
+    }),
+    supabase.from('companies').select('name').eq('id', companyId).single(),
+  ]);
+
+  if (leadResult.error) {
+    console.error('[booking-core] Lead insert error:', leadResult.error);
+  }
+
+  const companyName = companyResult.data?.name || 'Our team';
+
+  return {
+    ok: true,
+    booking: {
+      id: job.id,
+      service: serviceName,
+      date: finalDate,
+      time: finalTimeStart,
+      customer: customerName,
+      customerId,
+    },
+    companyName,
+    customerId,
+    leadCreated: !leadResult.error,
+  };
+}
+
+module.exports = { createBooking, calculateEndTime };

--- a/src/lib/jenny-language.js
+++ b/src/lib/jenny-language.js
@@ -1,0 +1,107 @@
+// Bilingual helpers for the Jenny Pro booking agent (SMS + voice).
+//
+// Jenny is Spanish-aware: she detects the language of an inbound message and
+// replies in kind. The operator (contractor) has their own preferred language
+// for notifications, independent of how the customer is talking to Jenny.
+
+// Common Spanish tokens / accented characters used for lightweight detection.
+// We don't need perfect language ID — the AI also reports the language it used.
+const SPANISH_HINTS = [
+  ' hola', 'buenos dias', 'buenos días', 'buenas', 'gracias', 'por favor',
+  'necesito', 'quiero', 'cuanto', 'cuánto', 'cuesta', 'precio', 'cita',
+  'mañana', 'manana', 'hoy', 'jardin', 'jardín', 'plomero', 'plomería',
+  'fuga', 'agua', 'cesped', 'césped', 'arreglar', 'servicio', 'disponible',
+  'ayuda', 'señor', 'senor', 'está', 'esta', 'puedo', 'tengo', 'sí',
+];
+
+const ACCENTED = /[áéíóúñ¿¡]/i;
+
+/**
+ * Detect whether an inbound message is Spanish or English.
+ * @param {string} text
+ * @returns {'es' | 'en'}
+ */
+function detectLanguage(text) {
+  if (!text) return 'en';
+  const lower = ` ${text.toLowerCase()} `;
+  if (ACCENTED.test(text)) return 'es';
+  const hits = SPANISH_HINTS.filter((h) => lower.includes(h)).length;
+  return hits >= 1 ? 'es' : 'en';
+}
+
+/**
+ * Resolve the language Jenny should reply in, honoring the company setting.
+ * - setting 'en'  → always English
+ * - setting 'es'  → always Spanish
+ * - setting 'both'/undefined → mirror the customer (auto-detect)
+ *
+ * @param {string} detected - 'en' | 'es'
+ * @param {string} [setting] - jenny_pro_settings.language
+ * @returns {'es' | 'en'}
+ */
+function resolveReplyLanguage(detected, setting) {
+  if (setting === 'en' || setting === 'es') return setting;
+  return detected === 'es' ? 'es' : 'en';
+}
+
+const STRINGS = {
+  en: {
+    optOutConfirm: 'You have been unsubscribed and will no longer receive messages. Reply START to opt back in.',
+    optInConfirm: "You're subscribed again. How can we help you today?",
+    help: 'This is an automated assistant. Reply STOP to unsubscribe. For urgent help, please call us directly.',
+    emergencyReply: "This sounds urgent — I'm connecting you with our team right now. Someone will call you shortly. If this is a life-threatening emergency, please call 911.",
+    fallback: "Thanks for your message! Someone from our team will get back to you shortly.",
+    missedCallText: (company) =>
+      `Hi! This is ${company}. Sorry we missed your call. How can we help? Reply here and I can get you scheduled. (Reply STOP to opt out.)`,
+    voiceGreeting: (company) =>
+      `Thank you for calling ${company}. I'm Jenny, the virtual assistant. How can I help you today?`,
+    voiceMissed: (company) =>
+      `Sorry we couldn't take your call. ${company} will text you right now so we can help. Goodbye.`,
+    bookingConfirmed: ({ name, service, date, time, company }) =>
+      `Hi ${name}! Your ${service} appointment with ${company} is confirmed for ${date} at ${time}. Reply STOP to opt out.`,
+  },
+  es: {
+    optOutConfirm: 'Te has dado de baja y ya no recibirás mensajes. Responde START para volver a suscribirte.',
+    optInConfirm: 'Estás suscrito de nuevo. ¿Cómo podemos ayudarte hoy?',
+    help: 'Este es un asistente automático. Responde STOP para darte de baja. Si es urgente, por favor llámanos directamente.',
+    emergencyReply: 'Esto parece urgente — te estoy comunicando con nuestro equipo ahora mismo. Alguien te llamará en breve. Si es una emergencia de vida o muerte, llama al 911.',
+    fallback: '¡Gracias por tu mensaje! Alguien de nuestro equipo te responderá muy pronto.',
+    missedCallText: (company) =>
+      `¡Hola! Habla ${company}. Lamentamos no haber contestado tu llamada. ¿En qué podemos ayudarte? Respóndeme aquí y te agendo una cita. (Responde STOP para darte de baja.)`,
+    voiceGreeting: (company) =>
+      `Gracias por llamar a ${company}. Soy Jenny, la asistente virtual. ¿En qué puedo ayudarte hoy?`,
+    voiceMissed: (company) =>
+      `Lamentamos no poder contestar tu llamada. ${company} te enviará un mensaje de texto ahora mismo para ayudarte. Adiós.`,
+    bookingConfirmed: ({ name, service, date, time, company }) =>
+      `¡Hola ${name}! Tu cita de ${service} con ${company} está confirmada para el ${date} a las ${time}. Responde STOP para darte de baja.`,
+  },
+};
+
+/**
+ * Get the localized string bundle for a language.
+ * @param {'en'|'es'} lang
+ */
+function t(lang) {
+  return STRINGS[lang === 'es' ? 'es' : 'en'];
+}
+
+// Inbound keyword compliance (Twilio Advanced Opt-Out also handles these, but
+// we recognize them so Jenny never tries to "book" an opt-out message).
+const STOP_WORDS = ['stop', 'stopall', 'unsubscribe', 'cancel', 'end', 'quit', 'baja', 'parar'];
+const START_WORDS = ['start', 'unstop', 'yes', 'alta'];
+const HELP_WORDS = ['help', 'info', 'ayuda'];
+
+function classifyKeyword(text) {
+  const word = (text || '').trim().toLowerCase().replace(/[^a-z]/g, '');
+  if (STOP_WORDS.includes(word)) return 'stop';
+  if (START_WORDS.includes(word)) return 'start';
+  if (HELP_WORDS.includes(word)) return 'help';
+  return null;
+}
+
+module.exports = {
+  detectLanguage,
+  resolveReplyLanguage,
+  classifyKeyword,
+  t,
+};

--- a/src/lib/jenny-notify.js
+++ b/src/lib/jenny-notify.js
@@ -1,0 +1,51 @@
+// Operator notifications for Jenny Pro events (new booking, new lead, missed call).
+//
+// Notifies the contractor in-app for every user on the company, and optionally
+// fires a heads-up SMS to their escalation/cell number.
+
+const { sendSMS } = require('./twilio');
+
+/**
+ * Create an in-app notification for every user on a company.
+ *
+ * @param {object} supabase - service-role client
+ * @param {object} params - { companyId, type, title, message, link }
+ */
+async function notifyOperatorInApp(supabase, { companyId, type, title, message, link }) {
+  try {
+    const { data: users } = await supabase
+      .from('users')
+      .select('id')
+      .eq('company_id', companyId);
+
+    if (!users || users.length === 0) return;
+
+    const rows = users.map((u) => ({
+      company_id: companyId,
+      user_id: u.id,
+      type,
+      title,
+      message,
+      link: link || null,
+    }));
+
+    await supabase.from('notifications').insert(rows);
+  } catch (err) {
+    console.error('[jenny-notify] in-app notify failed:', err.message);
+  }
+}
+
+/**
+ * Send a heads-up SMS to the operator's escalation number (their own phone).
+ * Best-effort: failures never block the customer-facing flow.
+ */
+async function notifyOperatorSMS(escalationPhone, body) {
+  if (!escalationPhone) return;
+  try {
+    await sendSMS({ to: escalationPhone, body });
+  } catch (err) {
+    console.error('[jenny-notify] operator SMS failed:', err.message);
+  }
+}
+
+module.exports = { notifyOperatorInApp, notifyOperatorSMS };

--- a/src/lib/jenny-sms-agent.js
+++ b/src/lib/jenny-sms-agent.js
@@ -1,0 +1,184 @@
+// Jenny Pro conversational booking agent.
+//
+// Channel-agnostic: given a conversation history + the latest inbound message,
+// Jenny replies in the customer's language and, when she has everything she
+// needs, returns a structured booking she can hand to booking-core.
+//
+// Used by the SMS webhook and the voice (speech) receptionist.
+
+const { aiComplete, parseAIJson } = require('./ai-client');
+const { detectLanguage, resolveReplyLanguage, t } = require('./jenny-language');
+
+// Today's date in the company's local context (server is UTC; good enough for
+// "tomorrow / next Tuesday" style relative scheduling at day granularity).
+function todayISO() {
+  return new Date().toISOString().split('T')[0];
+}
+
+function matchesEmergency(text, keywords) {
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  const list = Array.isArray(keywords) && keywords.length
+    ? keywords
+    : ['emergency', 'urgent', 'burst', 'leak', 'flood', 'fire', 'broken', 'emergencia', 'urgente', 'fuga', 'inundación', 'incendio'];
+  return list.some((k) => lower.includes(String(k).toLowerCase()));
+}
+
+function buildSystemPrompt({ companyName, businessType, services, lang, today, channel }) {
+  const serviceLines = services && services.length
+    ? services
+        .map((s) => {
+          const price = s.default_price != null ? ` (~$${s.default_price})` : '';
+          const dur = s.duration_minutes ? `, ${s.duration_minutes} min` : '';
+          return `- ${s.name}${price}${dur}`;
+        })
+        .join('\n')
+    : '- General service visit';
+
+  const langInstruction =
+    lang === 'es'
+      ? 'Respond ONLY in natural, friendly Mexican/California Spanish.'
+      : 'Respond ONLY in natural, friendly English.';
+
+  const channelNote =
+    channel === 'voice'
+      ? 'This is a phone call transcribed to text. Keep replies to ONE short spoken sentence. Ask only one question at a time.'
+      : 'This is an SMS conversation. Keep replies under 320 characters. Ask only one question at a time.';
+
+  return `You are Jenny, the booking assistant for ${companyName || 'a local service business'} (${businessType || 'home services'}). You turn an inbound message into a booked appointment.
+
+${langInstruction}
+${channelNote}
+
+Today's date is ${today}. Convert relative dates ("tomorrow", "next Tuesday", "this Friday") into real calendar dates.
+
+Services offered:
+${serviceLines}
+
+Your goal is to collect, conversationally and warmly:
+1. The customer's name
+2. The service they need (match to a service above when possible)
+3. The date and time they want
+You may also capture a street address if they offer it, but it is optional.
+
+Booking hours are 8:00 AM to 5:00 PM, Monday–Saturday. If they ask for a time outside that, offer the nearest valid slot.
+
+You MUST reply with a single JSON object and NOTHING else, in this exact shape:
+{
+  "reply": "the message to send back to the customer, in their language",
+  "language": "en" or "es",
+  "intent": "booking" | "question" | "emergency" | "other",
+  "ready_to_book": true or false,
+  "booking": {
+    "customerName": "string",
+    "serviceName": "string",
+    "scheduledDate": "YYYY-MM-DD",
+    "scheduledTimeStart": "HH:MM" (24-hour),
+    "address": "string or empty",
+    "notes": "short summary of the request"
+  } or null
+}
+
+Set "ready_to_book" to true ONLY when you have name, service, a concrete date, and a concrete time. When ready_to_book is true, your "reply" must clearly confirm the appointment details (service, day, and time) so the customer sees it. Otherwise ask for the single most important missing piece. Never invent details the customer did not give.`;
+}
+
+/**
+ * Run one turn of the Jenny booking agent.
+ *
+ * @param {object} opts
+ * @param {object} opts.supabase    - service-role client (for services/company lookup)
+ * @param {string} opts.companyId
+ * @param {object} [opts.company]   - { name, business_type } (fetched if omitted)
+ * @param {object} [opts.settings]  - jenny_pro_settings row
+ * @param {Array}  opts.history     - [{ role:'user'|'assistant', content }]
+ * @param {string} opts.message     - latest inbound text
+ * @param {'sms'|'voice'} [opts.channel='sms']
+ * @returns {Promise<{ reply, language, intent, readyToBook, booking, emergency }>}
+ */
+async function runJennyAgent({ supabase, companyId, company, settings, history = [], message, channel = 'sms' }) {
+  const detected = detectLanguage(message);
+  const lang = resolveReplyLanguage(detected, settings?.language);
+
+  // Emergency short-circuit — never run the booking flow on an emergency.
+  if (matchesEmergency(message, settings?.emergency_keywords)) {
+    return {
+      reply: t(lang).emergencyReply,
+      language: lang,
+      intent: 'emergency',
+      readyToBook: false,
+      booking: null,
+      emergency: true,
+    };
+  }
+
+  // Load company + services context (only if not provided).
+  let companyName = company?.name;
+  let businessType = company?.business_type;
+  if (!companyName) {
+    const { data } = await supabase
+      .from('companies')
+      .select('name, business_type')
+      .eq('id', companyId)
+      .single();
+    companyName = data?.name;
+    businessType = data?.business_type;
+  }
+
+  const { data: services } = await supabase
+    .from('services')
+    .select('name, default_price, duration_minutes')
+    .eq('company_id', companyId)
+    .eq('is_active', true)
+    .limit(25);
+
+  const systemPrompt = buildSystemPrompt({
+    companyName,
+    businessType,
+    services: services || [],
+    lang,
+    today: todayISO(),
+    channel,
+  });
+
+  let result;
+  try {
+    const ai = await aiComplete({
+      systemPrompt,
+      messages: [...history, { role: 'user', content: message }],
+      maxTokens: 400,
+      temperature: 0.4,
+      tier: 'fast',
+    });
+    result = parseAIJson(ai.content);
+  } catch (err) {
+    console.error('[jenny-agent] AI/parse error:', err.message);
+    // Graceful fallback so the customer always gets a reply.
+    return {
+      reply: t(lang).fallback,
+      language: lang,
+      intent: 'other',
+      readyToBook: false,
+      booking: null,
+      emergency: false,
+    };
+  }
+
+  const booking = result.booking || null;
+  const hasRequired =
+    booking &&
+    booking.customerName &&
+    booking.serviceName &&
+    booking.scheduledDate &&
+    booking.scheduledTimeStart;
+
+  return {
+    reply: typeof result.reply === 'string' && result.reply.trim() ? result.reply.trim() : t(lang).fallback,
+    language: result.language === 'es' || result.language === 'en' ? result.language : lang,
+    intent: result.intent || 'other',
+    readyToBook: !!(result.ready_to_book && hasRequired),
+    booking: hasRequired ? booking : null,
+    emergency: false,
+  };
+}
+
+module.exports = { runJennyAgent, matchesEmergency, buildSystemPrompt };

--- a/src/lib/jenny-voice.js
+++ b/src/lib/jenny-voice.js
@@ -1,0 +1,110 @@
+// TwiML helpers for the Jenny Pro voice receptionist.
+//
+// Voice is stateless per HTTP request, so we thread state through the same
+// jenny_sms_conversations table (source = 'voice'), rebuilding history from
+// the logged turns — the SMS and voice agents share one brain.
+
+const { createClient } = require('@supabase/supabase-js');
+
+let supabaseInstance = null;
+function getServiceSupabase() {
+  if (!supabaseInstance) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) throw new Error('Supabase not configured');
+    supabaseInstance = createClient(url, key, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+  }
+  return supabaseInstance;
+}
+
+async function resolveCompany(supabase, toNumber) {
+  const twilioNumber = process.env.TWILIO_PHONE_NUMBER;
+  if (!twilioNumber || toNumber === twilioNumber || !toNumber) {
+    const { data } = await supabase.from('companies').select('id, name').limit(1);
+    if (data?.length) return data[0];
+  }
+  return null;
+}
+
+function escapeXml(str) {
+  return String(str || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+// Amazon Polly voices available on Twilio for natural EN/ES speech.
+function sayVoice(lang) {
+  return lang === 'es'
+    ? { voice: 'Polly.Lupe', language: 'es-MX' }
+    : { voice: 'Polly.Joanna', language: 'en-US' };
+}
+
+function buildSay(text, lang) {
+  const v = sayVoice(lang);
+  return `<Say voice="${v.voice}" language="${v.language}">${escapeXml(text)}</Say>`;
+}
+
+// A speech <Gather> that posts the transcript to the given action URL.
+function buildGather(promptText, lang, actionUrl) {
+  const sttLang = lang === 'es' ? 'es-MX' : 'en-US';
+  return (
+    `<Gather input="speech" action="${actionUrl}" method="POST" ` +
+    `speechTimeout="auto" language="${sttLang}">` +
+    buildSay(promptText, lang) +
+    `</Gather>`
+  );
+}
+
+function voiceResponse(inner) {
+  return new Response(
+    `<?xml version="1.0" encoding="UTF-8"?><Response>${inner}</Response>`,
+    { status: 200, headers: { 'Content-Type': 'text/xml' } }
+  );
+}
+
+// Find or create the voice conversation thread for this caller.
+async function getOrCreateVoiceConversation(supabase, companyId, callerPhone) {
+  const { data: existing } = await supabase
+    .from('jenny_sms_conversations')
+    .select('id, message_count, language')
+    .eq('company_id', companyId)
+    .eq('customer_phone', callerPhone)
+    .eq('source', 'voice')
+    .neq('status', 'resolved')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (existing) return existing;
+
+  const { data: created } = await supabase
+    .from('jenny_sms_conversations')
+    .insert({
+      company_id: companyId,
+      customer_name: 'Caller',
+      customer_phone: callerPhone,
+      status: 'needs_response',
+      message_count: 0,
+      source: 'voice',
+      language: 'en',
+    })
+    .select('id, message_count, language')
+    .single();
+
+  return created;
+}
+
+module.exports = {
+  getServiceSupabase,
+  resolveCompany,
+  buildSay,
+  buildGather,
+  voiceResponse,
+  getOrCreateVoiceConversation,
+  escapeXml,
+};


### PR DESCRIPTION
Makes the Jenny Pro booking agent fully functional end to end. Previously the SMS webhook only logged inbound messages and the voice receptionist was a demo.

Text path:
- Rewrite /api/jenny-pro/sms-webhook to run a bilingual conversational agent that replies, auto-detects EN/ES, escalates emergencies, honors STOP/START/ HELP, and auto-books when it has name+service+date+time (respects auto_booking)
- Notify the operator (in-app + SMS) on bookings and emergencies

Voice path:
- /api/jenny-pro/voice rings the owner first, then falls back to the AI
- /api/jenny-pro/voice/after-dial texts the caller on a missed call (missed call -> booking) and logs/notifies
- /api/jenny-pro/voice/gather is a working speech receptionist that books by voice

Shared + Spanish-first:
- Extract booking-core.js (createBooking) shared by web/SMS/voice bookings; /api/bookings refactored to use it (behavior unchanged)
- jenny-language.js (detection + EN/ES strings + opt-out), jenny-sms-agent.js (Claude primary via existing ai-client), jenny-voice.js, jenny-notify.js
- Customer language auto-detects; operator picks their own notification language

Dashboard + data:
- Wire Jenny Pro settings UI to persist (greetings, escalation #, emergency keywords, customer + operator language, auto-book toggle); real Bookings Made stat
- Migration 038: conversation language/booking_id/last_intent, operator_language
- Add a Spanish booking scenario to the phone-receptionist demo
- Operator setup + architecture doc

Tests: +32 (language, booking-core, agent, webhook). Full suite 467 pass; build + lint clean.


Claude-Session: https://claude.ai/code/session_01Fw38sSQpf3TEVPE5AhV7Jt