### PR TITLE
test(e2e): add Cypress E2E suite + CI to automate the QA matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,66 @@
+name: E2E (Cypress)
+
+on:
+  push:
+    branches: [main, sandbox]
+  pull_request:
+    branches: [main, sandbox]
+  workflow_dispatch:
+
+jobs:
+  # Public / unauthenticated E2E — builds and serves the app locally, no secrets
+  # needed. This is the always-on regression gate.
+  e2e-public:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Cypress run (public specs against a local build)
+        uses: cypress-io/github-action@v6
+        with:
+          build: npm run build
+          start: npm start
+          wait-on: 'http://localhost:3000'
+          wait-on-timeout: 120
+          spec: cypress/e2e/public-pages.cy.js,cypress/e2e/public-extended.cy.js,cypress/e2e/booking-demo.cy.js
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder
+
+  # Authenticated E2E — runs against the deployed sandbox with a real login.
+  # Skips automatically until the E2E_* secrets are configured, so it never
+  # breaks CI before you wire them up.
+  e2e-authenticated:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Check for E2E credentials
+        id: guard
+        env:
+          E2E_EMAIL: ${{ secrets.E2E_EMAIL }}
+        run: |
+          if [ -z "$E2E_EMAIL" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::E2E_EMAIL secret not set — skipping authenticated E2E. Add E2E_EMAIL, E2E_PASSWORD, and E2E_BASE_URL repo secrets to enable."
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Cypress run (authenticated, against the sandbox)
+        if: steps.guard.outputs.run == 'true'
+        uses: cypress-io/github-action@v6
+        with:
+          install: true
+          spec: cypress/e2e/authenticated-flows.cy.js,cypress/e2e/customer-portal.cy.js
+          config: baseUrl=${{ secrets.E2E_BASE_URL }}
+        env:
+          CYPRESS_E2E_EMAIL: ${{ secrets.E2E_EMAIL }}
+          CYPRESS_E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}

--- a/cypress/e2e/authenticated-flows.cy.js
+++ b/cypress/e2e/authenticated-flows.cy.js
@@ -24,19 +24,33 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
     cy.get('body').should('be.visible');
   });
 
-  it('TC-CUST-01: creates a customer and sees it in the list', () => {
-    const name = `QA Test Customer ${Date.now()}`;
+  it('TC-CUST-01: creates a uniquely-namespaced customer, sees it, then deletes it (self-cleanup)', () => {
+    // Unique per run so parallel/repeat CI runs never collide, and any rare
+    // leftover is trivially findable/purgeable by the "e2e-" prefix.
+    const uid = `e2e-${Date.now()}-${Cypress._.random(1e9)}`;
+    const name = `E2E Test ${uid}`;
+    const email = `${uid}@example.com`;
+
     cy.visit('/dashboard/customers');
     // Open the add-customer modal (button reads "Add Customer" / "Add Your First Customer").
     cy.contains('button', /add (your first )?customer/i, { timeout: 20000 }).first().click();
     cy.contains(/Add New Customer/i, { timeout: 10000 }).should('be.visible');
-    // Fill the minimum: a name and a phone (the app says name + phone is enough).
     cy.get('.fixed, [role="dialog"], form').last().within(() => {
       cy.get('input[type="text"]').first().clear().type(name);
+      cy.get('input[type="email"]').first().clear().type(email);
       cy.get('input[type="tel"]').first().clear().type('5551234567');
       cy.contains('button', /save|add|create/i).click();
     });
     cy.contains(name, { timeout: 20000 }).should('exist');
+
+    // Self-cleanup: the app deletes via a row "Delete" button guarded by
+    // window.confirm. Isolate the row via search, accept the confirm, delete,
+    // and assert it's gone — so the test leaves no data behind.
+    cy.on('window:confirm', () => true);
+    cy.get('input[placeholder*="Search customers"]', { timeout: 10000 }).clear().type(name);
+    cy.contains(name).should('be.visible');
+    cy.contains('button', /^\s*delete\s*$/i).click();
+    cy.contains(name).should('not.exist');
   });
 
   it('TC-JOB-01: opens the jobs page', () => {

--- a/cypress/e2e/authenticated-flows.cy.js
+++ b/cypress/e2e/authenticated-flows.cy.js
@@ -1,0 +1,55 @@
+/**
+ * Authenticated E2E — runs against a deployed environment (the sandbox) with a
+ * real beta-tester login. These need credentials, so the whole suite SKIPS
+ * unless CYPRESS_E2E_EMAIL / CYPRESS_E2E_PASSWORD are provided. Point Cypress at
+ * the sandbox:
+ *
+ *   CYPRESS_E2E_EMAIL=... CYPRESS_E2E_PASSWORD=... \
+ *     npx cypress run --spec cypress/e2e/authenticated-flows.cy.js \
+ *     --config baseUrl=https://sandbox--lively-yeot-c640cd.netlify.app
+ *
+ * Start small (login + dashboard + create customer); expand once green in CI.
+ */
+
+const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
+
+(hasCreds ? describe : describe.skip)('Authenticated flows', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('TC-AUTH-03: lands on the dashboard after login', () => {
+    cy.visit('/dashboard');
+    cy.location('pathname', { timeout: 25000 }).should('include', '/dashboard');
+    cy.get('body').should('be.visible');
+  });
+
+  it('TC-CUST-01: creates a customer and sees it in the list', () => {
+    const name = `QA Test Customer ${Date.now()}`;
+    cy.visit('/dashboard/customers');
+    // Open the add-customer modal (button reads "Add Customer" / "Add Your First Customer").
+    cy.contains('button', /add (your first )?customer/i, { timeout: 20000 }).first().click();
+    cy.contains(/Add New Customer/i, { timeout: 10000 }).should('be.visible');
+    // Fill the minimum: a name and a phone (the app says name + phone is enough).
+    cy.get('.fixed, [role="dialog"], form').last().within(() => {
+      cy.get('input[type="text"]').first().clear().type(name);
+      cy.get('input[type="tel"]').first().clear().type('5551234567');
+      cy.contains('button', /save|add|create/i).click();
+    });
+    cy.contains(name, { timeout: 20000 }).should('exist');
+  });
+
+  it('TC-JOB-01: opens the jobs page', () => {
+    cy.visit('/dashboard/jobs');
+    cy.location('pathname').should('include', '/dashboard/jobs');
+    cy.get('body').should('be.visible');
+  });
+
+  it('TC-SEC-06: protected dashboard route requires auth (logged-out is redirected)', () => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+    cy.visit('/dashboard/customers', { failOnStatusCode: false });
+    // Either redirected to login, or a login form is shown — never the customer data.
+    cy.location('pathname', { timeout: 15000 }).should('match', /\/auth\/login|\/login/);
+  });
+});

--- a/cypress/e2e/public-extended.cy.js
+++ b/cypress/e2e/public-extended.cy.js
@@ -1,0 +1,73 @@
+/**
+ * Extended public / unauthenticated E2E — broadens public-pages.cy.js with the
+ * free tools, self-contained demo pages, auth entry points, graceful handling
+ * of invalid public links, and client-side form validation. No backend data or
+ * secrets required, so this runs in CI against a local build.
+ *
+ *   npx cypress run --spec cypress/e2e/public-extended.cy.js
+ */
+
+describe('Auth entry pages render', () => {
+  for (const path of ['/auth/login', '/auth/signup', '/auth/forgot-password']) {
+    it(`${path} renders a form`, () => {
+      cy.visit(path);
+      cy.get('form').should('exist');
+      cy.get('input').its('length').should('be.gte', 1);
+    });
+  }
+});
+
+describe('Free tools render and are interactive', () => {
+  const tools = ['/tools', '/tools/calculator', '/tools/classification', '/tools/checklist', '/tools/final-wage'];
+  for (const path of tools) {
+    it(`${path} renders`, () => {
+      cy.visit(path);
+      cy.get('body').should('be.visible');
+      cy.get('body').invoke('text').its('length').should('be.gt', 50);
+    });
+  }
+});
+
+describe('Self-contained demo pages render (no backend)', () => {
+  const demos = ['/demo/booking', '/demo/dashboard', '/demo/invoicing', '/demo/estimator', '/demo/scheduling', '/demo/reviews'];
+  for (const path of demos) {
+    it(`${path} renders`, () => {
+      cy.visit(path);
+      cy.get('body').should('be.visible');
+      cy.get('body').invoke('text').its('length').should('be.gt', 50);
+    });
+  }
+});
+
+describe('Comparison / SEO pages render', () => {
+  for (const path of ['/compare', '/compare/jobber', '/compare/housecall-pro']) {
+    it(`${path} renders`, () => {
+      cy.visit(path);
+      cy.get('body').should('be.visible');
+    });
+  }
+});
+
+describe('Graceful handling of invalid public links (TC-NEG-05)', () => {
+  it('an invalid quote id does not crash the page', () => {
+    cy.visit('/quote/zzz-does-not-exist-999', { failOnStatusCode: false });
+    cy.get('body').should('be.visible');
+    // Must show *something* meaningful, not a blank white screen.
+    cy.get('body').invoke('text').its('length').should('be.gt', 20);
+  });
+
+  it('an invalid invoice id does not crash the page', () => {
+    cy.visit('/invoice/zzz-does-not-exist-999', { failOnStatusCode: false });
+    cy.get('body').should('be.visible');
+    cy.get('body').invoke('text').its('length').should('be.gt', 20);
+  });
+});
+
+describe('Client-side form validation (TC-NEG-01)', () => {
+  it('signup does not navigate away on empty submit', () => {
+    cy.visit('/auth/signup');
+    cy.get('form').first().find('button[type="submit"]').click({ force: true });
+    // Native required-field validation should keep us on the signup page.
+    cy.location('pathname').should('include', '/auth/signup');
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,19 @@
+// Custom Cypress commands.
+
+// Log in via the real auth form, cached across tests with cy.session.
+// Credentials come from Cypress env (CYPRESS_E2E_EMAIL / CYPRESS_E2E_PASSWORD).
+Cypress.Commands.add('login', () => {
+  const email = Cypress.env('E2E_EMAIL');
+  const password = Cypress.env('E2E_PASSWORD');
+  if (!email || !password) {
+    throw new Error('cy.login() requires CYPRESS_E2E_EMAIL and CYPRESS_E2E_PASSWORD');
+  }
+  cy.session([email], () => {
+    cy.visit('/auth/login');
+    cy.get('input[name="email"]').clear().type(email);
+    cy.get('input[name="password"]').clear().type(password, { log: false });
+    cy.get('input[name="password"]').parents('form').first().find('button[type="submit"]').click();
+    // Successful login lands somewhere under /dashboard.
+    cy.location('pathname', { timeout: 25000 }).should('include', '/dashboard');
+  });
+});

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,6 +1,8 @@
 // Global Cypress support file
 // Add custom commands and global before/after hooks here
 
+import './commands';
+
 Cypress.on('uncaught:exception', () => {
   // Prevent Cypress from failing tests on uncaught app exceptions
   // (e.g. Next.js hydration errors in dev mode)

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -1,0 +1,58 @@
+# End-to-End Testing (Cypress)
+
+Automated browser tests that exercise real user flows, so a chunk of the manual
+QA matrix runs on every push instead of by hand.
+
+## What runs where
+
+| Suite | File(s) | Needs secrets? | When it runs |
+|-------|---------|----------------|--------------|
+| **Public / unauthenticated** | `cypress/e2e/public-pages.cy.js`, `public-extended.cy.js`, `booking-demo.cy.js` | No | Every push/PR, against a local build |
+| **Authenticated flows** | `cypress/e2e/authenticated-flows.cy.js`, `customer-portal.cy.js` | Yes | When `E2E_*` secrets are set, against the sandbox |
+
+The public suite covers: marketing/tools/demo pages render with no crash, auth
+pages render, invalid public links degrade gracefully (TC-NEG-05), and signup
+client-validation holds (TC-NEG-01).
+
+The authenticated suite covers (and will grow): login + dashboard (TC-AUTH-03),
+create customer (TC-CUST-01), jobs page (TC-JOB-01), and logged-out redirect
+(TC-SEC-06).
+
+## Enabling the authenticated suite
+
+The authenticated job **skips automatically** until you add these **repository
+secrets** (GitHub → repo **Settings → Secrets and variables → Actions**):
+
+| Secret | Value |
+|--------|-------|
+| `E2E_BASE_URL` | `https://sandbox--lively-yeot-c640cd.netlify.app` |
+| `E2E_EMAIL` | A sandbox beta-tester login email (NOT a real customer) |
+| `E2E_PASSWORD` | That account's password |
+
+> Use a **dedicated QA account on the sandbox**, never production credentials.
+> The tests create throwaway data (e.g. "QA Test Customer <timestamp>") on the
+> sandbox's isolated database.
+
+Once set, the `e2e-authenticated` job runs on every push/PR. You can also run it
+on demand from the **Actions** tab → **E2E (Cypress)** → **Run workflow**.
+
+## Running locally
+
+```bash
+# Public suite (no secrets) — against a running dev server
+npm run dev
+npx cypress run --spec "cypress/e2e/public-pages.cy.js,cypress/e2e/public-extended.cy.js"
+
+# Authenticated suite — against the sandbox
+CYPRESS_E2E_EMAIL=you@example.com CYPRESS_E2E_PASSWORD=secret \
+  npx cypress run --spec cypress/e2e/authenticated-flows.cy.js \
+  --config baseUrl=https://sandbox--lively-yeot-c640cd.netlify.app
+```
+
+## Adding more coverage
+
+The authenticated specs are intentionally a small, reliable starting set. Grow
+them by adding `it(...)` blocks mapped to the case IDs in
+`docs/QA_TEST_CASES.md` — quote → invoice → pay (Stripe test card
+`4242 4242 4242 4242`), worker flows, multi-tenant isolation, etc. Each green
+spec is one fewer case the human tester has to repeat every release.


### PR DESCRIPTION
## Summary

Turns part of the manual QA matrix into automated tests that run on every push — so each release re-checks the core flows for free and your human tester can focus on judgment-heavy work.

### Public / unauthenticated suite (always-on, no secrets)
`cypress/e2e/public-extended.cy.js` broadens coverage to auth pages, free tools, self-contained demo pages, and comparison pages, plus two functional checks:
- **TC-NEG-05** — invalid public links (`/quote/bad-id`, `/invoice/bad-id`) degrade gracefully, no blank/crash.
- **TC-NEG-01** — signup client-validation holds on empty submit.

The underlying behavior here was validated with a headless-Chromium run before committing.

### Authenticated suite (gated, runs against the sandbox)
`cypress/e2e/authenticated-flows.cy.js` covers login + dashboard (**TC-AUTH-03**), create customer (**TC-CUST-01**), jobs page (**TC-JOB-01**), and logged-out redirect (**TC-SEC-06**). It **skips automatically** unless E2E credentials are set, so it never breaks CI before secrets are wired. `cy.login()` (session-cached) lives in `cypress/support/commands.js`.

### CI (`.github/workflows/e2e.yml`)
- **`e2e-public`** — builds + serves the app locally and runs the public specs. No secrets; runs on every push/PR.
- **`e2e-authenticated`** — runs the authenticated specs against the sandbox. Guarded: warns and skips until `E2E_BASE_URL` / `E2E_EMAIL` / `E2E_PASSWORD` repo secrets exist; activates automatically once they do.

### Docs
`docs/E2E_TESTING.md` — what runs where, how to wire the secrets (use a dedicated sandbox QA account, never production), and how to grow the suite.

## Notes / test plan
- Cypress couldn't be executed in the authoring sandbox (its binary download is network-blocked there), so the **specs are validated on the first CI run** — where Cypress installs normally. I'm watching this PR and will fix anything CI surfaces.
- No app code changed; unit tests / build are unaffected.

## To fully enable
Add three repo secrets (Settings → Secrets and variables → Actions): `E2E_BASE_URL` = the sandbox URL, `E2E_EMAIL` / `E2E_PASSWORD` = a sandbox beta-tester login. Until then the authenticated job skips cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XmQz5STD2sDFzYgD7LDPk

---
_Generated by [Claude Code](https://claude.ai/code/session_013XmQz5STD2sDFzYgD7LDPk)_