### PR TITLE
Fix post-purchase login: heal orphaned accounts + stop webhook/fallback race

### DIFF
--- a/src/app/api/checkout/provision/route.js
+++ b/src/app/api/checkout/provision/route.js
@@ -57,15 +57,28 @@ export async function POST(request) {
     }
     const admin = createClient(supabaseUrl, serviceKey);
 
-    // If the webhook already created the company for this email, do nothing —
-    // it already sent the login email. This is the idempotency guard.
-    const { data: existingCompany } = await admin
-      .from('companies')
-      .select('id')
-      .ilike('email', email)
-      .maybeSingle();
-    if (existingCompany?.id) {
-      return NextResponse.json({ status: 'already_provisioned' }, { status: 200 });
+    // Give the Stripe webhook a head start. When the webhook is healthy it
+    // provisions the company and sends the login email within a few seconds;
+    // if we provisioned immediately we'd race it and the loser would send a
+    // SECOND, conflicting email (the plain "Welcome — Go to Dashboard" one),
+    // which dumps new buyers on the dashboard instead of set-password. So we
+    // poll for an existing company across a short grace window and only fall
+    // through to provisioning here if nothing appears — i.e. the webhook
+    // genuinely didn't fire. Kept well under the serverless timeout.
+    const GRACE_ATTEMPTS = 4;
+    const GRACE_DELAY_MS = 2000;
+    for (let attempt = 0; attempt < GRACE_ATTEMPTS; attempt++) {
+      const { data: existingCompany } = await admin
+        .from('companies')
+        .select('id')
+        .ilike('email', email)
+        .maybeSingle();
+      if (existingCompany?.id) {
+        return NextResponse.json({ status: 'already_provisioned' }, { status: 200 });
+      }
+      if (attempt < GRACE_ATTEMPTS - 1) {
+        await new Promise((r) => setTimeout(r, GRACE_DELAY_MS));
+      }
     }
 
     const metadata = session.metadata || {};


### PR DESCRIPTION
Fixes two related defects that left new buyers unable to reach the set-password screen after paying.

## 1. Orphaned company → dead-ends at the login page
**Symptom:** clicking the post-purchase email lands on the "sign in to your account" page, which asks for a password the buyer never set.

**Cause:** when a `companies` row exists for an email but has no auth-backed `users` row (login deleted, or signup never finished), the webhook resolved that company and sent the plain "Welcome — Go to Dashboard" email. `/dashboard` bounces unauthenticated visitors to the login page. Underneath, `handle_new_signup` unconditionally `INSERT`s a company and `companies.email` is `UNIQUE`, so for an existing company the INSERT fails and its `users` INSERT never runs — the auth↔company link is never (re)created.

**Fix:**
- `auto-provision`: after resolving the company, upsert the `users` row so the auth user is always linked. Provisioning is now idempotent and self-healing (no-op for normal fresh signups).
- `webhook`: detect a resolved company with no `users` row and route it through the shared provision helper (recreates auth user + sends a magic-link set-password email) instead of the dead-end welcome email.
- success-page fallback: same orphan detection, so it also heals accounts when the webhook is down.

## 2. Success-page fallback racing the webhook
The fallback ran immediately and, when the webhook was healthy, both provisioned the same checkout — the loser sent a second, conflicting "Go to Dashboard" email. Added a short grace window so the fallback only acts if the webhook genuinely didn't fire.

## Verification
- `npm run build` ✅
- `npm test` — 481/481 ✅ (adds an orphan-heal regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)