### PR TITLE
Live technician GPS on the customer tracking map

### DIFF
--- a/src/app/api/track/[token]/route.ts
+++ b/src/app/api/track/[token]/route.ts
@@ -44,7 +44,7 @@ export async function GET(_req: NextRequest, { params }: { params: { token: stri
     .from('jobs')
     .select(`
       id, status, scheduled_date, scheduled_time_start, scheduled_time_end,
-      address, city, lat, lng,
+      address, city, lat, lng, tech_lat, tech_lng, tech_location_at,
       company:companies(name),
       customer:customers(name),
       assigned_users:job_assignments(user:users(full_name))
@@ -62,7 +62,21 @@ export async function GET(_req: NextRequest, { params }: { params: { token: stri
   const techUser = Array.isArray(firstAssignment) ? firstAssignment[0] : firstAssignment
   const { label, phase } = statusLabel(job.status)
 
+  // Expose the technician's live position only while en route and only if the
+  // fix is recent (within 10 minutes) — stale or off-job positions stay hidden.
+  let techLocation: { lat: number; lng: number } | null = null
+  if (
+    job.status === 'in_progress' &&
+    job.tech_lat != null &&
+    job.tech_lng != null &&
+    job.tech_location_at &&
+    Date.now() - new Date(job.tech_location_at).getTime() < 10 * 60 * 1000
+  ) {
+    techLocation = { lat: job.tech_lat, lng: job.tech_lng }
+  }
+
   return NextResponse.json({
+    techLocation,
     companyName: company?.name || 'Your service provider',
     customerName: customer?.name || null,
     techFirstName: firstName(techUser?.full_name),

--- a/src/app/api/track/location/route.ts
+++ b/src/app/api/track/location/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+export const dynamic = 'force-dynamic'
+
+// Worker app posts the technician's current GPS position for an in-progress
+// job, so the customer's tracking page can show a live pin. Auth required and
+// scoped to the caller's company.
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+    process.env.SUPABASE_SERVICE_ROLE_KEY || '',
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  )
+}
+
+function validCoord(lat: unknown, lng: unknown): lat is number {
+  return (
+    typeof lat === 'number' && typeof lng === 'number' &&
+    isFinite(lat) && isFinite(lng) &&
+    lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180 &&
+    !(lat === 0 && lng === 0)
+  )
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const token = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const { jobId, lat, lng } = await request.json()
+    if (!jobId) return NextResponse.json({ error: 'Missing jobId' }, { status: 400 })
+    if (!validCoord(lat, lng)) return NextResponse.json({ error: 'Invalid coordinates' }, { status: 400 })
+
+    const admin = getAdmin()
+    const { data: { user } } = await admin.auth.getUser(token)
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const { data: caller } = await admin.from('users').select('company_id').eq('id', user.id).single()
+    if (!caller?.company_id) return NextResponse.json({ error: 'No company' }, { status: 403 })
+
+    const { data: job } = await admin.from('jobs').select('id, company_id, status').eq('id', jobId).single()
+    if (!job || job.company_id !== caller.company_id) {
+      return NextResponse.json({ error: 'Job not found' }, { status: 404 })
+    }
+    // Only track while the job is actually in progress.
+    if (job.status !== 'in_progress') {
+      return NextResponse.json({ success: true, skipped: 'job not in progress' })
+    }
+
+    const { error } = await admin
+      .from('jobs')
+      .update({ tech_lat: lat, tech_lng: lng, tech_location_at: new Date().toISOString() })
+      .eq('id', jobId)
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error('[track/location] error:', err)
+    return NextResponse.json({ error: 'Failed to update location' }, { status: 500 })
+  }
+}

--- a/src/app/track/[token]/page.tsx
+++ b/src/app/track/[token]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback } from 'react'
+import type * as LeafletNS from 'leaflet'
 
 interface TrackingInfo {
   companyName: string
@@ -13,6 +14,100 @@ interface TrackingInfo {
   windowStart: string | null
   windowEnd: string | null
   destination: { lat: number; lng: number; city: string | null } | null
+  techLocation: { lat: number; lng: number } | null
+}
+
+// Live map showing the destination and (when en route) the technician's
+// current position. Re-renders markers whenever coordinates change.
+function TrackMap({
+  destination,
+  techLocation,
+}: {
+  destination: { lat: number; lng: number } | null
+  techLocation: { lat: number; lng: number } | null
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<LeafletNS.Map | null>(null)
+  const layerRef = useRef<LeafletNS.LayerGroup | null>(null)
+
+  useEffect(() => {
+    if (!containerRef.current || (!destination && !techLocation)) return
+    let mounted = true
+
+    Promise.all([
+      import('leaflet'),
+      // @ts-expect-error - CSS import for leaflet styles has no type declaration
+      import('leaflet/dist/leaflet.css'),
+    ]).then(([leaflet]) => {
+      const L = leaflet.default
+      if (!mounted || !containerRef.current) return
+
+      if (!mapRef.current) {
+        const center = techLocation || destination!
+        mapRef.current = L.map(containerRef.current).setView([center.lat, center.lng], 13)
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution: '&copy; OpenStreetMap',
+          maxZoom: 19,
+        }).addTo(mapRef.current)
+        layerRef.current = L.layerGroup().addTo(mapRef.current)
+      }
+
+      const layer = layerRef.current!
+      layer.clearLayers()
+      const bounds: [number, number][] = []
+
+      const pin = (emoji: string, bg: string) =>
+        L.divIcon({
+          className: 'track-pin',
+          html: `<div style="width:34px;height:34px;border-radius:50%;background:${bg};display:flex;align-items:center;justify-content:center;font-size:17px;border:3px solid white;box-shadow:0 2px 6px rgba(0,0,0,0.3)">${emoji}</div>`,
+          iconSize: [34, 34],
+          iconAnchor: [17, 17],
+        })
+
+      if (destination) {
+        L.marker([destination.lat, destination.lng], { icon: pin('🏠', '#1a1a2e') })
+          .bindPopup('Service location')
+          .addTo(layer)
+        bounds.push([destination.lat, destination.lng])
+      }
+      if (techLocation) {
+        L.marker([techLocation.lat, techLocation.lng], { icon: pin('🚐', '#22c55e') })
+          .bindPopup('Your technician')
+          .addTo(layer)
+        bounds.push([techLocation.lat, techLocation.lng])
+        if (destination) {
+          L.polyline(
+            [
+              [techLocation.lat, techLocation.lng],
+              [destination.lat, destination.lng],
+            ],
+            { color: '#22c55e', weight: 3, opacity: 0.7, dashArray: '8, 6' }
+          ).addTo(layer)
+        }
+      }
+
+      if (bounds.length === 1) {
+        mapRef.current!.setView(bounds[0], 14)
+      } else if (bounds.length > 1) {
+        mapRef.current!.fitBounds(bounds, { padding: [40, 40], maxZoom: 15 })
+      }
+    })
+
+    return () => {
+      mounted = false
+    }
+  }, [destination, techLocation])
+
+  useEffect(() => {
+    return () => {
+      if (mapRef.current) {
+        mapRef.current.remove()
+        mapRef.current = null
+      }
+    }
+  }, [])
+
+  return <div ref={containerRef} className="w-full h-56 rounded-xl overflow-hidden border border-gray-200 mt-4" style={{ zIndex: 0 }} />
 }
 
 function formatTime(t: string | null): string {
@@ -84,9 +179,10 @@ export default function TrackingPage({ params }: { params: { token: string } }) 
                 </span>
               </div>
 
-              {info.phase === 'enroute' && info.techFirstName && (
+              {info.phase === 'enroute' && (
                 <p className="text-gray-700 mb-4">
-                  <strong>{info.techFirstName}</strong> is on the way to you now.
+                  {info.techFirstName ? <><strong>{info.techFirstName}</strong> is</> : 'Your technician is'} on the way to you now
+                  {info.techLocation ? ' — follow along on the map below.' : '.'}
                 </p>
               )}
               {info.phase === 'scheduled' && (
@@ -110,15 +206,8 @@ export default function TrackingPage({ params }: { params: { token: string } }) 
                 </p>
               )}
 
-              {info.destination && (
-                <a
-                  href={`https://www.openstreetmap.org/?mlat=${info.destination.lat}&mlon=${info.destination.lng}#map=15/${info.destination.lat}/${info.destination.lng}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block text-center text-sm text-blue-600 underline mt-2"
-                >
-                  View service location{info.destination.city ? ` in ${info.destination.city}` : ''}
-                </a>
+              {(info.destination || info.techLocation) && (
+                <TrackMap destination={info.destination} techLocation={info.techLocation} />
               )}
 
               <p className="text-xs text-gray-400 text-center mt-6">

--- a/src/app/worker/job/page.tsx
+++ b/src/app/worker/job/page.tsx
@@ -186,6 +186,42 @@ function JobDetailContent() {
     return () => clearInterval(interval);
   }, [activeTimeEntry]);
 
+  // While the job is in progress, post the tech's GPS every 30s so the
+  // customer's tracking page shows a live "on the way" pin.
+  useEffect(() => {
+    if (!jobId || !activeTimeEntry || job?.status !== 'in_progress') return
+    if (typeof navigator === 'undefined' || !navigator.geolocation) return
+
+    let cancelled = false
+    const postLocation = () => {
+      navigator.geolocation.getCurrentPosition(
+        async (pos) => {
+          if (cancelled) return
+          try {
+            const { data: { session } } = await supabase.auth.getSession()
+            if (!session?.access_token) return
+            await fetch('/api/track/location', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+              body: JSON.stringify({ jobId, lat: pos.coords.latitude, lng: pos.coords.longitude }),
+            })
+          } catch {
+            // Non-fatal — tracking is best-effort.
+          }
+        },
+        () => {},
+        { enableHighAccuracy: true, timeout: 8000, maximumAge: 15000 }
+      )
+    }
+
+    postLocation()
+    const interval = setInterval(postLocation, 30000)
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
+  }, [jobId, activeTimeEntry, job?.status]);
+
   const formatTime = (seconds: number) => {
     const hrs = Math.floor(seconds / 3600);
     const mins = Math.floor((seconds % 3600) / 60);

--- a/supabase/migrations/20260621020000_add_job_tech_location.sql
+++ b/supabase/migrations/20260621020000_add_job_tech_location.sql
@@ -1,0 +1,8 @@
+-- Live technician location for the customer tracking page.
+-- While a job is in progress, the worker app posts the tech's current position
+-- here so the customer's tracking page can show an Uber-style live pin.
+-- Only the latest fix is kept (no history).
+
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS tech_lat double precision;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS tech_lng double precision;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS tech_location_at timestamptz;


### PR DESCRIPTION
## Overview

The customer tracking page now shows the technician's **live position** moving toward the destination — an Uber-style arrival experience that builds on the "on the way" tracking link.

## Changes

- **Migration `20260621020000_add_job_tech_location.sql`** — adds `jobs.tech_lat`, `jobs.tech_lng`, `jobs.tech_location_at` (latest fix only, no history).
- **Worker app** (`worker/job`) — while a job is `in_progress`, posts the tech's GPS every 30s to `/api/track/location`. Best-effort; silently no-ops if geolocation is unavailable or permission denied.
- **`/api/track/location`** — auth + company-scoped write; ignored unless the job is in progress.
- **Public tracking API** (`/api/track/[token]`) — exposes the tech position **only while en route** and **only when the fix is under 10 minutes old**, so stale or off-job positions stay hidden.
- **Public tracking page** (`/track/[token]`) — a live Leaflet map with destination + technician pins and a route line, refreshing on the existing 30s poll.

## Privacy

The technician's location is never exposed before they start the job, after it completes, or once a fix goes stale (>10 min). It's scoped to a single job's unguessable tracking token.

## Testing
- `npm run build` ✓
- `npm test` → **508 passed** ✓
- `npm run lint` → no new errors ✓

## Deploy note
Run the new migration on Supabase so the `tech_*` columns exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0186e2ruMrttLk8FCKhB6zGg)_