### PR TITLE
Fix broken migrate.yml automation (uuid_generate_v4 → gen_random_uuid)

### DIFF
--- a/supabase/migrations/20260401000000_add_stripe_audit_logs.sql
+++ b/supabase/migrations/20260401000000_add_stripe_audit_logs.sql
@@ -1,6 +1,6 @@
 -- Stripe audit logs — tracks all admin price/product management actions
 CREATE TABLE IF NOT EXISTS stripe_audit_logs (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     admin_user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE SET NULL,
     admin_email VARCHAR(255) NOT NULL,
     action VARCHAR(100) NOT NULL,       -- create_product, update_product, create_price, update_price

--- a/supabase/migrations/20260411000002_add_company_payment_methods.sql
+++ b/supabase/migrations/20260411000002_add_company_payment_methods.sql
@@ -2,7 +2,7 @@
 -- Replaces freeform payment_instructions with structured data
 
 CREATE TABLE IF NOT EXISTS company_payment_methods (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
     method VARCHAR(50) NOT NULL,  -- zelle, venmo, cashapp, paypal, square, stripe, check, cash, other
     handle VARCHAR(255),          -- email, phone, @handle, URL, or payable-to name


### PR DESCRIPTION
## Problem

The **Run Supabase Migrations** workflow (`migrate.yml`) has failed on every run. The workflow YAML itself is fine — the failure happens inside `supabase db push` when it applies a migration:

```
ERROR: function uuid_generate_v4() does not exist (SQLSTATE 42883)
At statement: CREATE TABLE IF NOT EXISTS company_payment_methods (
    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
```

`uuid_generate_v4()` belongs to the `uuid-ossp` extension, which is **not enabled** on the remote database (no migration enables it). Two migrations relied on it while the other seven all use the built-in `gen_random_uuid()` (pgcrypto, available by default in Postgres 13+ / Supabase). The push hits the bad migration and exits 1.

## Fix

Switch the two outliers to `gen_random_uuid()`, matching the rest of the codebase and removing the extension dependency:

- `supabase/migrations/20260411000002_add_company_payment_methods.sql` — the migration actively blocking the push
- `supabase/migrations/20260401000000_add_stripe_audit_logs.sql` — same latent bug, fixed proactively so it can't break a fresh database

`db push` tracks applied migrations by version (not content), so re-touching the already-applied `stripe_audit_logs` file won't trigger a re-run or a history mismatch.

## Verification

- Confirmed via the failing job logs that `uuid_generate_v4()` was the exact cause.
- Grepped all migrations: no remaining `uuid_generate_v4()` / `uuid-ossp` references after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011PsAuKpr3dEaBmbqV9fn2T)_