### PR TITLE
Fix duplicate bookings — dedup + reschedule awareness

### DIFF
--- a/src/__tests__/lib/jenny-bookings.test.js
+++ b/src/__tests__/lib/jenny-bookings.test.js
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment node
+ */
+
+const { getUpcomingBookings, isDuplicate, rescheduleBooking } = require('@/lib/jenny-bookings');
+
+describe('jenny-bookings', () => {
+  describe('isDuplicate', () => {
+    const existing = [{ scheduled_date: '2026-07-02', scheduled_time_start: '09:00' }];
+    it('flags an exact date+time match', () => {
+      expect(isDuplicate(existing, '2026-07-02', '09:00')).toBe(true);
+    });
+    it('does not flag a different time', () => {
+      expect(isDuplicate(existing, '2026-07-02', '10:00')).toBe(false);
+    });
+    it('does not flag a different day', () => {
+      expect(isDuplicate(existing, '2026-07-03', '09:00')).toBe(false);
+    });
+    it('handles empty/undefined safely', () => {
+      expect(isDuplicate(undefined, '2026-07-02', '09:00')).toBe(false);
+    });
+  });
+
+  describe('getUpcomingBookings', () => {
+    function makeSupabase({ customer, jobs }) {
+      return {
+        from(table) {
+          const obj = {};
+          obj.select = () => obj;
+          obj.eq = () => obj;
+          obj.ilike = () => obj;
+          obj.gte = () => obj;
+          obj.neq = () => obj;
+          obj.order = () => obj;
+          obj.limit = () => (table === 'jobs' ? Promise.resolve({ data: jobs }) : obj);
+          obj.maybeSingle = () => Promise.resolve({ data: customer });
+          return obj;
+        },
+      };
+    }
+
+    it('returns the customer\'s upcoming jobs', async () => {
+      const jobs = [{ id: 'j1', title: 'Lawn Care', scheduled_date: '2026-07-02', scheduled_time_start: '09:00' }];
+      const res = await getUpcomingBookings(makeSupabase({ customer: { id: 'c1' }, jobs }), 'co1', '7657895752');
+      expect(res).toEqual(jobs);
+    });
+
+    it('returns [] when the customer is unknown', async () => {
+      const res = await getUpcomingBookings(makeSupabase({ customer: null, jobs: [] }), 'co1', '7657895752');
+      expect(res).toEqual([]);
+    });
+
+    it('returns [] for an empty phone', async () => {
+      const res = await getUpcomingBookings(makeSupabase({ customer: { id: 'c1' }, jobs: [] }), 'co1', '');
+      expect(res).toEqual([]);
+    });
+  });
+
+  describe('rescheduleBooking', () => {
+    it('updates the job with the new date/time and end time', async () => {
+      const update = jest.fn(() => ({ eq: jest.fn(() => Promise.resolve({ error: null })) }));
+      const supabase = { from: jest.fn(() => ({ update })) };
+      const res = await rescheduleBooking(supabase, 'j1', { date: '2026-07-03', time: '10:00', durationMinutes: 60 });
+      expect(res.ok).toBe(true);
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({ scheduled_date: '2026-07-03', scheduled_time_start: '10:00', scheduled_time_end: '11:00' })
+      );
+    });
+  });
+});

--- a/src/__tests__/lib/jenny-sms-agent.test.js
+++ b/src/__tests__/lib/jenny-sms-agent.test.js
@@ -117,6 +117,35 @@ describe('runJennyAgent', () => {
     expect(res.booking).toBeNull();
   });
 
+  it('parses is_reschedule into isReschedule', async () => {
+    mockAiComplete.mockResolvedValue({
+      content: JSON.stringify({
+        reply: 'Moved your Lawn Care to 10 AM!',
+        language: 'en',
+        intent: 'booking',
+        ready_to_book: true,
+        is_reschedule: true,
+        booking: {
+          customerName: 'Sarah',
+          serviceName: 'Lawn Care',
+          scheduledDate: '2026-07-02',
+          scheduledTimeStart: '10:00',
+        },
+      }),
+    });
+
+    const res = await runJennyAgent({
+      supabase: makeSupabase(),
+      companyId: 'c1',
+      settings: {},
+      message: 'can you move it to 10',
+      existingBookings: [{ id: 'j1', title: 'Lawn Care', scheduled_date: '2026-07-02', scheduled_time_start: '09:00' }],
+    });
+
+    expect(res.readyToBook).toBe(true);
+    expect(res.isReschedule).toBe(true);
+  });
+
   it('replies in Spanish when the customer writes Spanish', async () => {
     mockAiComplete.mockResolvedValue({
       content: JSON.stringify({

--- a/src/app/api/jenny-pro/sms-webhook/route.js
+++ b/src/app/api/jenny-pro/sms-webhook/route.js
@@ -4,6 +4,7 @@ import { createBooking } from '@/lib/booking-core';
 import { classifyKeyword, detectLanguage, resolveReplyLanguage, t } from '@/lib/jenny-language';
 import { notifyOperatorInApp, notifyOperatorSMS } from '@/lib/jenny-notify';
 import { resolveCompanyByNumber } from '@/lib/jenny-company';
+import { getUpcomingBookings, isDuplicate, rescheduleBooking } from '@/lib/jenny-bookings';
 
 export const dynamic = 'force-dynamic';
 
@@ -221,6 +222,10 @@ export async function POST(request) {
       }));
     }
 
+    // Jenny's awareness of this customer's existing appointments (prevents
+    // duplicate bookings and lets her reschedule instead).
+    const existingBookings = await getUpcomingBookings(supabase, companyId, from);
+
     const result = await runJennyAgent({
       supabase,
       companyId,
@@ -228,6 +233,7 @@ export async function POST(request) {
       history,
       message: body,
       channel: 'sms',
+      existingBookings,
     });
 
     // Persist language/intent on the conversation.
@@ -262,6 +268,31 @@ export async function POST(request) {
     const autoBookingOn = !settings || settings.auto_booking !== false;
     if (result.readyToBook && result.booking && autoBookingOn) {
       const b = result.booking;
+
+      // ── Reschedule an existing appointment instead of duplicating ────────
+      if (result.isReschedule && existingBookings.length) {
+        const target = existingBookings[0];
+        const r = await rescheduleBooking(supabase, target.id, {
+          date: b.scheduledDate,
+          time: b.scheduledTimeStart,
+          durationMinutes: 60,
+        });
+        if (r.ok && conversationId) {
+          await supabase
+            .from('jenny_sms_conversations')
+            .update({ booking_id: target.id, customer_name: b.customerName })
+            .eq('id', conversationId);
+        }
+        await logOutbound(result.reply);
+        return twiml(result.reply);
+      }
+
+      // ── Don't create a duplicate for a slot they already hold ────────────
+      if (isDuplicate(existingBookings, b.scheduledDate, b.scheduledTimeStart)) {
+        await logOutbound(result.reply);
+        return twiml(result.reply);
+      }
+
       const bookingRes = await createBooking(supabase, {
         companyId,
         serviceName: b.serviceName,

--- a/src/app/api/jenny-pro/voice/gather/route.js
+++ b/src/app/api/jenny-pro/voice/gather/route.js
@@ -9,6 +9,7 @@ import {
 import { runJennyAgent } from '@/lib/jenny-sms-agent';
 import { createBooking } from '@/lib/booking-core';
 import { notifyOperatorInApp } from '@/lib/jenny-notify';
+import { getUpcomingBookings, isDuplicate, rescheduleBooking } from '@/lib/jenny-bookings';
 
 export const dynamic = 'force-dynamic';
 
@@ -78,6 +79,8 @@ export async function POST(request) {
       }));
     }
 
+    const existingBookings = await getUpcomingBookings(supabase, company.id, caller);
+
     const result = await runJennyAgent({
       supabase,
       companyId: company.id,
@@ -85,6 +88,7 @@ export async function POST(request) {
       history,
       message: speech,
       channel: 'voice',
+      existingBookings,
     });
 
     const lang = result.language;
@@ -118,6 +122,22 @@ export async function POST(request) {
     const autoBookingOn = !settings || settings.auto_booking !== false;
     if (result.readyToBook && result.booking && autoBookingOn) {
       const b = result.booking;
+      const closing = lang === 'es' ? ' ¡Gracias por llamar!' : ' Thanks for calling!';
+
+      // Reschedule an existing appointment rather than duplicating it.
+      if (result.isReschedule && existingBookings.length) {
+        await rescheduleBooking(supabase, existingBookings[0].id, {
+          date: b.scheduledDate,
+          time: b.scheduledTimeStart,
+          durationMinutes: 60,
+        });
+        return voiceResponse(buildSay(result.reply + closing, lang) + '<Hangup/>');
+      }
+      // Don't double-book a slot they already hold.
+      if (isDuplicate(existingBookings, b.scheduledDate, b.scheduledTimeStart)) {
+        return voiceResponse(buildSay(result.reply + closing, lang) + '<Hangup/>');
+      }
+
       const bookingRes = await createBooking(supabase, {
         companyId: company.id,
         serviceName: b.serviceName,
@@ -159,7 +179,6 @@ export async function POST(request) {
           link: '/dashboard/dispatch',
         });
 
-        const closing = lang === 'es' ? ' ¡Gracias por llamar!' : ' Thanks for calling!';
         return voiceResponse(buildSay(result.reply + closing, lang) + '<Hangup/>');
       }
       console.error('[voice/gather] booking failed:', bookingRes.error);

--- a/src/lib/jenny-bookings.js
+++ b/src/lib/jenny-bookings.js
@@ -1,0 +1,58 @@
+// Helpers so Jenny is aware of a customer's existing appointments — prevents
+// duplicate bookings and lets her reschedule instead of re-creating.
+
+const { calculateEndTime } = require('./booking-core');
+
+/**
+ * Upcoming, non-cancelled appointments for a customer (matched by phone).
+ * @returns {Promise<Array<{id, title, scheduled_date, scheduled_time_start}>>}
+ */
+async function getUpcomingBookings(supabase, companyId, customerPhone) {
+  const cleanPhone = String(customerPhone || '').replace(/\D/g, '').slice(-10);
+  if (cleanPhone.length < 7) return [];
+
+  const { data: customer } = await supabase
+    .from('customers')
+    .select('id')
+    .eq('company_id', companyId)
+    .ilike('phone', `%${cleanPhone}%`)
+    .limit(1)
+    .maybeSingle();
+  if (!customer?.id) return [];
+
+  const today = new Date().toISOString().split('T')[0];
+  const { data: jobs } = await supabase
+    .from('jobs')
+    .select('id, title, scheduled_date, scheduled_time_start')
+    .eq('company_id', companyId)
+    .eq('customer_id', customer.id)
+    .gte('scheduled_date', today)
+    .neq('status', 'cancelled')
+    .order('scheduled_date', { ascending: true })
+    .limit(10);
+
+  return jobs || [];
+}
+
+/** True if any existing booking is at the same date AND time as the request. */
+function isDuplicate(existing, date, time) {
+  return (existing || []).some(
+    (b) => b.scheduled_date === date && b.scheduled_time_start === time
+  );
+}
+
+/** Move an existing appointment to a new date/time. */
+async function rescheduleBooking(supabase, jobId, { date, time, durationMinutes }) {
+  const { error } = await supabase
+    .from('jobs')
+    .update({
+      scheduled_date: date,
+      scheduled_time_start: time,
+      scheduled_time_end: calculateEndTime(time, durationMinutes || 60),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', jobId);
+  return { ok: !error, error };
+}
+
+module.exports = { getUpcomingBookings, isDuplicate, rescheduleBooking };

--- a/src/lib/jenny-sms-agent.js
+++ b/src/lib/jenny-sms-agent.js
@@ -24,7 +24,12 @@ function matchesEmergency(text, keywords) {
   return list.some((k) => lower.includes(String(k).toLowerCase()));
 }
 
-function buildSystemPrompt({ companyName, businessType, services, lang, today, channel, businessInfo }) {
+function buildSystemPrompt({ companyName, businessType, services, lang, today, channel, businessInfo, existingBookings }) {
+  const existingLines = existingBookings && existingBookings.length
+    ? existingBookings
+        .map((b) => `- ${b.title || 'Appointment'} on ${b.scheduled_date} at ${b.scheduled_time_start}`)
+        .join('\n')
+    : '';
   const serviceLines = services && services.length
     ? services
         .map((s) => {
@@ -67,7 +72,7 @@ Today's date is ${today}. Convert relative dates ("tomorrow", "next Tuesday", "t
 
 Services offered:
 ${serviceLines}
-${businessInfo ? `\nAbout this business (use this to answer accurately — pricing, service area, hours, specials, tone):\n${businessInfo}\n` : ''}
+${businessInfo ? `\nAbout this business (use this to answer accurately — pricing, service area, hours, specials, tone):\n${businessInfo}\n` : ''}${existingLines ? `\nIMPORTANT — this customer ALREADY has these upcoming appointments:\n${existingLines}\nDo NOT create a duplicate. If they want to MOVE one to a different day/time, set "is_reschedule": true and put the NEW date/time in "booking". If they're just confirming or chatting, set ready_to_book false and don't book again. Only book a brand-new appointment if it's clearly a different/additional job.\n` : ''}
 Your goal is to collect, conversationally and warmly:
 1. The customer's name
 2. The service they need (match to a service above when possible)
@@ -82,6 +87,7 @@ You MUST reply with a single JSON object and NOTHING else, in this exact shape:
   "language": "en" or "es",
   "intent": "booking" | "question" | "emergency" | "other",
   "ready_to_book": true or false,
+  "is_reschedule": true or false (true ONLY when moving an existing appointment to a new day/time),
   "booking": {
     "customerName": "string",
     "serviceName": "string",
@@ -108,7 +114,7 @@ Set "ready_to_book" to true ONLY when you have name, service, a concrete date, a
  * @param {'sms'|'voice'} [opts.channel='sms']
  * @returns {Promise<{ reply, language, intent, readyToBook, booking, emergency }>}
  */
-async function runJennyAgent({ supabase, companyId, company, settings, history = [], message, channel = 'sms' }) {
+async function runJennyAgent({ supabase, companyId, company, settings, history = [], message, channel = 'sms', existingBookings = [] }) {
   const detected = detectLanguage(message);
   const lang = resolveReplyLanguage(detected, settings?.language);
 
@@ -152,6 +158,7 @@ async function runJennyAgent({ supabase, companyId, company, settings, history =
     today: todayISO(),
     channel,
     businessInfo: settings?.business_info || '',
+    existingBookings,
   });
 
   let ai;
@@ -209,6 +216,7 @@ async function runJennyAgent({ supabase, companyId, company, settings, history =
     language: result.language === 'es' || result.language === 'en' ? result.language : lang,
     intent: result.intent || 'other',
     readyToBook: !!(result.ready_to_book && hasRequired),
+    isReschedule: !!(result.is_reschedule && hasRequired),
     booking: hasRequired ? booking : null,
     emergency: false,
   };


### PR DESCRIPTION
## Problem
In the same thread with the same customer, Jenny created a **second booking for the exact same time** instead of recognizing the existing appointment. Two causes: she had no awareness of the customer's existing bookings, and there was no guard against double-booking.

## Fix
Jenny now looks up the customer's upcoming appointments (matched by phone) before booking, and:
- **Never double-books** a slot the customer already holds (dedup guard).
- **Reschedules in place** when they change the day/time — the agent emits `is_reschedule` and the existing job is **updated**, not duplicated.
- The agent's prompt now lists the customer's existing appointments so it stops re-booking them.

Works across both SMS and the voice receptionist, and is robust even if a follow-up text starts a new conversation thread (the check is job-based, by phone).

## Changes
- `src/lib/jenny-bookings.js` — `getUpcomingBookings` / `isDuplicate` / `rescheduleBooking`
- `src/lib/jenny-sms-agent.js` — inject existing appointments + parse `is_reschedule`
- `sms-webhook` + `voice/gather` — reschedule/dedup before `createBooking`

## Verification
Full suite **532 pass** (new `jenny-bookings` tests + reschedule-parse test); `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw38sSQpf3TEVPE5AhV7Jt)_