### PR TITLE
Make RLS-policy migrations idempotent (fix migrate.yml round 2)

### DIFF
--- a/supabase/migrations/20260411000002_add_company_payment_methods.sql
+++ b/supabase/migrations/20260411000002_add_company_payment_methods.sql
@@ -26,6 +26,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_company_payment_methods_unique
 ALTER TABLE company_payment_methods ENABLE ROW LEVEL SECURITY;
 
 -- Users can view payment methods for their own company
+DROP POLICY IF EXISTS "Users can view own company payment methods" ON company_payment_methods;
 CREATE POLICY "Users can view own company payment methods"
     ON company_payment_methods FOR SELECT
     USING (
@@ -35,6 +36,7 @@ CREATE POLICY "Users can view own company payment methods"
     );
 
 -- Owners and admins can manage payment methods
+DROP POLICY IF EXISTS "Owners and admins can insert payment methods" ON company_payment_methods;
 CREATE POLICY "Owners and admins can insert payment methods"
     ON company_payment_methods FOR INSERT
     WITH CHECK (
@@ -44,6 +46,7 @@ CREATE POLICY "Owners and admins can insert payment methods"
         )
     );
 
+DROP POLICY IF EXISTS "Owners and admins can update payment methods" ON company_payment_methods;
 CREATE POLICY "Owners and admins can update payment methods"
     ON company_payment_methods FOR UPDATE
     USING (
@@ -53,6 +56,7 @@ CREATE POLICY "Owners and admins can update payment methods"
         )
     );
 
+DROP POLICY IF EXISTS "Owners and admins can delete payment methods" ON company_payment_methods;
 CREATE POLICY "Owners and admins can delete payment methods"
     ON company_payment_methods FOR DELETE
     USING (
@@ -63,6 +67,7 @@ CREATE POLICY "Owners and admins can delete payment methods"
     );
 
 -- Public read access for invoice/quote display (customers viewing invoices don't have auth)
+DROP POLICY IF EXISTS "Public can view active payment methods" ON company_payment_methods;
 CREATE POLICY "Public can view active payment methods"
     ON company_payment_methods FOR SELECT
     USING (is_active = true);

--- a/supabase/migrations/20260415000000_fix_missing_rls_policies.sql
+++ b/supabase/migrations/20260415000000_fix_missing_rls_policies.sql
@@ -22,6 +22,7 @@
 -- ============================================
 ALTER TABLE recurring_jobs ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Recurring jobs belong to company" ON recurring_jobs;
 CREATE POLICY "Recurring jobs belong to company"
     ON recurring_jobs FOR ALL
     USING (company_id = (SELECT company_id FROM users WHERE id = auth.uid()))
@@ -32,18 +33,22 @@ CREATE POLICY "Recurring jobs belong to company"
 -- ============================================
 ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users see own notifications" ON notifications;
 CREATE POLICY "Users see own notifications"
     ON notifications FOR SELECT
     USING (user_id = auth.uid());
 
+DROP POLICY IF EXISTS "System inserts notifications for company users" ON notifications;
 CREATE POLICY "System inserts notifications for company users"
     ON notifications FOR INSERT
     WITH CHECK (company_id = (SELECT company_id FROM users WHERE id = auth.uid()));
 
+DROP POLICY IF EXISTS "Users update own notifications" ON notifications;
 CREATE POLICY "Users update own notifications"
     ON notifications FOR UPDATE
     USING (user_id = auth.uid());
 
+DROP POLICY IF EXISTS "Users delete own notifications" ON notifications;
 CREATE POLICY "Users delete own notifications"
     ON notifications FOR DELETE
     USING (user_id = auth.uid());
@@ -53,6 +58,7 @@ CREATE POLICY "Users delete own notifications"
 -- ============================================
 ALTER TABLE google_calendar_connections ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users manage own calendar connection" ON google_calendar_connections;
 CREATE POLICY "Users manage own calendar connection"
     ON google_calendar_connections FOR ALL
     USING (user_id = auth.uid())
@@ -63,6 +69,7 @@ CREATE POLICY "Users manage own calendar connection"
 -- ============================================
 ALTER TABLE payment_plans ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Payment plans belong to company" ON payment_plans;
 CREATE POLICY "Payment plans belong to company"
     ON payment_plans FOR ALL
     USING (company_id = (SELECT company_id FROM users WHERE id = auth.uid()))
@@ -73,6 +80,7 @@ CREATE POLICY "Payment plans belong to company"
 -- ============================================
 ALTER TABLE payment_plan_installments ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Installments belong to company payment plans" ON payment_plan_installments;
 CREATE POLICY "Installments belong to company payment plans"
     ON payment_plan_installments FOR ALL
     USING (
@@ -93,6 +101,7 @@ CREATE POLICY "Installments belong to company payment plans"
 -- ============================================
 ALTER TABLE webhooks ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Webhooks belong to company" ON webhooks;
 CREATE POLICY "Webhooks belong to company"
     ON webhooks FOR ALL
     USING (company_id = (SELECT company_id FROM users WHERE id = auth.uid()))
@@ -103,6 +112,7 @@ CREATE POLICY "Webhooks belong to company"
 -- ============================================
 ALTER TABLE webhook_logs ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Webhook logs belong to company webhooks" ON webhook_logs;
 CREATE POLICY "Webhook logs belong to company webhooks"
     ON webhook_logs FOR ALL
     USING (
@@ -126,10 +136,12 @@ CREATE POLICY "Webhook logs belong to company webhooks"
 --    Add a read policy so authenticated users can see their own company,
 --    and an update policy for owners/admins.
 -- ============================================
+DROP POLICY IF EXISTS "Users can view their own company" ON companies;
 CREATE POLICY "Users can view their own company"
     ON companies FOR SELECT
     USING (id IN (SELECT company_id FROM users WHERE id = auth.uid()));
 
+DROP POLICY IF EXISTS "Owners and admins can update their company" ON companies;
 CREATE POLICY "Owners and admins can update their company"
     ON companies FOR UPDATE
     USING (


### PR DESCRIPTION
## Context

Follow-up to #628. That PR fixed the `uuid_generate_v4()` error, and the migrate workflow re-ran on the merge to `main` — it got **further** but still failed, this time on a non-idempotent policy:

```
NOTICE: relation "company_payment_methods" already exists, skipping
ERROR: policy "Users can view own company payment methods" ... already exists (SQLSTATE 42710)
```

## Root cause

The remote database already contains these tables/policies, but they are **not recorded in Supabase's migration history**, so `supabase db push` replays the migrations on every run. `CREATE TABLE` / `CREATE INDEX` survive because they use `IF NOT EXISTS`; bare `CREATE POLICY` has no such guard and aborts the run.

## Fix

Add `DROP POLICY IF EXISTS "<name>" ON <table>;` before every `CREATE POLICY` in the two older migrations:

- `supabase/migrations/20260411000002_add_company_payment_methods.sql` (5 policies)
- `supabase/migrations/20260415000000_fix_missing_rls_policies.sql` (12 policies)

This is exactly the idempotent pattern the newer `20260620*` migrations already use. The push now succeeds whether the policies pre-exist (current drifted prod) or not (a fresh database).

## Scope check

I reviewed all remaining pending migrations:
- `20260416000000_cascade_delete_company_fks.sql` — already self-idempotent (its `DO` block only rewrites FKs still set to NO ACTION/RESTRICT, so a re-run is a no-op).
- `20260518…`, `20260620…`, `20260621…` — all use `ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` / already-guarded `DROP POLICY IF EXISTS`.

No other changes needed.

## Verification

- Confirmed the new failure via the workflow run that fired on the #628 merge.
- Verified each file now has a matching `DROP POLICY IF EXISTS` for every `CREATE POLICY` (5/5 and 12/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011PsAuKpr3dEaBmbqV9fn2T)_