### PR TITLE
fix(invoices): force dynamic rendering on public invoice page (fixes …

### DIFF
--- a/src/app/invoice/[id]/page.tsx
+++ b/src/app/invoice/[id]/page.tsx
@@ -1,8 +1,9 @@
 import InvoiceViewClient from './InvoiceViewClient';
 
-export function generateStaticParams() {
-  return [];
-}
+// Force dynamic rendering — the root layout uses cookies() for i18n,
+// which is incompatible with ISR/SSG on Netlify and throws a
+// static-to-dynamic 500 on the public invoice link (matches the quote page).
+export const dynamic = 'force-dynamic';
 
 export default function InvoicePage({ params }: { params: { id: string } }) {
   return <InvoiceViewClient params={params} />;


### PR DESCRIPTION
…500)

The public invoice link returned a hard 500 ("Page changed from static to dynamic at runtime, reason: cookies"). The page declared generateStaticParams() returning [], marking it for static generation, but the root layout reads cookies() for i18n locale — which forces dynamic rendering. On Netlify that static-vs-dynamic conflict throws a 500 before any data is fetched, so the customer never sees the invoice.

The quote page already solved this exact issue with `export const dynamic = 'force-dynamic'`; apply the same to the invoice page and drop the static-params declaration.

Reproduced locally (HTTP 500 -> 200 after the fix) and verified no static-to-dynamic error remains. npm run build + npm test (543) pass.


Claude-Session: https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk