### PR TITLE
fix(portal): unblock customer portal login + magic-link email

### DIFF
--- a/database/migrations/044_fix_missing_grants.sql
+++ b/database/migrations/044_fix_missing_grants.sql
@@ -1,0 +1,34 @@
+-- ============================================================
+-- 044: Fix missing role GRANTs on public schema
+-- ============================================================
+-- WHY: Migration 043 created ~22 tables (customer_sessions, portal_*,
+-- reschedule_requests, etc.) with plain CREATE TABLE + RLS, but no GRANTs.
+-- On a normal Supabase project, tables created in the dashboard are
+-- auto-granted to anon/authenticated/service_role via ALTER DEFAULT
+-- PRIVILEGES. Tables created by this raw migration were NOT, so even the
+-- service_role key (which bypasses RLS) got "permission denied for table"
+-- because it lacked the base table-level privilege. This restores the
+-- standard Supabase grant set and default privileges so it never recurs.
+-- Idempotent — safe to run repeatedly.
+-- ============================================================
+
+BEGIN;
+
+-- Schema usage
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+
+-- Privileges on everything that already exists
+GRANT ALL ON ALL TABLES    IN SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO anon, authenticated, service_role;
+
+-- Ensure anything created in the future is auto-granted too
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES    TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO anon, authenticated, service_role;
+
+COMMIT;
+
+-- NOTE: RLS remains enabled on all these tables, so anon/authenticated are
+-- still row-filtered by their policies. These grants only restore the
+-- table-level access layer that Supabase normally provisions automatically.

--- a/src/app/api/portal/route.ts
+++ b/src/app/api/portal/route.ts
@@ -562,8 +562,13 @@ export async function POST(request: NextRequest) {
       expires_at: expiresAt.toISOString(),
     });
 
-    // Build portal URL with RAW token (only the customer receives this)
-    const portalUrl = `${process.env.NEXT_PUBLIC_SITE_URL || 'https://app.tooltimepro.com'}/portal?token=${rawToken}`;
+    // Build portal URL with RAW token (only the customer receives this).
+    // Use APP_URL first: it's the per-deploy canonical URL (sandbox on the
+    // sandbox branch, prod on prod), so the magic link always lands on the
+    // same environment whose DB holds this session token. SITE_URL points at
+    // the marketing/prod host and would send sandbox links to production.
+    const portalBase = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://app.tooltimepro.com';
+    const portalUrl = `${portalBase}/portal?token=${rawToken}`;
 
     // Get company name for email
     const { data: company } = await supabase


### PR DESCRIPTION
## Summary

Fixes two bugs that completely blocked the **customer portal** (login + magic-link email), surfaced during pre-Beta QA on the sandbox.

### 1. Missing DB grants → `permission denied for table customer_sessions`
Migration `043` created ~22 tables (`customer_sessions`, `portal_*`, `reschedule_requests`, …) with `CREATE TABLE` + RLS but **no `GRANT`s**. On a normal Supabase project the dashboard auto-grants new tables to `anon`/`authenticated`/`service_role` via default privileges; a raw migration does not. As a result even the `service_role` key (which bypasses RLS) hit `permission denied for table` before RLS was evaluated — so every portal query failed despite the token, hash, key, and row all being correct.

**Fix:** `database/migrations/044_fix_missing_grants.sql` restores the standard Supabase grant set + default privileges. Idempotent. RLS stays enabled, so nothing is exposed.

### 2. Magic-link email pointed at production
The portal login email built its link from `NEXT_PUBLIC_SITE_URL` (the marketing/prod host). On the sandbox that emailed testers a **production** link, but the session token lives in the **sandbox** DB — so the link always failed with "Session expired or invalid."

**Fix:** prefer `NEXT_PUBLIC_APP_URL` (the per-deploy canonical app URL, already used for every other email link) so the magic link always lands on the same environment that created the token.

## Diagnosis notes
Root causes were pinned via temporary, gated debug instrumentation on the sandbox branch (now removed), not guesswork:
- Confirmed the server saw the correct sandbox DB, the correct `service_role` key (decoded `role` claim), and the correct token hash — yet the query returned `permission denied`, which isolated the missing grant.
- Confirmed Resend sending works and the `tooltimepro.com` domain is verified (a test send returned a real message id) — which isolated the problem to the link URL, not deliverability.

## Changes
- `database/migrations/044_fix_missing_grants.sql` — new, grants public-schema privileges to the three Supabase roles.
- `src/app/api/portal/route.ts` — magic-link URL uses `NEXT_PUBLIC_APP_URL` first.

## Testing
- `044` was run live against the sandbox Supabase project; the portal profile endpoint now returns the customer/company JSON instead of the permission error.
- Verified the worker welcome email path (`sendTeamMemberWelcomeEmail`) already uses the correct per-context URL — no change needed there.
- No type errors in `portal/route.ts` (pre-existing test-file matcher noise is unrelated and excluded from the Next build).

## Post-merge
Back-sync (`main` → `sandbox`) keeps the sandbox in step. `044` should be applied to the **production** Supabase project as well if any of the `043` tables are missing grants there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013XmQz5STD2sDFzYgD7LDPk)_