### PR TITLE
Fix stale job-delete UI + Jenny cancel-by-text/call

### DIFF
--- a/src/__tests__/lib/jenny-bookings.test.js
+++ b/src/__tests__/lib/jenny-bookings.test.js
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-const { getUpcomingBookings, isDuplicate, rescheduleBooking } = require('@/lib/jenny-bookings');
+const { getUpcomingBookings, isDuplicate, rescheduleBooking, cancelBooking } = require('@/lib/jenny-bookings');
 
 describe('jenny-bookings', () => {
   describe('isDuplicate', () => {
@@ -65,6 +65,16 @@ describe('jenny-bookings', () => {
       expect(update).toHaveBeenCalledWith(
         expect.objectContaining({ scheduled_date: '2026-07-03', scheduled_time_start: '10:00', scheduled_time_end: '11:00' })
       );
+    });
+  });
+
+  describe('cancelBooking', () => {
+    it('sets the job status to cancelled', async () => {
+      const update = jest.fn(() => ({ eq: jest.fn(() => Promise.resolve({ error: null })) }));
+      const supabase = { from: jest.fn(() => ({ update })) };
+      const res = await cancelBooking(supabase, 'j1');
+      expect(res.ok).toBe(true);
+      expect(update).toHaveBeenCalledWith(expect.objectContaining({ status: 'cancelled' }));
     });
   });
 });

--- a/src/app/api/jenny-pro/sms-webhook/route.js
+++ b/src/app/api/jenny-pro/sms-webhook/route.js
@@ -4,7 +4,7 @@ import { createBooking } from '@/lib/booking-core';
 import { classifyKeyword, detectLanguage, resolveReplyLanguage, t } from '@/lib/jenny-language';
 import { notifyOperatorInApp, notifyOperatorSMS } from '@/lib/jenny-notify';
 import { resolveCompanyByNumber } from '@/lib/jenny-company';
-import { getUpcomingBookings, isDuplicate, rescheduleBooking } from '@/lib/jenny-bookings';
+import { getUpcomingBookings, isDuplicate, rescheduleBooking, cancelBooking } from '@/lib/jenny-bookings';
 
 export const dynamic = 'force-dynamic';
 
@@ -261,6 +261,37 @@ export async function POST(request) {
           link: '/dashboard/jenny-pro',
         }),
       ]);
+      return twiml(result.reply);
+    }
+
+    // ── Cancellation — cancel the existing appointment ─────────────────────
+    if (result.isCancellation && existingBookings.length) {
+      const target = existingBookings[0];
+      await cancelBooking(supabase, target.id);
+      if (conversationId) {
+        await supabase
+          .from('jenny_sms_conversations')
+          .update({ status: 'resolved', last_intent: 'cancellation' })
+          .eq('id', conversationId);
+      }
+      const opLang = settings?.operator_language || 'en';
+      await Promise.all([
+        notifyOperatorSMS(
+          settings?.escalation_phone,
+          `❌ Jenny cancelled an appointment for ${knownCustomer?.name || from} (${target.title || 'job'} ${target.scheduled_date}).`
+        ),
+        notifyOperatorInApp(supabase, {
+          companyId,
+          type: 'new_lead',
+          title: opLang === 'es' ? 'Cita cancelada' : 'Appointment cancelled',
+          message:
+            opLang === 'es'
+              ? `Jenny canceló la cita de ${knownCustomer?.name || from} (${target.scheduled_date}).`
+              : `Jenny cancelled ${knownCustomer?.name || from}'s appointment (${target.scheduled_date}).`,
+          link: '/dashboard/dispatch',
+        }),
+      ]);
+      await logOutbound(result.reply);
       return twiml(result.reply);
     }
 

--- a/src/app/api/jenny-pro/voice/gather/route.js
+++ b/src/app/api/jenny-pro/voice/gather/route.js
@@ -9,7 +9,7 @@ import {
 import { runJennyAgent } from '@/lib/jenny-sms-agent';
 import { createBooking } from '@/lib/booking-core';
 import { notifyOperatorInApp } from '@/lib/jenny-notify';
-import { getUpcomingBookings, isDuplicate, rescheduleBooking } from '@/lib/jenny-bookings';
+import { getUpcomingBookings, isDuplicate, rescheduleBooking, cancelBooking } from '@/lib/jenny-bookings';
 
 export const dynamic = 'force-dynamic';
 
@@ -115,6 +115,19 @@ export async function POST(request) {
 
     // Emergency — escalate by voice and end.
     if (result.emergency) {
+      return voiceResponse(buildSay(result.reply, lang) + '<Hangup/>');
+    }
+
+    // Cancellation — cancel the existing appointment and end.
+    if (result.isCancellation && existingBookings.length) {
+      await cancelBooking(supabase, existingBookings[0].id);
+      await notifyOperatorInApp(supabase, {
+        companyId: company.id,
+        type: 'new_lead',
+        title: 'Appointment cancelled (call)',
+        message: `Jenny cancelled an appointment for ${caller} (${existingBookings[0].scheduled_date}).`,
+        link: '/dashboard/dispatch',
+      });
       return voiceResponse(buildSay(result.reply, lang) + '<Hangup/>');
     }
 

--- a/src/app/dashboard/jobs/page.tsx
+++ b/src/app/dashboard/jobs/page.tsx
@@ -226,6 +226,16 @@ function JobsContent() {
         const result = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
 
         if (res.ok && result.success) {
+          // Drop the row immediately, then refresh from the server.
+          setJobs((prev) => prev.filter((j) => j.id !== jobId))
+          if (companyId) fetchJobs(companyId)
+          return
+        }
+
+        // If the job is already gone (404), the list is just stale — remove the
+        // row and refresh instead of showing a scary error.
+        if (res.status === 404) {
+          setJobs((prev) => prev.filter((j) => j.id !== jobId))
           if (companyId) fetchJobs(companyId)
           return
         }

--- a/src/lib/jenny-bookings.js
+++ b/src/lib/jenny-bookings.js
@@ -55,4 +55,13 @@ async function rescheduleBooking(supabase, jobId, { date, time, durationMinutes 
   return { ok: !error, error };
 }
 
-module.exports = { getUpcomingBookings, isDuplicate, rescheduleBooking };
+/** Cancel an existing appointment (soft — status only, keeps the record). */
+async function cancelBooking(supabase, jobId) {
+  const { error } = await supabase
+    .from('jobs')
+    .update({ status: 'cancelled', updated_at: new Date().toISOString() })
+    .eq('id', jobId);
+  return { ok: !error, error };
+}
+
+module.exports = { getUpcomingBookings, isDuplicate, rescheduleBooking, cancelBooking };

--- a/src/lib/jenny-sms-agent.js
+++ b/src/lib/jenny-sms-agent.js
@@ -72,7 +72,7 @@ Today's date is ${today}. Convert relative dates ("tomorrow", "next Tuesday", "t
 
 Services offered:
 ${serviceLines}
-${businessInfo ? `\nAbout this business (use this to answer accurately — pricing, service area, hours, specials, tone):\n${businessInfo}\n` : ''}${existingLines ? `\nIMPORTANT — this customer ALREADY has these upcoming appointments:\n${existingLines}\nDo NOT create a duplicate. If they want to MOVE one to a different day/time, set "is_reschedule": true and put the NEW date/time in "booking". If they're just confirming or chatting, set ready_to_book false and don't book again. Only book a brand-new appointment if it's clearly a different/additional job.\n` : ''}
+${businessInfo ? `\nAbout this business (use this to answer accurately — pricing, service area, hours, specials, tone):\n${businessInfo}\n` : ''}${existingLines ? `\nIMPORTANT — this customer ALREADY has these upcoming appointments:\n${existingLines}\nDo NOT create a duplicate. If they want to MOVE one to a different day/time, set "is_reschedule": true and put the NEW date/time in "booking". If they want to CANCEL an appointment, set "is_cancellation": true and confirm the cancellation in your reply. If they're just confirming or chatting, set ready_to_book false and don't book again. Only book a brand-new appointment if it's clearly a different/additional job.\n` : ''}
 Your goal is to collect, conversationally and warmly:
 1. The customer's name
 2. The service they need (match to a service above when possible)
@@ -88,6 +88,7 @@ You MUST reply with a single JSON object and NOTHING else, in this exact shape:
   "intent": "booking" | "question" | "emergency" | "other",
   "ready_to_book": true or false,
   "is_reschedule": true or false (true ONLY when moving an existing appointment to a new day/time),
+  "is_cancellation": true or false (true ONLY when the customer wants to cancel an existing appointment),
   "booking": {
     "customerName": "string",
     "serviceName": "string",
@@ -217,6 +218,7 @@ async function runJennyAgent({ supabase, companyId, company, settings, history =
     intent: result.intent || 'other',
     readyToBook: !!(result.ready_to_book && hasRequired),
     isReschedule: !!(result.is_reschedule && hasRequired),
+    isCancellation: !!result.is_cancellation,
     booking: hasRequired ? booking : null,
     emergency: false,
   };


### PR DESCRIPTION
## Two things

### 1. Fix: deleted job stays in the list
Deleting a job said "Job not found" on retry while the row was still showing. The first delete actually succeeded in the DB, but the UI refresh was gated on `companyId` being present, so the stale row stuck around — and the second attempt correctly 404'd.

Now the row is removed from the list **immediately** on a successful delete **or** a 404 (already gone), regardless of `companyId`, then refreshed from the server. (Clean up that earlier duplicate by deleting it once — it'll disappear now.)

### 2. Feature: cancel by text or call
A customer can now **cancel** an appointment by text or voice ("cancel my Thursday appointment"). The agent emits `is_cancellation`; Jenny sets the existing appointment to `status = 'cancelled'` and notifies the operator. Pairs with the reschedule/dedup logic from #618.

## Changes
- `src/app/dashboard/jobs/page.tsx` — optimistic row removal on success/404
- `src/lib/jenny-bookings.js` — `cancelBooking()`
- `src/lib/jenny-sms-agent.js` — `is_cancellation` in prompt/contract/parse
- `sms-webhook` + `voice/gather` — cancellation branch

## Verification
Full suite **533 pass**; `npm run build` clean. No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw38sSQpf3TEVPE5AhV7Jt)_