### PR TITLE
Add GET health check to Jenny webhook routes (clean 200 instead of 405)

### DIFF
--- a/src/app/api/jenny-pro/sms-webhook/route.js
+++ b/src/app/api/jenny-pro/sms-webhook/route.js
@@ -7,6 +7,15 @@ import { resolveCompanyByNumber } from '@/lib/jenny-company';
 
 export const dynamic = 'force-dynamic';
 
+// Health check — lets a browser or a webhook validator confirm the endpoint is
+// live (returns 200) without triggering the booking flow. Twilio always POSTs.
+export async function GET() {
+  return new Response('Jenny SMS webhook is live. Twilio sends inbound messages here via POST.', {
+    status: 200,
+    headers: { 'Content-Type': 'text/plain' },
+  });
+}
+
 let supabaseInstance = null;
 
 function getSupabase() {

--- a/src/app/api/jenny-pro/voice/route.js
+++ b/src/app/api/jenny-pro/voice/route.js
@@ -3,6 +3,14 @@ import { t } from '@/lib/jenny-language';
 
 export const dynamic = 'force-dynamic';
 
+// Health check — confirms the endpoint is live for a browser/validator. Twilio POSTs here.
+export async function GET() {
+  return new Response('Jenny voice webhook is live. Twilio sends inbound calls here via POST.', {
+    status: 200,
+    headers: { 'Content-Type': 'text/plain' },
+  });
+}
+
 /**
  * Primary inbound-call webhook for Jenny Pro voice.
  *


### PR DESCRIPTION
## Problem
Opening the SMS/voice webhook URLs in a browser (a GET) returned **405** because the routes only handle POST. That's technically correct, but it's confusing and some webhook URL validators reject a 405.

## Fix
Add a `GET` handler to `/api/jenny-pro/sms-webhook` and `/api/jenny-pro/voice` that returns **200** with a short "live" message. Twilio still POSTs for real inbound messages/calls; the booking flow is untouched.

## Verification
Webhook tests pass; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw38sSQpf3TEVPE5AhV7Jt)_