### PR TITLE
fix(team): add missing users columns so team-member create/edit works (#106)

### DIFF
--- a/database/migrations/045_add_users_team_member_columns.sql
+++ b/database/migrations/045_add_users_team_member_columns.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- 045: Add missing team-member columns to public.users
+-- ============================================================
+-- WHY: The Add/Edit Team Member flow writes `notes`, `admin_permissions`,
+-- `home_address`, and `home_city` to the users table, but `notes` was never
+-- added to the schema (worker HR notes live in the separate worker_notes
+-- table, which is for categorized notes only — not this free-text field).
+-- Result: creating a team member failed with
+--   "Could not find the 'notes' column of 'users' in the schema cache".
+-- The other three are added by earlier migrations, but are included here with
+-- IF NOT EXISTS so a database missing any of them is fully repaired in one run.
+-- Idempotent — safe to run repeatedly.
+-- ============================================================
+
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS notes TEXT;
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS admin_permissions JSONB;
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS home_address TEXT;
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS home_city TEXT;
+
+-- Ask PostgREST to reload its schema cache so the new columns are usable
+-- immediately (Supabase normally does this automatically on DDL).
+NOTIFY pgrst, 'reload schema';

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -56,6 +56,10 @@ CREATE TABLE users (
     is_active BOOLEAN DEFAULT true,
     avatar_url TEXT,
     pin VARCHAR(10), -- Worker PIN for mobile app authentication
+    notes TEXT, -- Free-text general notes about a team member (set on create/edit)
+    admin_permissions JSONB, -- Granular admin capability grants (owner-managed)
+    home_address TEXT, -- Worker start location for route optimization
+    home_city TEXT,
     last_login_at TIMESTAMP WITH TIME ZONE, -- NULL means never logged in (pending activation)
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()


### PR DESCRIPTION
## Summary

Adding a team member failed on sandbox with:
> Error creating team member profile: **Could not find the 'notes' column of 'users' in the schema cache**

The Add/Edit Team Member flow writes `notes`, `admin_permissions`, `home_address`, and `home_city` to the `users` table, but **`notes` was never added to the schema** — free-text member notes have no column (the separate `worker_notes` table is for *categorized* HR notes only: injury/ada/fmla/vacation/sick). This is QA's **#106** ("Add Team Member stuck on Saving") and it gates worker assignment testing (**#66**).

## Changes (DB schema only — no app code)
- `database/schema.sql`: add `notes`, `admin_permissions`, `home_address`, `home_city` to the `users` table so fresh environments are complete.
- `database/migrations/045_add_users_team_member_columns.sql`: idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for all four (the latter three exist via earlier migrations; included so any DB missing one is repaired in a single run), plus `NOTIFY pgrst, 'reload schema'`.

The create/edit routes already write these fields — the columns just needed to exist.

## Applying to running environments
The idempotent `ALTER`s must be run against the live Supabase project(s) — sandbox to unblock QA now, and production before release. No code deploy required for the fix to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk

---
_Generated by [Claude Code](https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk)_