### PR TITLE
Automatic Jenny phone-number provisioning (one-click onboarding)

### DIFF
--- a/docs/jenny-pro-booking-agent.md
+++ b/docs/jenny-pro-booking-agent.md
@@ -112,9 +112,29 @@ right business. Resolution order (`src/lib/jenny-company.js`):
 2. **`JENNY_COMPANY_ID` env var** — explicit pin for a single live/test business.
 3. **First company** — legacy single-tenant fallback.
 
-To onboard a contractor: provision a Twilio number, point its SMS + voice
-webhooks at `/api/jenny-pro/sms-webhook` and `/api/jenny-pro/voice`, and register
-the number on their company (dashboard, or insert into `company_phone_numbers`).
+### Onboarding a contractor
+
+**Automatic (recommended):** in **Dashboard → Jenny Pro → Settings → Your Jenny
+Phone Number**, click **"Get my Jenny number."** This calls
+`POST /api/jenny-pro/provision-number`, which:
+1. buys a US local number (optionally near a requested area code),
+2. sets its voice + SMS webhooks to `/api/jenny-pro/voice` and
+   `/api/jenny-pro/sms-webhook`,
+3. attaches it to the A2P Messaging Service (`TWILIO_MESSAGING_SERVICE_SID`) for
+   SMS deliverability, and
+4. saves the number → company mapping.
+
+It's idempotent (one active number per company). The contractor never touches
+the Twilio console.
+
+> Because numbers are added to the Messaging Service, set the Messaging
+> Service's **inbound** webhook to `/api/jenny-pro/sms-webhook` once, at the
+> account level — Jenny routes by the `To` number, so all tenants share that one
+> inbound setting.
+
+**Manual:** provision a Twilio number yourself, point its SMS + voice webhooks at
+the two routes, and register it via the dashboard's "Connect Number" field (or
+insert into `company_phone_numbers`).
 
 ## Notes / limitations
 - The voice receptionist uses Twilio `<Gather input="speech">` + Amazon Polly

--- a/src/__tests__/api/jenny-provision-number.test.js
+++ b/src/__tests__/api/jenny-provision-number.test.js
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ */
+
+let mockExistingNumber = null;
+let mockUpsertError = null;
+const mockUpsert = jest.fn(() => Promise.resolve({ error: mockUpsertError }));
+
+jest.mock('@/lib/server-auth', () => ({
+  authenticateRequest: jest.fn().mockResolvedValue({ user: { id: 'user-1' } }),
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: (table) => {
+      const obj = {};
+      obj.select = () => obj;
+      obj.eq = () => obj;
+      obj.limit = () => obj;
+      obj.single = () => Promise.resolve({ data: { company_id: 'comp-1' } });
+      obj.maybeSingle = () =>
+        Promise.resolve({
+          data: table === 'company_phone_numbers' && mockExistingNumber
+            ? { phone_number: mockExistingNumber }
+            : null,
+        });
+      obj.upsert = mockUpsert;
+      return obj;
+    },
+  })),
+}));
+
+const mockList = jest.fn().mockResolvedValue([{ phoneNumber: '+15550009999' }]);
+const mockIncomingCreate = jest.fn().mockResolvedValue({ sid: 'PN1', phoneNumber: '+15550009999' });
+const mockMsCreate = jest.fn().mockResolvedValue({});
+
+jest.mock('twilio', () => {
+  const fn = jest.fn(() => ({
+    availablePhoneNumbers: jest.fn(() => ({ local: { list: mockList } })),
+    incomingPhoneNumbers: { create: mockIncomingCreate },
+    messaging: { v1: { services: jest.fn(() => ({ phoneNumbers: { create: mockMsCreate } })) } },
+  }));
+  return fn;
+});
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+process.env.TWILIO_ACCOUNT_SID = 'ACtest';
+process.env.TWILIO_AUTH_TOKEN = 'tok';
+process.env.TWILIO_MESSAGING_SERVICE_SID = 'MGtest';
+process.env.URL = 'https://www.tooltimepro.com';
+
+const { POST } = require('@/app/api/jenny-pro/provision-number/route');
+const { authenticateRequest } = require('@/lib/server-auth');
+
+function req(body = {}) {
+  return new Request('http://localhost/api/jenny-pro/provision-number', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('/api/jenny-pro/provision-number', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExistingNumber = null;
+    mockUpsertError = null;
+    authenticateRequest.mockResolvedValue({ user: { id: 'user-1' } });
+  });
+
+  it('buys a number, wires its webhooks, and saves the mapping', async () => {
+    const res = await POST(req({ _authToken: 't', areaCode: '209' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.phoneNumber).toBe('+15550009999');
+    expect(data.attachedToCampaign).toBe(true);
+
+    // Webhooks point at Jenny's routes.
+    expect(mockIncomingCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        voiceUrl: 'https://www.tooltimepro.com/api/jenny-pro/voice',
+        smsUrl: 'https://www.tooltimepro.com/api/jenny-pro/sms-webhook',
+      })
+    );
+    // Attached to the A2P Messaging Service and mapping saved.
+    expect(mockMsCreate).toHaveBeenCalledWith({ phoneNumberSid: 'PN1' });
+    expect(mockUpsert).toHaveBeenCalled();
+  });
+
+  it('is idempotent — returns the existing number without buying', async () => {
+    mockExistingNumber = '+15551112222';
+    const res = await POST(req({ _authToken: 't' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.phoneNumber).toBe('+15551112222');
+    expect(data.alreadyProvisioned).toBe(true);
+    expect(mockIncomingCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns the auth error when unauthenticated', async () => {
+    const { NextResponse } = require('next/server');
+    authenticateRequest.mockResolvedValue({ error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) });
+
+    const res = await POST(req({}));
+    expect(res.status).toBe(401);
+    expect(mockIncomingCreate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/jenny-pro/provision-number/route.js
+++ b/src/app/api/jenny-pro/provision-number/route.js
@@ -1,0 +1,170 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import Twilio from 'twilio';
+import { authenticateRequest } from '@/lib/server-auth';
+
+export const dynamic = 'force-dynamic';
+
+let supabaseInstance = null;
+function getSupabase() {
+  if (!supabaseInstance) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) throw new Error('Supabase not configured');
+    supabaseInstance = createClient(url, key, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+  }
+  return supabaseInstance;
+}
+
+function getTwilio() {
+  const sid = process.env.TWILIO_ACCOUNT_SID;
+  const token = process.env.TWILIO_AUTH_TOKEN;
+  if (!sid || !token) return null;
+  return Twilio(sid, token);
+}
+
+// Absolute base URL for the webhooks Twilio will call. Netlify sets URL.
+function baseUrl() {
+  const raw =
+    process.env.PUBLIC_BASE_URL ||
+    process.env.URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    'https://www.tooltimepro.com';
+  return raw.replace(/\/$/, '');
+}
+
+/**
+ * Provision a dedicated Jenny phone number for the caller's company.
+ *
+ * Buys a US local number, points its voice + SMS webhooks at Jenny's routes,
+ * attaches it to the A2P Messaging Service (for SMS deliverability), and saves
+ * the number → company mapping. Idempotent: returns the existing number if the
+ * company already has one.
+ *
+ * POST body: { areaCode?: string, _authToken?: string }
+ */
+export async function POST(request) {
+  let body = {};
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const { user, error: authResponse } = await authenticateRequest(request, body?._authToken);
+  if (authResponse) return authResponse;
+
+  const supabase = getSupabase();
+
+  const { data: dbUser } = await supabase
+    .from('users')
+    .select('company_id')
+    .eq('id', user.id)
+    .single();
+
+  if (!dbUser?.company_id) {
+    return NextResponse.json({ error: 'No company found for this user' }, { status: 400 });
+  }
+  const companyId = dbUser.company_id;
+
+  // Idempotent — never buy a second number for a company that already has one.
+  const { data: existing } = await supabase
+    .from('company_phone_numbers')
+    .select('phone_number')
+    .eq('company_id', companyId)
+    .eq('is_active', true)
+    .limit(1)
+    .maybeSingle();
+  if (existing?.phone_number) {
+    return NextResponse.json({ phoneNumber: existing.phone_number, alreadyProvisioned: true });
+  }
+
+  const client = getTwilio();
+  if (!client) {
+    return NextResponse.json(
+      { error: 'Twilio is not configured. Set TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN.' },
+      { status: 500 }
+    );
+  }
+
+  const base = baseUrl();
+  const areaCode = String(body?.areaCode || '').replace(/\D/g, '').slice(0, 3);
+
+  try {
+    // 1. Find an available local number (voice + SMS capable).
+    const searchOpts = { smsEnabled: true, voiceEnabled: true, limit: 1 };
+    if (areaCode.length === 3) searchOpts.areaCode = parseInt(areaCode, 10);
+
+    let available = await client.availablePhoneNumbers('US').local.list(searchOpts);
+    if ((!available || available.length === 0) && searchOpts.areaCode) {
+      // Nothing in that area code — fall back to any US local number.
+      available = await client
+        .availablePhoneNumbers('US')
+        .local.list({ smsEnabled: true, voiceEnabled: true, limit: 1 });
+    }
+    if (!available || available.length === 0) {
+      return NextResponse.json(
+        { error: 'No phone numbers available right now. Try a different area code.' },
+        { status: 409 }
+      );
+    }
+
+    // 2. Purchase it, wiring the webhooks to Jenny's routes.
+    const purchased = await client.incomingPhoneNumbers.create({
+      phoneNumber: available[0].phoneNumber,
+      voiceUrl: `${base}/api/jenny-pro/voice`,
+      voiceMethod: 'POST',
+      smsUrl: `${base}/api/jenny-pro/sms-webhook`,
+      smsMethod: 'POST',
+      friendlyName: `Jenny — company ${companyId}`,
+    });
+
+    // 3. Attach to the A2P Messaging Service (best-effort — required for SMS
+    //    deliverability to US numbers, but never block provisioning on it).
+    const messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
+    let attachedToCampaign = false;
+    if (messagingServiceSid) {
+      try {
+        await client.messaging.v1
+          .services(messagingServiceSid)
+          .phoneNumbers.create({ phoneNumberSid: purchased.sid });
+        attachedToCampaign = true;
+      } catch (e) {
+        console.error('[provision] Messaging Service attach failed:', e.message);
+      }
+    }
+
+    // 4. Save the number → company mapping.
+    const { error: saveError } = await supabase.from('company_phone_numbers').upsert(
+      {
+        company_id: companyId,
+        phone_number: purchased.phoneNumber,
+        label: 'jenny',
+        is_active: true,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'phone_number' }
+    );
+    if (saveError) {
+      console.error('[provision] mapping save error:', saveError);
+      return NextResponse.json(
+        { error: 'Number purchased but the mapping failed to save. Please contact support.', phoneNumber: purchased.phoneNumber },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      phoneNumber: purchased.phoneNumber,
+      sid: purchased.sid,
+      attachedToCampaign,
+    });
+  } catch (err) {
+    console.error('[provision] error:', err);
+    return NextResponse.json(
+      { error: err?.message || 'Failed to provision a number' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/jenny-pro/page.tsx
+++ b/src/app/dashboard/jenny-pro/page.tsx
@@ -86,6 +86,8 @@ function JennyProDashboard() {
   const [savingNumber, setSavingNumber] = useState(false);
   const [numberSaved, setNumberSaved] = useState(false);
   const [numberError, setNumberError] = useState('');
+  const [areaCode, setAreaCode] = useState('');
+  const [provisioning, setProvisioning] = useState(false);
 
   const fetchConversations = useCallback(async () => {
     if (!dbUser?.company_id) return;
@@ -212,6 +214,30 @@ function JennyProDashboard() {
     }
     setSavingNumber(false);
   }, [dbUser?.company_id, jennyNumber]);
+
+  const provisionNumber = useCallback(async () => {
+    setProvisioning(true);
+    setNumberError('');
+    setNumberSaved(false);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const res = await fetch('/api/jenny-pro/provision-number', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ _authToken: session?.access_token, areaCode }),
+      });
+      const data = await res.json();
+      if (res.ok && data.phoneNumber) {
+        setJennyNumber(data.phoneNumber);
+        setNumberSaved(true);
+      } else {
+        setNumberError(data.error || 'Could not get a number. Please try again.');
+      }
+    } catch {
+      setNumberError('Could not get a number. Please try again.');
+    }
+    setProvisioning(false);
+  }, [areaCode]);
 
   useEffect(() => {
     fetchConversations();
@@ -555,35 +581,73 @@ function JennyProDashboard() {
           <div className="bg-white rounded-xl border p-6">
             <h3 className="text-lg font-semibold text-gray-900 mb-1">Your Jenny Phone Number</h3>
             <p className="text-sm text-gray-600 mb-4">
-              The business phone number Jenny answers on. Inbound texts and calls to this number
-              are routed to <span className="font-medium">your</span> company, so Jenny replies as
-              your business with your services and books into your calendar.
+              The dedicated business number Jenny answers on. Texts and calls to it are routed to
+              <span className="font-medium"> your</span> company, so Jenny replies as your business,
+              with your services, and books into your calendar.
             </p>
-            <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
-              <input
-                type="tel"
-                className="flex-1 border rounded-lg p-3 text-sm"
-                value={jennyNumber}
-                onChange={(e) => setJennyNumber(e.target.value)}
-                placeholder="+1 765 789 5752"
-              />
-              <button
-                onClick={saveNumber}
-                disabled={savingNumber || !jennyNumber.trim()}
-                className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
-              >
-                {savingNumber ? 'Saving…' : 'Save Number'}
-              </button>
-            </div>
-            {numberSaved && !numberError && (
-              <p className="text-xs text-green-600 mt-2">Saved ✓ — Jenny is now routed to your company.</p>
+
+            {jennyNumber ? (
+              <div className="flex items-center justify-between gap-3 p-4 bg-green-50 rounded-lg border border-green-200">
+                <div>
+                  <p className="text-xs text-gray-500 uppercase tracking-wide">Active number</p>
+                  <p className="text-lg font-semibold text-gray-900">{jennyNumber}</p>
+                </div>
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm font-medium">
+                  Connected
+                </span>
+              </div>
+            ) : (
+              <>
+                {/* Auto-provision (recommended) */}
+                <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    maxLength={3}
+                    className="w-full sm:w-40 border rounded-lg p-3 text-sm"
+                    value={areaCode}
+                    onChange={(e) => setAreaCode(e.target.value.replace(/\D/g, '').slice(0, 3))}
+                    placeholder="Area code (optional)"
+                  />
+                  <button
+                    onClick={provisionNumber}
+                    disabled={provisioning}
+                    className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+                  >
+                    {provisioning ? 'Getting your number…' : 'Get my Jenny number'}
+                  </button>
+                </div>
+                <p className="text-xs text-gray-500 mt-2">
+                  We&apos;ll set you up with a dedicated number and wire it automatically — no Twilio setup needed.
+                </p>
+
+                {/* Manual fallback — register an existing number */}
+                <div className="mt-4 pt-4 border-t">
+                  <p className="text-xs text-gray-500 mb-2">Already have a number? Connect it instead:</p>
+                  <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
+                    <input
+                      type="tel"
+                      className="flex-1 border rounded-lg p-3 text-sm"
+                      value={jennyNumber}
+                      onChange={(e) => setJennyNumber(e.target.value)}
+                      placeholder="+1 765 789 5752"
+                    />
+                    <button
+                      onClick={saveNumber}
+                      disabled={savingNumber || !jennyNumber.trim()}
+                      className="px-4 py-2 bg-white border text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-50 disabled:opacity-60"
+                    >
+                      {savingNumber ? 'Saving…' : 'Connect Number'}
+                    </button>
+                  </div>
+                </div>
+              </>
             )}
-            {numberError && <p className="text-xs text-red-600 mt-2">{numberError}</p>}
-            <p className="text-xs text-gray-500 mt-3">
-              Then point this number&apos;s Twilio webhooks at
-              <code className="mx-1 px-1 bg-gray-100 rounded">/api/jenny-pro/sms-webhook</code> and
-              <code className="mx-1 px-1 bg-gray-100 rounded">/api/jenny-pro/voice</code>.
-            </p>
+
+            {numberSaved && !numberError && (
+              <p className="text-xs text-green-600 mt-3">Saved ✓ — Jenny is now routed to your company.</p>
+            )}
+            {numberError && <p className="text-xs text-red-600 mt-3">{numberError}</p>}
           </div>
 
           {/* Twilio Status */}


### PR DESCRIPTION
## What

Makes Jenny truly **self-serve for onboarding**: a contractor gets their own dedicated phone number with **one click**, no Twilio console needed. This is the piece that answers "how do my customers get a number?" — they don't; the app provisions one for them.

## How

New route `POST /api/jenny-pro/provision-number` (authenticated):
1. Buys a US local number (optionally near a requested area code).
2. Sets its **voice + SMS webhooks** to `/api/jenny-pro/voice` and `/api/jenny-pro/sms-webhook`.
3. Attaches it to the **A2P Messaging Service** (`TWILIO_MESSAGING_SERVICE_SID`) for SMS deliverability (best-effort, non-blocking).
4. Saves the **number → company** mapping (`company_phone_numbers`).

Idempotent — one active number per company; returns the existing one if already provisioned.

## Changes
- `src/app/api/jenny-pro/provision-number/route.js`
- **Dashboard → Jenny Pro → Settings**: "Get my Jenny number" button (optional area code) + manual "Connect Number" fallback; shows the active number once connected.
- Docs: automatic + manual onboarding.

## Notes
- Each contractor needs their **own** number (one number = one company); this hands them one automatically.
- One-time account setup: point the **Messaging Service's inbound webhook** at `/api/jenny-pro/sms-webhook` (Jenny routes by the `To` number, so all tenants share that single inbound setting).
- Each number carries a small Twilio monthly cost.

## Verification
Full suite **517 pass**; `npm run build` clean. New route test covers buy/wire/save, idempotency, and auth failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw38sSQpf3TEVPE5AhV7Jt)_