### PR TITLE
Address autocomplete at job entry (Mapbox, graceful fallback)

### DIFF
--- a/src/__tests__/lib/address-autocomplete.test.ts
+++ b/src/__tests__/lib/address-autocomplete.test.ts
@@ -1,0 +1,68 @@
+import { buildSuggestUrl, parseSuggestions } from '@/lib/address-autocomplete';
+
+describe('address-autocomplete', () => {
+  describe('buildSuggestUrl', () => {
+    it('builds a Mapbox address-autocomplete URL with the query encoded', () => {
+      const url = buildSuggestUrl('1048 Farley Ave', 'tok123');
+      expect(url).toContain('https://api.mapbox.com/geocoding/v5/mapbox.places/1048%20Farley%20Ave.json?');
+      expect(url).toContain('access_token=tok123');
+      expect(url).toContain('autocomplete=true');
+      expect(url).toContain('types=address');
+      expect(url).toContain('country=us');
+    });
+  });
+
+  describe('parseSuggestions', () => {
+    const sample = {
+      features: [
+        {
+          id: 'address.123',
+          place_name: '1048 Farley Ave, Mountain View, California 94043, United States',
+          text: 'Farley Avenue',
+          address: '1048',
+          center: [-122.08, 37.39],
+          context: [
+            { id: 'postcode.1', text: '94043' },
+            { id: 'place.1', text: 'Mountain View' },
+            { id: 'region.1', short_code: 'US-CA', text: 'California' },
+            { id: 'country.1', short_code: 'us', text: 'United States' },
+          ],
+        },
+      ],
+    };
+
+    it('normalizes a Mapbox feature into address parts + coordinates', () => {
+      const [s] = parseSuggestions(sample);
+      expect(s.address).toBe('1048 Farley Avenue');
+      expect(s.city).toBe('Mountain View');
+      expect(s.state).toBe('CA');
+      expect(s.zip).toBe('94043');
+      expect(s.lat).toBe(37.39);
+      expect(s.lng).toBe(-122.08);
+      expect(s.label).toContain('Mountain View');
+    });
+
+    it('returns [] for missing/empty features', () => {
+      expect(parseSuggestions(null)).toEqual([]);
+      expect(parseSuggestions({})).toEqual([]);
+      expect(parseSuggestions({ features: [] })).toEqual([]);
+    });
+
+    it('skips features without coordinates', () => {
+      expect(parseSuggestions({ features: [{ text: 'Nowhere St', context: [] }] })).toEqual([]);
+    });
+
+    it('falls back to region text when no short_code is present', () => {
+      const [s] = parseSuggestions({
+        features: [
+          {
+            text: 'Main St',
+            center: [-100, 40],
+            context: [{ id: 'region.1', text: 'Nebraska' }],
+          },
+        ],
+      });
+      expect(s.state).toBe('Nebraska');
+    });
+  });
+});

--- a/src/app/api/jobs/save/route.ts
+++ b/src/app/api/jobs/save/route.ts
@@ -25,6 +25,17 @@ async function resolveJobCoordinates(jobData: JobAddressFields, existing: JobAdd
   const hasAddress = (jobData.address || '').trim().length > 0
   if (!hasAddress) return null
 
+  // Coordinates supplied by the client (address autocomplete) are authoritative
+  // and precise — store them directly without geocoding.
+  if (jobData.lat != null && jobData.lng != null) {
+    return {
+      lat: jobData.lat,
+      lng: jobData.lng,
+      geo_precision: 'exact',
+      geocoded_at: new Date().toISOString(),
+    }
+  }
+
   if (existing) {
     const addrUnchanged =
       (existing.address || '') === (jobData.address || '') &&

--- a/src/app/dashboard/customers/page.tsx
+++ b/src/app/dashboard/customers/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
+import AddressAutocomplete from '@/components/AddressAutocomplete'
 
 type CustomerType = 'residential' | 'commercial'
 
@@ -546,10 +547,18 @@ function CustomerModal({ customer, companyId, onClose, onSave }: {
 
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Street Address</label>
-            <input
-              type="text"
+            <AddressAutocomplete
               value={formData.address}
-              onChange={(e) => setFormData({ ...formData, address: e.target.value })}
+              onChange={(v) => setFormData({ ...formData, address: v })}
+              onSelect={(s) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  address: s.address || prev.address,
+                  city: s.city || prev.city,
+                  state: s.state || prev.state,
+                  zip: s.zip || prev.zip,
+                }))
+              }
               className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
               placeholder="123 Main St"
             />

--- a/src/app/dashboard/jobs/page.tsx
+++ b/src/app/dashboard/jobs/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback, useRef, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
+import AddressAutocomplete from '@/components/AddressAutocomplete'
 
 interface Job {
   id: string
@@ -477,6 +478,11 @@ function JobModal({ job, companyId, customers, workers, quotes, initialQuoteId, 
     price: job?.total_amount?.toString() || initialQuote?.total?.toString() || '',
     assigned_worker_id: job?.assigned_users?.[0]?.user?.id || '',
     required_service_id: job?.required_service_id || '',
+    lat: null as number | null,
+    lng: null as number | null,
+    // True only when the current address/coords came from an autocomplete pick,
+    // so we send coordinates and skip server-side geocoding.
+    coordsFromAutocomplete: false,
   })
   const [services, setServices] = useState<{ id: string; name: string; requires_license: boolean }[]>([])
   const [saving, setSaving] = useState(false)
@@ -586,6 +592,11 @@ function JobModal({ job, companyId, customers, workers, quotes, initialQuoteId, 
       priority: formData.priority,
       total_amount: formData.price ? Number(formData.price) : null,
       required_service_id: formData.required_service_id || null,
+      // Send precise coordinates only when chosen via autocomplete; otherwise
+      // let the server geocode the typed address.
+      ...(formData.coordsFromAutocomplete && formData.lat != null && formData.lng != null
+        ? { lat: formData.lat, lng: formData.lng }
+        : {}),
       company_id: companyId,
       status: job?.status || 'scheduled',
     }
@@ -760,12 +771,24 @@ function JobModal({ job, companyId, customers, workers, quotes, initialQuoteId, 
 
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Street Address *</label>
-            <input
-              type="text"
+            <AddressAutocomplete
               required
               value={formData.address}
-              onChange={(e) => {
-                setFormData({ ...formData, address: e.target.value })
+              onChange={(v) => {
+                setFormData((prev) => ({ ...prev, address: v, coordsFromAutocomplete: false }))
+                if (errors.address) setErrors({ ...errors, address: undefined })
+              }}
+              onSelect={(s) => {
+                setFormData((prev) => ({
+                  ...prev,
+                  address: s.address || prev.address,
+                  city: s.city || prev.city,
+                  state: s.state || prev.state,
+                  zip: s.zip || prev.zip,
+                  lat: s.lat,
+                  lng: s.lng,
+                  coordsFromAutocomplete: true,
+                }))
                 if (errors.address) setErrors({ ...errors, address: undefined })
               }}
               className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 ${errors.address ? 'border-red-500' : ''}`}

--- a/src/components/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  fetchAddressSuggestions,
+  isAutocompleteEnabled,
+  AddressSuggestion,
+} from '@/lib/address-autocomplete'
+
+interface Props {
+  value: string
+  onChange: (value: string) => void
+  /** Called when a suggestion is picked — provides the full canonical address. */
+  onSelect: (s: AddressSuggestion) => void
+  placeholder?: string
+  className?: string
+  required?: boolean
+  id?: string
+}
+
+/**
+ * Street-address input with Mapbox autocomplete. When no Mapbox token is
+ * configured it degrades to a plain text input (same behavior as before),
+ * so it's always safe to use.
+ */
+export default function AddressAutocomplete({
+  value,
+  onChange,
+  onSelect,
+  placeholder,
+  className,
+  required,
+  id,
+}: Props) {
+  const [suggestions, setSuggestions] = useState<AddressSuggestion[]>([])
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const enabled = isAutocompleteEnabled()
+  const containerRef = useRef<HTMLDivElement>(null)
+  // When the user picks a suggestion we suppress the next fetch (the value
+  // change from selection shouldn't reopen the dropdown).
+  const skipNextFetch = useRef(false)
+
+  useEffect(() => {
+    if (!enabled) return
+    if (skipNextFetch.current) {
+      skipNextFetch.current = false
+      return
+    }
+    if (value.trim().length < 3) {
+      setSuggestions([])
+      setOpen(false)
+      return
+    }
+    const controller = new AbortController()
+    const t = setTimeout(async () => {
+      const results = await fetchAddressSuggestions(value, { signal: controller.signal })
+      setSuggestions(results)
+      setOpen(results.length > 0)
+      setActiveIndex(-1)
+    }, 250)
+    return () => {
+      clearTimeout(t)
+      controller.abort()
+    }
+  }, [value, enabled])
+
+  // Close the dropdown on outside click.
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  }, [])
+
+  const pick = (s: AddressSuggestion) => {
+    skipNextFetch.current = true
+    onSelect(s)
+    setOpen(false)
+    setSuggestions([])
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (!open || suggestions.length === 0) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveIndex((i) => Math.min(i + 1, suggestions.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveIndex((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter' && activeIndex >= 0) {
+      e.preventDefault()
+      pick(suggestions[activeIndex])
+    } else if (e.key === 'Escape') {
+      setOpen(false)
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        id={id}
+        type="text"
+        required={required}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        onFocus={() => suggestions.length > 0 && setOpen(true)}
+        autoComplete="off"
+        className={className}
+        placeholder={placeholder}
+      />
+      {open && suggestions.length > 0 && (
+        <ul className="absolute z-50 left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto">
+          {suggestions.map((s, i) => (
+            <li
+              key={s.id}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                pick(s)
+              }}
+              onMouseEnter={() => setActiveIndex(i)}
+              className={`px-3 py-2 text-sm cursor-pointer ${i === activeIndex ? 'bg-gray-100' : 'hover:bg-gray-50'}`}
+            >
+              {s.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/lib/address-autocomplete.ts
+++ b/src/lib/address-autocomplete.ts
@@ -1,0 +1,111 @@
+/**
+ * Address autocomplete via Mapbox Geocoding — validates and canonicalizes
+ * addresses at entry so they're geocodable downstream.
+ *
+ * Pure, provider-specific helpers (URL building + response parsing) live here
+ * so they can be unit-tested. The React component uses them. When no token is
+ * configured, autocomplete is disabled and callers fall back to a plain text
+ * input — nothing breaks.
+ *
+ * Configure with NEXT_PUBLIC_MAPBOX_TOKEN.
+ */
+
+export interface AddressSuggestion {
+  id: string;
+  label: string; // full human-readable address
+  address: string; // street line (house number + street)
+  city: string;
+  state: string; // 2-letter where available
+  zip: string;
+  lat: number;
+  lng: number;
+}
+
+export function getMapboxToken(): string | undefined {
+  return process.env.NEXT_PUBLIC_MAPBOX_TOKEN || undefined;
+}
+
+export function isAutocompleteEnabled(): boolean {
+  return !!getMapboxToken();
+}
+
+export function buildSuggestUrl(query: string, token: string): string {
+  const q = encodeURIComponent(query.trim());
+  const params = new URLSearchParams({
+    access_token: token,
+    autocomplete: 'true',
+    country: 'us',
+    types: 'address',
+    limit: '5',
+  });
+  return `https://api.mapbox.com/geocoding/v5/mapbox.places/${q}.json?${params}`;
+}
+
+interface MapboxContextEntry {
+  id?: string;
+  text?: string;
+  short_code?: string;
+}
+
+interface MapboxFeature {
+  id?: string;
+  place_name?: string;
+  text?: string;
+  address?: string;
+  center?: [number, number]; // [lng, lat]
+  context?: MapboxContextEntry[];
+}
+
+function contextValue(context: MapboxContextEntry[] | undefined, prefix: string): MapboxContextEntry | undefined {
+  return context?.find((c) => (c.id || '').startsWith(prefix));
+}
+
+/**
+ * Parse a Mapbox geocoding response into normalized address suggestions.
+ * Skips any feature lacking coordinates.
+ */
+export function parseSuggestions(json: unknown): AddressSuggestion[] {
+  const features = (json as { features?: MapboxFeature[] } | null)?.features;
+  if (!Array.isArray(features)) return [];
+
+  const out: AddressSuggestion[] = [];
+  for (const f of features) {
+    if (!Array.isArray(f.center) || f.center.length < 2) continue;
+    const [lng, lat] = f.center;
+
+    const street = f.text || '';
+    const address = f.address ? `${f.address} ${street}`.trim() : street;
+    const city = contextValue(f.context, 'place')?.text || '';
+    const regionEntry = contextValue(f.context, 'region');
+    // short_code like "US-CA" -> "CA"
+    const state = regionEntry?.short_code?.split('-')[1]?.toUpperCase() || regionEntry?.text || '';
+    const zip = contextValue(f.context, 'postcode')?.text || '';
+
+    out.push({
+      id: f.id || `${lat},${lng}`,
+      label: f.place_name || address,
+      address,
+      city,
+      state,
+      zip,
+      lat,
+      lng,
+    });
+  }
+  return out;
+}
+
+/**
+ * Fetch address suggestions. Returns [] on any failure or when disabled.
+ */
+export async function fetchAddressSuggestions(query: string, opts?: { signal?: AbortSignal }): Promise<AddressSuggestion[]> {
+  const token = getMapboxToken();
+  if (!token || query.trim().length < 3) return [];
+  try {
+    const res = await fetch(buildSuggestUrl(query, token), { signal: opts?.signal });
+    if (!res.ok) return [];
+    return parseSuggestions(await res.json());
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Overview

Adds address autocomplete at job entry — the root-cause fix for ungeocodable, free-form addresses (the original `"1048 Farley Ave"` problem). A canonical address and its exact coordinates flow straight into the persisted-coordinates path, so jobs are accurately located from creation with no live geocoding.

## Changes

- **`src/lib/address-autocomplete.ts`** — Mapbox geocoding helpers: `isAutocompleteEnabled`, `buildSuggestUrl`, `parseSuggestions`, `fetchAddressSuggestions`. Pure parts are unit-tested.
- **`src/components/AddressAutocomplete.tsx`** — reusable input with debounced suggestions, keyboard navigation, and outside-click close. **Degrades to a plain text input** when `NEXT_PUBLIC_MAPBOX_TOKEN` is unset, so it's always safe to use.
- **Job form** — the street-address field now uses autocomplete; picking a suggestion fills city/state/zip and captures exact lat/lng.
- **Job save** — trusts client-supplied (autocomplete) coordinates and skips server-side geocoding for them.

## Why it matters

It compounds with the recently merged work: persisted coordinates become accurate from the start, road routing gets real endpoints, and there are far fewer approximate pins to correct or "couldn't geocode" warnings. Garbage-in at entry is where the whole geocoding chain was breaking.

## Testing
- `npm run build` ✓
- `npm test` → **499 passed** (+5 new autocomplete tests) ✓
- `npm run lint` → no new errors ✓

## Deploy note
Set `NEXT_PUBLIC_MAPBOX_TOKEN` to enable autocomplete (Mapbox free tier). Until then it runs as a plain text input — no breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0186e2ruMrttLk8FCKhB6zGg)_