### PR TITLE
Appointment reminders + post-job thank-you/review texts

### DIFF
--- a/database/migrations/042_reminders_followups.sql
+++ b/database/migrations/042_reminders_followups.sql
@@ -1,0 +1,11 @@
+-- Appointment reminders + post-job follow-up/review automation.
+-- Track per-job whether each automated text has already gone out (so the cron
+-- sends exactly once), and per-company toggles to enable/disable each.
+
+ALTER TABLE jobs
+  ADD COLUMN IF NOT EXISTS reminder_sent_at TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN IF NOT EXISTS followup_sent_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE jenny_pro_settings
+  ADD COLUMN IF NOT EXISTS reminders_enabled BOOLEAN DEFAULT true,
+  ADD COLUMN IF NOT EXISTS review_followup_enabled BOOLEAN DEFAULT true;

--- a/docs/jenny-pro-booking-agent.md
+++ b/docs/jenny-pro-booking-agent.md
@@ -99,6 +99,20 @@ Migration `038_jenny_sms_booking_agent.sql` adds:
 (The `jenny_sms_conversations`, `jenny_sms_messages`, `jenny_voice_calls`, and
 `jenny_pro_settings` tables come from `021_jenny_pro_sms_conversations.sql`.)
 
+## Reminders & post-job follow-ups
+
+An hourly cron (`netlify/functions/appointment-reminders-cron` →
+`GET /api/jenny-pro/reminders`, secured by `CRON_SECRET`) sends:
+- **Appointment reminders** — the day before a scheduled job.
+- **Post-job thank-you + review request** — 1–36h after a job is marked
+  `completed`, using the company's Google/Yelp review link and logging to
+  `review_requests`.
+
+Sent **once per job** (`jobs.reminder_sent_at` / `followup_sent_at`, migration
+`042`), only to **SMS-consented** customers, and each is gated by a per-company
+toggle (`jenny_pro_settings.reminders_enabled` / `review_followup_enabled`,
+editable in Jenny Pro → Settings). Add review links under the Reviews section.
+
 ## Improving Jenny's replies
 
 Reply quality comes from three levers (all live):

--- a/netlify.toml
+++ b/netlify.toml
@@ -77,3 +77,9 @@
 # Calendar so the sync is automatic without clicking "Sync Now".
 [functions."calendar-sync-cron"]
   schedule = "*/30 * * * *"
+
+# Appointment Reminders + Post-Job Follow-ups — runs hourly
+# Texts customers a reminder the day before a job, and a thank-you + review
+# request after a job is completed (once per job, SMS-consented customers only).
+[functions."appointment-reminders-cron"]
+  schedule = "0 * * * *"

--- a/netlify/functions/appointment-reminders-cron.ts
+++ b/netlify/functions/appointment-reminders-cron.ts
@@ -1,0 +1,30 @@
+// Netlify Scheduled Function: Appointment Reminders + Post-Job Follow-ups
+// Runs hourly via netlify.toml schedule. Sends:
+//  - reminder texts the day before a scheduled job
+//  - a thank-you + review-request text after a job is completed
+// The route only sends once per job and only to SMS-consented customers.
+
+export default async function handler() {
+  const siteUrl = process.env.URL || process.env.DEPLOY_PRIME_URL || 'http://localhost:3000';
+  const cronSecret = process.env.CRON_SECRET || '';
+
+  try {
+    const response = await fetch(`${siteUrl}/api/jenny-pro/reminders`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${cronSecret}` },
+    });
+    const data = await response.json();
+    console.log('[Appointment Reminders Cron] Results:', JSON.stringify(data));
+
+    return new Response(JSON.stringify({ success: true, ...data }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('[Appointment Reminders Cron] Error:', error);
+    return new Response(JSON.stringify({ error: 'Cron execution failed' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/src/__tests__/api/jenny-reminders.test.js
+++ b/src/__tests__/api/jenny-reminders.test.js
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment node
+ */
+
+let mockJobsResults = [[], []];
+let mockJobsIdx = 0;
+const mockUpdateCalls = [];
+const mockReviewInserts = [];
+
+const mockSendSMS = jest.fn().mockResolvedValue({ success: true, messageId: 'SM1' });
+jest.mock('@/lib/twilio', () => ({
+  sendSMS: (...a) => mockSendSMS(...a),
+  SMS_TEMPLATES: {
+    bookingReminder: (d) => `Reminder: ${d.serviceName} with ${d.companyName} tomorrow ${d.date} ${d.time}`,
+    jobComplete: (d) => (d.reviewLink ? `Thanks ${d.customerName}! Review: ${d.reviewLink}` : `Thanks ${d.customerName}!`),
+  },
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from(table) {
+      if (table === 'jenny_pro_settings') {
+        return { select: () => Promise.resolve({ data: [] }) };
+      }
+      if (table === 'jobs') {
+        const obj = {};
+        obj.select = () => obj;
+        obj.eq = () => obj;
+        obj.is = () => obj;
+        obj.gte = () => obj;
+        obj.lte = () => obj;
+        obj.limit = () => Promise.resolve({ data: mockJobsResults[mockJobsIdx++] || [] });
+        obj.update = (payload) => { mockUpdateCalls.push(payload); return { eq: () => Promise.resolve({ error: null }) }; };
+        return obj;
+      }
+      if (table === 'review_requests') {
+        return { insert: (payload) => { mockReviewInserts.push(payload); return Promise.resolve({ error: null }); } };
+      }
+      return { select: () => Promise.resolve({ data: [] }) };
+    },
+  })),
+}));
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'k';
+delete process.env.CRON_SECRET;
+
+const { GET } = require('@/app/api/jenny-pro/reminders/route');
+
+function req() {
+  return new Request('http://localhost/api/jenny-pro/reminders', { method: 'GET' });
+}
+
+describe('/api/jenny-pro/reminders', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockJobsResults = [[], []];
+    mockJobsIdx = 0;
+    mockUpdateCalls.length = 0;
+    mockReviewInserts.length = 0;
+  });
+
+  it('sends a reminder for a consented customer with a job tomorrow', async () => {
+    mockJobsResults = [
+      [{
+        id: 'j1', title: 'Lawn Care', scheduled_date: '2026-07-02', scheduled_time_start: '09:00',
+        company_id: 'c1', customer: { name: 'Maria', phone: '+15551112222', sms_consent: true }, company: { name: 'Green Co' },
+      }],
+      [],
+    ];
+    const res = await GET(req());
+    const data = await res.json();
+    expect(data.remindersSent).toBe(1);
+    expect(mockSendSMS).toHaveBeenCalledWith(expect.objectContaining({ to: '+15551112222' }));
+    expect(mockUpdateCalls.some((u) => u.reminder_sent_at)).toBe(true);
+  });
+
+  it('skips customers without SMS consent', async () => {
+    mockJobsResults = [
+      [{
+        id: 'j1', title: 'Lawn Care', scheduled_date: '2026-07-02', scheduled_time_start: '09:00',
+        company_id: 'c1', customer: { name: 'Maria', phone: '+15551112222', sms_consent: false }, company: { name: 'Green Co' },
+      }],
+      [],
+    ];
+    const res = await GET(req());
+    const data = await res.json();
+    expect(data.remindersSent).toBe(0);
+    expect(mockSendSMS).not.toHaveBeenCalled();
+  });
+
+  it('sends a post-job thank-you + review and logs it', async () => {
+    mockJobsResults = [
+      [],
+      [{
+        id: 'j2', title: 'Lawn Care', company_id: 'c1', customer_id: 'cu1', updated_at: new Date().toISOString(),
+        customer: { name: 'Maria', phone: '+15551112222', sms_consent: true },
+        company: { name: 'Green Co', google_review_link: 'https://g.page/review' },
+      }],
+    ];
+    const res = await GET(req());
+    const data = await res.json();
+    expect(data.followupsSent).toBe(1);
+    expect(mockSendSMS).toHaveBeenCalledWith(expect.objectContaining({ to: '+15551112222' }));
+    expect(mockUpdateCalls.some((u) => u.followup_sent_at)).toBe(true);
+    expect(mockReviewInserts.length).toBe(1);
+    expect(mockReviewInserts[0].review_platform).toBe('google');
+  });
+
+  it('rejects unauthorized calls when CRON_SECRET is set', async () => {
+    process.env.CRON_SECRET = 'secret';
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+    delete process.env.CRON_SECRET;
+  });
+});

--- a/src/app/api/jenny-pro/reminders/route.js
+++ b/src/app/api/jenny-pro/reminders/route.js
@@ -1,0 +1,158 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { sendSMS, SMS_TEMPLATES } from '@/lib/twilio';
+
+export const dynamic = 'force-dynamic';
+
+let supabaseInstance = null;
+function getSupabase() {
+  if (!supabaseInstance) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) throw new Error('Supabase not configured');
+    supabaseInstance = createClient(url, key, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+  }
+  return supabaseInstance;
+}
+
+function fmtDate(dateStr) {
+  try {
+    return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
+      weekday: 'short', month: 'short', day: 'numeric',
+    });
+  } catch { return dateStr; }
+}
+function fmtTime(timeStr) {
+  if (!timeStr) return '';
+  const [h, m] = String(timeStr).split(':');
+  const hour = parseInt(h, 10);
+  const ampm = hour >= 12 ? 'PM' : 'AM';
+  return `${hour % 12 || 12}:${m || '00'} ${ampm}`;
+}
+
+/**
+ * Cron-triggered automation (called by netlify/functions/appointment-reminders-cron):
+ *  1. Appointment reminders — texts customers the day before their job.
+ *  2. Post-job follow-up — thanks the customer and asks for a review after a job
+ *     is marked completed.
+ *
+ * Only sends to customers who consented to SMS, and exactly once per job
+ * (tracked via reminder_sent_at / followup_sent_at). Each is gated by a
+ * per-company toggle in jenny_pro_settings.
+ *
+ * Secured with CRON_SECRET when set.
+ */
+export async function GET(request) {
+  const secret = process.env.CRON_SECRET;
+  if (secret) {
+    const auth = request.headers.get('authorization') || '';
+    if (auth !== `Bearer ${secret}`) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  }
+
+  const supabase = getSupabase();
+
+  // Per-company toggles.
+  const settingsMap = new Map();
+  try {
+    const { data: settings } = await supabase
+      .from('jenny_pro_settings')
+      .select('company_id, reminders_enabled, review_followup_enabled');
+    (settings || []).forEach((s) => settingsMap.set(s.company_id, s));
+  } catch {
+    // columns may not exist yet — default everything enabled
+  }
+
+  let remindersSent = 0;
+  let followupsSent = 0;
+
+  // ── 1. Appointment reminders (jobs scheduled for tomorrow) ───────────────
+  const tomorrow = new Date();
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+  const tomorrowStr = tomorrow.toISOString().split('T')[0];
+
+  const { data: upcoming } = await supabase
+    .from('jobs')
+    .select('id, title, scheduled_date, scheduled_time_start, company_id, customer:customers(name, phone, sms_consent), company:companies(name)')
+    .eq('scheduled_date', tomorrowStr)
+    .eq('status', 'scheduled')
+    .is('reminder_sent_at', null)
+    .limit(500);
+
+  for (const job of upcoming || []) {
+    const s = settingsMap.get(job.company_id);
+    if (s && s.reminders_enabled === false) continue;
+    const cust = job.customer;
+    if (!cust?.phone || !cust?.sms_consent) continue;
+
+    const r = await sendSMS({
+      to: cust.phone,
+      body: SMS_TEMPLATES.bookingReminder({
+        customerName: cust.name || 'there',
+        serviceName: job.title || 'appointment',
+        date: fmtDate(job.scheduled_date),
+        time: fmtTime(job.scheduled_time_start),
+        companyName: job.company?.name || 'us',
+      }),
+    });
+    if (r.success) {
+      await supabase.from('jobs').update({ reminder_sent_at: new Date().toISOString() }).eq('id', job.id);
+      remindersSent++;
+    }
+  }
+
+  // ── 2. Post-job follow-up + review (completed 1h–36h ago) ────────────────
+  const windowStart = new Date(Date.now() - 36 * 3600 * 1000).toISOString();
+  const windowEnd = new Date(Date.now() - 1 * 3600 * 1000).toISOString();
+
+  const { data: done } = await supabase
+    .from('jobs')
+    .select('id, title, company_id, customer_id, updated_at, customer:customers(name, phone, sms_consent), company:companies(name, google_review_link, yelp_review_link)')
+    .eq('status', 'completed')
+    .is('followup_sent_at', null)
+    .gte('updated_at', windowStart)
+    .lte('updated_at', windowEnd)
+    .limit(500);
+
+  for (const job of done || []) {
+    const s = settingsMap.get(job.company_id);
+    if (s && s.review_followup_enabled === false) continue;
+    const cust = job.customer;
+    if (!cust?.phone || !cust?.sms_consent) continue;
+
+    const reviewLink = job.company?.google_review_link || job.company?.yelp_review_link || '';
+    const r = await sendSMS({
+      to: cust.phone,
+      body: SMS_TEMPLATES.jobComplete({
+        customerName: cust.name || 'there',
+        companyName: job.company?.name || 'us',
+        reviewLink: reviewLink || undefined,
+      }),
+    });
+    if (r.success) {
+      await supabase.from('jobs').update({ followup_sent_at: new Date().toISOString() }).eq('id', job.id);
+      try {
+        await supabase.from('review_requests').insert({
+          company_id: job.company_id,
+          job_id: job.id,
+          customer_id: job.customer_id,
+          customer_name: cust.name,
+          customer_phone: cust.phone,
+          review_link: reviewLink || null,
+          review_platform: job.company?.google_review_link ? 'google' : (job.company?.yelp_review_link ? 'yelp' : 'none'),
+          status: 'sent',
+          channel: 'sms',
+          sent_at: new Date().toISOString(),
+        });
+      } catch {
+        // review_requests logging is best-effort
+      }
+      followupsSent++;
+    }
+  }
+
+  return NextResponse.json({ success: true, remindersSent, followupsSent });
+}

--- a/src/app/api/jenny-pro/settings/route.js
+++ b/src/app/api/jenny-pro/settings/route.js
@@ -69,6 +69,8 @@ export async function POST(request) {
     operator_language,
     auto_booking,
     business_info,
+    reminders_enabled,
+    review_followup_enabled,
   } = body;
 
   const { data, error } = await supabase
@@ -84,6 +86,8 @@ export async function POST(request) {
         operator_language,
         auto_booking,
         business_info,
+        reminders_enabled,
+        review_followup_enabled,
         updated_at: new Date().toISOString(),
       },
       { onConflict: 'company_id' }

--- a/src/app/dashboard/jenny-pro/page.tsx
+++ b/src/app/dashboard/jenny-pro/page.tsx
@@ -46,6 +46,8 @@ interface JennyProSettings {
   operator_language: 'en' | 'es';
   auto_booking: boolean;
   business_info: string;
+  reminders_enabled: boolean;
+  review_followup_enabled: boolean;
 }
 
 const DEFAULT_SETTINGS: JennyProSettings = {
@@ -57,6 +59,8 @@ const DEFAULT_SETTINGS: JennyProSettings = {
   operator_language: 'en',
   auto_booking: true,
   business_info: '',
+  reminders_enabled: true,
+  review_followup_enabled: true,
 };
 
 export default function JennyProPage() {
@@ -144,6 +148,8 @@ function JennyProDashboard() {
           operator_language: (data.operator_language as JennyProSettings['operator_language']) || 'en',
           auto_booking: data.auto_booking !== false,
           business_info: data.business_info || '',
+          reminders_enabled: data.reminders_enabled !== false,
+          review_followup_enabled: data.review_followup_enabled !== false,
         });
       }
     } catch {
@@ -169,6 +175,8 @@ function JennyProDashboard() {
           operator_language: settings.operator_language,
           auto_booking: settings.auto_booking,
           business_info: settings.business_info,
+          reminders_enabled: settings.reminders_enabled,
+          review_followup_enabled: settings.review_followup_enabled,
           updated_at: new Date().toISOString(),
         },
         { onConflict: 'company_id' }
@@ -527,6 +535,47 @@ function JennyProDashboard() {
                     settings.auto_booking ? 'translate-x-6' : 'translate-x-1'
                   }`}
                 />
+              </button>
+            </div>
+
+            {/* Appointment reminders toggle */}
+            <div className="flex items-start justify-between gap-4 p-4 bg-gray-50 rounded-lg border mb-4">
+              <div>
+                <p className="text-sm font-medium text-gray-900">Appointment reminders</p>
+                <p className="text-xs text-gray-600 mt-0.5">
+                  Text customers a reminder the day before their appointment. (SMS-consented customers only.)
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSettings((s) => ({ ...s, reminders_enabled: !s.reminders_enabled }))}
+                className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
+                  settings.reminders_enabled ? 'bg-blue-600' : 'bg-gray-300'
+                }`}
+                aria-pressed={settings.reminders_enabled}
+              >
+                <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${settings.reminders_enabled ? 'translate-x-6' : 'translate-x-1'}`} />
+              </button>
+            </div>
+
+            {/* Post-job thank-you + review toggle */}
+            <div className="flex items-start justify-between gap-4 p-4 bg-gray-50 rounded-lg border mb-4">
+              <div>
+                <p className="text-sm font-medium text-gray-900">Thank-you &amp; review request</p>
+                <p className="text-xs text-gray-600 mt-0.5">
+                  After a job is marked completed, text the customer a thank-you and your review link.
+                  Add your links under <span className="font-medium">Reviews</span>.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSettings((s) => ({ ...s, review_followup_enabled: !s.review_followup_enabled }))}
+                className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
+                  settings.review_followup_enabled ? 'bg-blue-600' : 'bg-gray-300'
+                }`}
+                aria-pressed={settings.review_followup_enabled}
+              >
+                <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${settings.review_followup_enabled ? 'translate-x-6' : 'translate-x-1'}`} />
               </button>
             </div>
 


### PR DESCRIPTION
## What
Adds two automations you asked for, reusing the existing review-link system:

1. **Appointment reminders** — a text the **day before** a scheduled job.
2. **Post-job thank-you + review request** — a text **after a job is marked completed** (1–36h later), using the company's Google/Yelp review link, logged to `review_requests`.

## How
- Hourly cron `netlify/functions/appointment-reminders-cron` → `GET /api/jenny-pro/reminders` (secured by `CRON_SECRET`).
- Sent **once per job** (`jobs.reminder_sent_at` / `followup_sent_at`) and only to **SMS-consented** customers.
- Each gated by a **per-company toggle** in **Jenny Pro → Settings** (`reminders_enabled` / `review_followup_enabled`, default on).
- Reuses `SMS_TEMPLATES.bookingReminder` / `jobComplete` (previously defined but unused) and the existing review-link config.

## Review system note
The review-link infrastructure already existed (`/api/reviews`, `review_requests` table, Google/Yelp links). The post-job text now actually **sends** automatically on completion (previously the autonomous action only logged a pending entry).

## Changes
- `database/migrations/042_reminders_followups.sql`
- `src/app/api/jenny-pro/reminders/route.js` + `netlify/functions/appointment-reminders-cron.ts` + `netlify.toml` schedule
- Dashboard toggles + settings route
- Docs

## After merge
Run migration `042`, set `CRON_SECRET` in Netlify, and add Google/Yelp review links (Reviews section) so the follow-up includes them.

## Verification
Full suite **537 pass**; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw38sSQpf3TEVPE5AhV7Jt)_