### PR TITLE
Better Jenny replies: Sonnet model, richer prompt, per-business info

### DIFF
--- a/database/migrations/041_jenny_business_info.sql
+++ b/database/migrations/041_jenny_business_info.sql
@@ -1,0 +1,7 @@
+-- Let each contractor teach Jenny about their business — pricing, service area,
+-- hours, specials, and tone. This text is injected into Jenny's prompt so her
+-- SMS + voice replies are accurate and on-brand (the practical "improve Jenny"
+-- lever the operator controls).
+
+ALTER TABLE jenny_pro_settings
+  ADD COLUMN IF NOT EXISTS business_info TEXT;

--- a/docs/jenny-pro-booking-agent.md
+++ b/docs/jenny-pro-booking-agent.md
@@ -99,6 +99,22 @@ Migration `038_jenny_sms_booking_agent.sql` adds:
 (The `jenny_sms_conversations`, `jenny_sms_messages`, `jenny_voice_calls`, and
 `jenny_pro_settings` tables come from `021_jenny_pro_sms_conversations.sql`.)
 
+## Improving Jenny's replies
+
+Reply quality comes from three levers (all live):
+1. **Model** — the agent runs on the `high` tier (Claude Sonnet) for natural,
+   persuasive replies. See `tier` in `src/lib/jenny-sms-agent.js`.
+2. **Prompt** — `buildSystemPrompt` includes personality + how-to-handle-common-
+   situations guidance.
+3. **Per-business context** — each contractor fills **"Tell Jenny about your
+   business"** (Jenny Pro → Settings; `jenny_pro_settings.business_info`,
+   migration `041`). It's injected into the prompt so Jenny answers pricing,
+   service-area, and availability questions accurately. This is the operator's
+   continuous-improvement loop: refine the text, replies get better immediately.
+
+Note: Jenny does not auto-train from past chats — improvement comes from the
+business-info field and prompt/model, not autonomous learning.
+
 ## Multi-tenant routing (number → company)
 
 Each contractor's Twilio number maps to their company, so Jenny answers as the

--- a/src/app/api/jenny-pro/settings/route.js
+++ b/src/app/api/jenny-pro/settings/route.js
@@ -68,6 +68,7 @@ export async function POST(request) {
     language,
     operator_language,
     auto_booking,
+    business_info,
   } = body;
 
   const { data, error } = await supabase
@@ -82,6 +83,7 @@ export async function POST(request) {
         language,
         operator_language,
         auto_booking,
+        business_info,
         updated_at: new Date().toISOString(),
       },
       { onConflict: 'company_id' }

--- a/src/app/dashboard/jenny-pro/page.tsx
+++ b/src/app/dashboard/jenny-pro/page.tsx
@@ -45,6 +45,7 @@ interface JennyProSettings {
   language: 'en' | 'es' | 'both';
   operator_language: 'en' | 'es';
   auto_booking: boolean;
+  business_info: string;
 }
 
 const DEFAULT_SETTINGS: JennyProSettings = {
@@ -55,6 +56,7 @@ const DEFAULT_SETTINGS: JennyProSettings = {
   language: 'both',
   operator_language: 'en',
   auto_booking: true,
+  business_info: '',
 };
 
 export default function JennyProPage() {
@@ -141,6 +143,7 @@ function JennyProDashboard() {
           language: (data.language as JennyProSettings['language']) || 'both',
           operator_language: (data.operator_language as JennyProSettings['operator_language']) || 'en',
           auto_booking: data.auto_booking !== false,
+          business_info: data.business_info || '',
         });
       }
     } catch {
@@ -165,6 +168,7 @@ function JennyProDashboard() {
           language: settings.language,
           operator_language: settings.operator_language,
           auto_booking: settings.auto_booking,
+          business_info: settings.business_info,
           updated_at: new Date().toISOString(),
         },
         { onConflict: 'company_id' }
@@ -527,6 +531,21 @@ function JennyProDashboard() {
             </div>
 
             <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Tell Jenny about your business</label>
+                <textarea
+                  className="w-full border rounded-lg p-3 text-sm"
+                  rows={5}
+                  value={settings.business_info}
+                  onChange={(e) => setSettings((s) => ({ ...s, business_info: e.target.value }))}
+                  placeholder={'The more you tell Jenny, the better her replies. For example:\n• Services & typical pricing (e.g. lawn mowing $65–85, cleanups $120+)\n• Service area / cities you cover\n• Hours, and how fast you can usually come out\n• Specials, what makes you different, the tone you want\n• Anything customers always ask'}
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  This is how you make Jenny smarter. She uses it to answer pricing, availability, and
+                  service questions accurately — update it anytime and her replies improve instantly.
+                </p>
+              </div>
+
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Business Hours Greeting</label>
                 <textarea

--- a/src/lib/jenny-sms-agent.js
+++ b/src/lib/jenny-sms-agent.js
@@ -24,7 +24,7 @@ function matchesEmergency(text, keywords) {
   return list.some((k) => lower.includes(String(k).toLowerCase()));
 }
 
-function buildSystemPrompt({ companyName, businessType, services, lang, today, channel }) {
+function buildSystemPrompt({ companyName, businessType, services, lang, today, channel, businessInfo }) {
   const serviceLines = services && services.length
     ? services
         .map((s) => {
@@ -50,11 +50,24 @@ function buildSystemPrompt({ companyName, businessType, services, lang, today, c
 ${langInstruction}
 ${channelNote}
 
+PERSONALITY & STYLE:
+- Sound like a warm, sharp human receptionist — never robotic or generic. No "I'm an AI" disclaimers.
+- Greet by name once you know it, and acknowledge what they actually said before asking the next thing.
+- Be concise and confident. One clear question at a time, always nudging toward a booked appointment.
+- Sound local and helpful, not salesy. A single emoji is fine occasionally; don't overdo it.
+
+HANDLING COMMON SITUATIONS:
+- Price questions: give the range from the services list if available; if unknown, say it depends and offer a free estimate visit instead of guessing a number.
+- Hesitation or "just checking": offer the easiest next step (a quick estimate or a tentative time) to keep momentum.
+- Vague timing ("sometime this week", "ASAP"): propose a specific concrete slot (e.g., "How about tomorrow at 9 AM?").
+- Out-of-scope or off-topic: answer briefly, then steer back to booking.
+- Never promise anything not in the services/business info below.
+
 Today's date is ${today}. Convert relative dates ("tomorrow", "next Tuesday", "this Friday") into real calendar dates.
 
 Services offered:
 ${serviceLines}
-
+${businessInfo ? `\nAbout this business (use this to answer accurately — pricing, service area, hours, specials, tone):\n${businessInfo}\n` : ''}
 Your goal is to collect, conversationally and warmly:
 1. The customer's name
 2. The service they need (match to a service above when possible)
@@ -138,6 +151,7 @@ async function runJennyAgent({ supabase, companyId, company, settings, history =
     lang,
     today: todayISO(),
     channel,
+    businessInfo: settings?.business_info || '',
   });
 
   let ai;
@@ -146,8 +160,10 @@ async function runJennyAgent({ supabase, companyId, company, settings, history =
       systemPrompt,
       messages: [...history, { role: 'user', content: message }],
       maxTokens: 400,
-      temperature: 0.4,
-      tier: 'fast',
+      temperature: 0.5,
+      // 'high' = Claude Sonnet — far more natural/persuasive replies than the
+      // fast model. Worth it for a revenue-driving booking conversation.
+      tier: 'high',
     });
   } catch (err) {
     // Both providers unavailable — always give the customer a reply.


### PR DESCRIPTION
## What
Makes Jenny's replies noticeably better — addresses "the replies are mediocre."

Three levers:
1. **Model upgrade** — the booking agent now runs on the **high tier (Claude Sonnet)** instead of the fast model (Haiku). Far more natural, persuasive, context-aware replies. (Worth the cost on a revenue-driving booking conversation.)
2. **Richer prompt** — `buildSystemPrompt` now includes a receptionist personality and explicit guidance for pricing questions, hesitation, vague timing, and off-topic messages.
3. **Per-business context** — new **"Tell Jenny about your business"** field (`jenny_pro_settings.business_info`, migration `041`). Each contractor describes their services, pricing, service area, hours, specials, and tone; it's injected into Jenny's prompt so she answers accurately. This is the operator's continuous-improvement loop — refine the text, replies improve instantly.

## Honest note
Jenny doesn't auto-train from past chats (that needs a training pipeline). Improvement comes from the model, the prompt, and the business-info field.

## Changes
- `src/lib/jenny-sms-agent.js` — tier `fast`→`high`, expanded prompt, inject `business_info`
- `database/migrations/041_jenny_business_info.sql`
- Settings API + dashboard textarea to edit business info
- Docs: "Improving Jenny's replies"

## After merge
Run migration `041`, then fill in **Jenny Pro → Settings → "Tell Jenny about your business."**

## Verification
Full suite **523 pass**; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw38sSQpf3TEVPE5AhV7Jt)_