### PR TITLE
ci: auto back-sync main → sandbox (stop the QA branch drifting)

### DIFF
--- a/.github/workflows/backsync-sandbox.yml
+++ b/.github/workflows/backsync-sandbox.yml
@@ -1,0 +1,68 @@
+name: Back-sync main → sandbox
+
+# Keeps the long-lived `sandbox` branch current with `main` automatically, so
+# the QA sandbox never silently falls behind production after a hotfix or a
+# merged promotion. This is the DOWN half of the promote loop:
+#   sandbox -> main   ... promotion (see promote-sandbox.yml)
+#   main -> sandbox   ... this workflow (back-sync)
+#
+# It preserves any unpromoted work sitting on `sandbox`: it MERGES main into
+# sandbox rather than overwriting it. If the merge conflicts, the job fails
+# loudly so a human resolves it instead of anything being forced.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Prevent overlapping runs from racing on the sandbox branch.
+concurrency:
+  group: backsync-sandbox
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  backsync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Back-sync main into sandbox
+        run: |
+          set -euo pipefail
+
+          # If the sandbox branch doesn't exist (e.g. it was deleted after a
+          # promotion merged), recreate it from main and stop.
+          if ! git ls-remote --exit-code --heads origin sandbox >/dev/null 2>&1; then
+            echo "sandbox branch missing — creating it from main."
+            git push origin origin/main:refs/heads/sandbox
+            exit 0
+          fi
+
+          git checkout -B sandbox origin/sandbox
+
+          # If sandbox already contains every commit on main, there is nothing
+          # to do (covers the common 'sandbox == main' and 'sandbox ahead' cases).
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "sandbox already up to date with main — nothing to do."
+            exit 0
+          fi
+
+          # Merge main into sandbox, preserving any unpromoted sandbox work.
+          if git merge --no-edit -m "chore: back-sync main into sandbox" origin/main; then
+            git push origin sandbox
+            echo "sandbox synced with main."
+          else
+            echo "::error::Merge conflict back-syncing main into sandbox. Resolve manually (git merge origin/main on the sandbox branch)."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Completes the sandbox promote loop so the QA sandbox never silently falls behind production again — the friction we hit where the sandbox was running stale code and a fix couldn't reach it.

You already have **`promote-sandbox.yml`** (the `sandbox → main` direction — auto-opens a promotion PR when you push to `sandbox`). This adds the missing **`main → sandbox`** direction.

### What it does
On every push to `main` (a merged promotion, or a hotfix straight to prod), it:
- **Merges `main` into `sandbox`** — preserving any unpromoted work sitting on `sandbox` (it merges, never force-overwrites).
- **Recreates `sandbox` from `main`** if the branch was deleted (the exact failure that broke the sandbox deploy — the branch had been auto-deleted after a prior promotion).
- **No-ops** when `sandbox` already contains `main`.
- **Fails loudly on a merge conflict** instead of forcing anything, so a human resolves it.

Uses the default `GITHUB_TOKEN` with `contents: write`, a `concurrency` group so runs don't race on the branch, and `workflow_dispatch` for manual runs.

### Why
This removes the manual "remember to update the sandbox" step. Combined with turning off **auto-delete head branches** (repo Setting → General), the sandbox stays current and present with zero manual upkeep:

```
build on sandbox ─▶ test ─▶ promote-sandbox.yml opens PR ─▶ merge ─▶ prod
        ▲                                                              │
        └──────────────── backsync-sandbox.yml (this) ◀───────────────┘
```

## Test plan
- YAML validated (parses; triggers = push + workflow_dispatch; one `backsync` job).
- After merge, the first push to `main` will exercise it — expected to no-op or fast-forward `sandbox` (it was just realigned to `main`).
- Does not touch app code or tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XmQz5STD2sDFzYgD7LDPk

---
_Generated by [Claude Code](https://claude.ai/code/session_013XmQz5STD2sDFzYgD7LDPk)_