### PR TITLE
db: grant beta access to QA tester (qat56217@gmail.com)

### DIFF
--- a/database/grant_beta_testers.sql
+++ b/database/grant_beta_testers.sql
@@ -14,7 +14,9 @@
 -- each email to its company via the users table (and also match the company's
 -- own email column, in case the owner email lives there).
 --
--- Idempotent: safe to re-run. Run in the Supabase SQL Editor (Prod project).
+-- Idempotent: safe to re-run. Run in the Supabase SQL Editor of the project
+-- you are granting access on — the SANDBOX project for QA testers, the Prod
+-- project for real beta testers. The account must have signed up first.
 
 UPDATE companies c
 SET
@@ -27,7 +29,8 @@ WHERE
   lower(c.email) IN (
     'missmv@gmail.com',
     'justinkirksey@hotmail.com',
-    'sandbox-test@tooltimepro.com'
+    'sandbox-test@tooltimepro.com',
+    'qat56217@gmail.com'
   )
   OR c.id IN (
     SELECT u.company_id
@@ -35,7 +38,8 @@ WHERE
     WHERE lower(u.email) IN (
       'missmv@gmail.com',
       'justinkirksey@hotmail.com',
-      'sandbox-test@tooltimepro.com'
+      'sandbox-test@tooltimepro.com',
+      'qat56217@gmail.com'
     )
   );
 


### PR DESCRIPTION
## Summary

Adds the QA tester's signup email (`qat56217@gmail.com`) to `database/grant_beta_testers.sql` so running the script unlocks every feature/add-on for their account during the pre-Beta test run (`is_beta_tester = true`, plan `elite`, trial extended a year — same as the existing entries).

Also corrects the header comment: the script runs against the **sandbox** Supabase project for QA testers (prod for real beta testers), and the account must sign up first (the script resolves the email → company).

## Note
This SQL is run manually in the Supabase SQL Editor; it isn't executed by CI or deploy. Merging just version-controls the canonical grant list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XmQz5STD2sDFzYgD7LDPk

---
_Generated by [Claude Code](https://claude.ai/code/session_013XmQz5STD2sDFzYgD7LDPk)_