### PR TITLE
fix: blank /worker/login and /portal/login (trailingSlash mismatch)

### DIFF
--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -33,7 +33,7 @@ function PortalLayoutInner({ children }: { children: React.ReactNode }) {
     const token = urlToken || storedToken;
 
     if (!token) {
-      if (pathname !== '/portal/login') {
+      if (pathname !== '/portal/login' && pathname !== '/portal/login/') {
         router.push('/portal/login');
       }
       setLoading(false);
@@ -63,7 +63,7 @@ function PortalLayoutInner({ children }: { children: React.ReactNode }) {
       })
       .catch(() => {
         localStorage.removeItem('portal_token');
-        if (pathname !== '/portal/login') {
+        if (pathname !== '/portal/login' && pathname !== '/portal/login/') {
           router.push('/portal/login');
         }
         setLoading(false);
@@ -90,7 +90,9 @@ function PortalLayoutInner({ children }: { children: React.ReactNode }) {
     router.push('/portal/login');
   };
 
-  if (pathname === '/portal/login') {
+  // next.config has trailingSlash:true, so the path arrives as '/portal/login/'.
+  // Match both, else this falls through and renders null (a blank page) on login.
+  if (pathname === '/portal/login' || pathname === '/portal/login/') {
     return <>{children}</>;
   }
 

--- a/src/app/worker/layout.tsx
+++ b/src/app/worker/layout.tsx
@@ -33,7 +33,7 @@ export default function WorkerLayout({ children }: { children: React.ReactNode }
       const { data: { user: authUser } } = await supabase.auth.getUser()
 
       if (!authUser) {
-        if (pathname !== '/worker/login') {
+        if (pathname !== '/worker/login' && pathname !== '/worker/login/') {
           router.push('/worker/login')
         }
         setLoading(false)
@@ -75,7 +75,7 @@ export default function WorkerLayout({ children }: { children: React.ReactNode }
 
   const { showWarning, secondsRemaining, resetTimeout } = useSessionTimeout({
     onTimeout: handleSignOut,
-    enabled: !!user && pathname !== '/worker/login',
+    enabled: !!user && pathname !== '/worker/login' && pathname !== '/worker/login/',
   })
 
   // Helper to get company name (handles both object and array from Supabase)
@@ -85,8 +85,10 @@ export default function WorkerLayout({ children }: { children: React.ReactNode }
     return company.name || 'ToolTime Pro'
   }
 
-  // Don't show layout on login page
-  if (pathname === '/worker/login') {
+  // Don't show layout on login page. next.config has trailingSlash:true, so the
+  // path arrives as '/worker/login/' — match both, otherwise this falls through
+  // to the auth gate below and renders null (a blank page) on the login route.
+  if (pathname === '/worker/login' || pathname === '/worker/login/') {
     return <>{children}</>
   }
 


### PR DESCRIPTION
## Summary

**Real production bug** found during QA: the **worker app login** (`/worker/login`) and **customer portal login** (`/portal/login`) render **completely blank**.

### Root cause
`next.config.js` sets **`trailingSlash: true`**, so those routes resolve to `/worker/login/` and `/portal/login/` (with a trailing slash). But both nested layouts guard the login page with an **exact** match:

```js
if (pathname === '/worker/login') return <>{children}</>   // login form
...
if (!user) return null                                     // ← blank
```

With the trailing slash the check fails, so the layout skips the login branch, falls through to its authenticated-only path, finds no logged-in user, and `return null` → a blank white page. This affects **production**, not just the sandbox.

### Fix
Make the login-route checks tolerate the trailing slash (match both `/x/login` and `/x/login/`) in:
- the early-return guard that renders the login page,
- the `useEffect` redirect-to-login guard,
- (worker) the session-timeout `enabled` flag.

No other layouts use this pattern (checked).

## Verification
Rendered both routes in a headless browser before/after:
- **Before:** blank page, no form (0 visible text).
- **After:** `/worker/login` shows the email+password form; `/portal/login` shows the Customer Portal email form.

`npm run build` ✓ · `npm test` ✓ (543 passing).

## Impact
Unblocks the QA tester's worker-app (TC-WORK-*) and customer-portal (TC-PORTAL-*) cases — and fixes worker/customer login in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XmQz5STD2sDFzYgD7LDPk

---
_Generated by [Claude Code](https://claude.ai/code/session_013XmQz5STD2sDFzYgD7LDPk)_