### PR TITLE
fix(security): role-gate the dashboard (#78/#79/#88, TC-AUTH-08/SEC-04/SEC-07)

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -58,6 +58,8 @@ function SettingsContent() {
   const tabParam = searchParams.get('tab')
   const initialTab = (tabParam === 'integrations' || tabParam === 'subscription') ? tabParam : 'account'
   const [activeTab, setActiveTab] = useState<'account' | 'integrations' | 'subscription'>(initialTab)
+  // Billing/subscription is owner-only (admins keep everything else).
+  const isOwner = dbUser?.role === 'owner'
   const [saving, setSaving] = useState(false)
   const [saveMessage, setSaveMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
   const [qboConnected, setQboConnected] = useState(false)
@@ -82,6 +84,14 @@ function SettingsContent() {
   const [savingPaymentMethods, setSavingPaymentMethods] = useState(false)
 
   // Load payment methods
+  // Non-owners must not view billing — if one lands on ?tab=subscription
+  // (e.g. via a bookmarked URL), bounce them to the Account tab.
+  useEffect(() => {
+    if (dbUser && !isOwner && activeTab === 'subscription') {
+      setActiveTab('account')
+    }
+  }, [dbUser, isOwner, activeTab])
+
   useEffect(() => {
     const fetchPaymentMethods = async () => {
       if (!company?.id) return
@@ -454,16 +464,18 @@ function SettingsContent() {
         >
           Integrations
         </button>
-        <button
-          onClick={() => setActiveTab('subscription')}
-          className={`px-4 py-2 font-medium border-b-2 -mb-px transition-colors ${
-            activeTab === 'subscription'
-              ? 'text-blue-600 border-blue-600'
-              : 'text-gray-500 border-transparent hover:text-gray-700'
-          }`}
-        >
-          Subscription
-        </button>
+        {isOwner && (
+          <button
+            onClick={() => setActiveTab('subscription')}
+            className={`px-4 py-2 font-medium border-b-2 -mb-px transition-colors ${
+              activeTab === 'subscription'
+                ? 'text-blue-600 border-blue-600'
+                : 'text-gray-500 border-transparent hover:text-gray-700'
+            }`}
+          >
+            Subscription
+          </button>
+        )}
       </div>
 
       {/* Account Tab */}
@@ -1026,8 +1038,8 @@ function SettingsContent() {
         </div>
       )}
 
-      {/* Subscription Tab */}
-      {activeTab === 'subscription' && (() => {
+      {/* Subscription Tab — owner-only */}
+      {activeTab === 'subscription' && isOwner && (() => {
         const isBetaTester = company?.is_beta_tester
         const planKey = company?.plan || 'free_trial'
         const planInfo = PLAN_CONFIG[planKey] || { name: planKey.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()), price: '--', period: '' }

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -145,6 +145,15 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     }
   }, [isLoading, company, router]);
 
+  // Field workers belong in the worker app, not the owner/admin dashboard.
+  // Only pure `worker` accounts are redirected — `worker_admin` (Team Member +
+  // Admin), `admin`, and `owner` keep dashboard access.
+  useEffect(() => {
+    if (!isLoading && dbUser && dbUser.role === 'worker') {
+      router.push('/worker');
+    }
+  }, [isLoading, dbUser, router]);
+
   const handleSignOut = async () => {
     await signOut();
     router.push('/auth/login');
@@ -189,6 +198,15 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     if (role === 'worker_admin') return 'Team Member + Admin';
     return role.charAt(0).toUpperCase() + role.slice(1);
   };
+
+  // Don't flash owner/admin UI to a worker while the redirect above runs.
+  if (!isLoading && dbUser?.role === 'worker') {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
 
   return (
     <ProtectedRoute>


### PR DESCRIPTION
## Summary

The dashboard had **no route-level role enforcement**: `middleware.ts` only checked authentication, and `DashboardLayout` only hid some nav *items*. So any authenticated user — including a field `worker` or a non-owner `admin` — could reach owner-only areas by typing the URL. This is the role/tenant boundary QA flagged (#78/#79/#88, and TC-AUTH-08 / SEC-04 / SEC-07).

## Gating model (Option A, confirmed with owner)
- **worker** → out of the dashboard entirely
- **admin / worker_admin** → dashboard access, **billing/subscription blocked**
- **owner** → full access

## Changes
- `src/components/layout/DashboardLayout.tsx`: redirect pure `worker` accounts to `/worker`, and render a spinner instead of flashing owner/admin UI while the redirect runs. `worker_admin` / `admin` / `owner` keep access.
- `src/app/dashboard/settings/page.tsx`: the **Subscription (billing) tab** is now owner-only — tab hidden for non-owners, panel won't render, and a non-owner landing on `?tab=subscription` is bounced to Account.

## Scope note
This is **client-side** gating; company data is already protected by **RLS**. Server-side owner enforcement on the **checkout API** is a recommended follow-up — that route is shared with the **signup** flow, so it needs a careful new-company-vs-existing-owner distinction rather than a blanket owner-only block. Called out so it isn't mistaken for full server-side lockdown.

## Testing
- `npm run build` ✓ · `npm run lint` ✓ · `npm test` ✓ (543 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk

---
_Generated by [Claude Code](https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk)_