### PR TITLE
fixes: worker switch-link, time_entries.total_hours, portal reschedule notification

### DIFF
--- a/database/migrations/046_add_time_entries_total_hours.sql
+++ b/database/migrations/046_add_time_entries_total_hours.sql
@@ -1,0 +1,14 @@
+-- ============================================================
+-- 046: Add missing total_hours column to public.time_entries
+-- ============================================================
+-- WHY: Clock-out writes `total_hours` (computed shift length) to time_entries,
+-- and the worker Hours view reads it, but the column was never added to the
+-- schema. Result: clocking out failed with
+--   "Could not find the 'total_hours' column of 'time_entries' in the schema cache".
+-- Idempotent — safe to run repeatedly.
+-- ============================================================
+
+ALTER TABLE public.time_entries ADD COLUMN IF NOT EXISTS total_hours DECIMAL(10,2);
+
+-- Reload PostgREST's schema cache so the column is usable immediately.
+NOTIFY pgrst, 'reload schema';

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -224,6 +224,7 @@ CREATE TABLE time_entries (
     clock_in_location JSONB, -- {lat, lng, address}
     clock_out_location JSONB,
     break_minutes INTEGER DEFAULT 0,
+    total_hours DECIMAL(10,2), -- Computed shift length in hours, set on clock-out
     notes TEXT,
     status VARCHAR(50) DEFAULT 'active', -- active, completed, edited
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),

--- a/messages/en/worker.json
+++ b/messages/en/worker.json
@@ -155,7 +155,8 @@
       "passwordPlaceholder": "At least 8 characters",
       "confirmPasswordPlaceholder": "Confirm your password",
       "updatePassword": "Update Password",
-      "updating": "Updating..."
+      "updating": "Updating...",
+      "switchToDashboard": "Switch to Dashboard"
     },
     "safety": {
       "emergency": "Emergency?",

--- a/messages/es/worker.json
+++ b/messages/es/worker.json
@@ -155,7 +155,8 @@
       "passwordPlaceholder": "Mínimo 8 caracteres",
       "confirmPasswordPlaceholder": "Confirma tu contraseña",
       "updatePassword": "Actualizar contraseña",
-      "updating": "Actualizando..."
+      "updating": "Actualizando...",
+      "switchToDashboard": "Ir al panel de administración"
     },
     "safety": {
       "emergency": "¿Emergencia?",

--- a/src/app/api/portal/route.ts
+++ b/src/app/api/portal/route.ts
@@ -645,6 +645,35 @@ export async function POST(request: NextRequest) {
 
     await logPortalAccess(supabase, session.company_id, session.customer_id, 'reschedule_requested', clientIp, `Reschedule requested for job ${jobId}`);
 
+    // Notify the company's owner/admins so the request is actually visible on
+    // the business side (Bug #52/#65: the request was saved but nobody saw it).
+    // Best-effort — a notification failure must not fail the reschedule itself.
+    try {
+      const [{ data: managers }, { data: cust }, { data: jobRow }] = await Promise.all([
+        supabase.from('users').select('id').eq('company_id', session.company_id)
+          .in('role', ['owner', 'admin', 'worker_admin']).eq('is_active', true),
+        supabase.from('customers').select('name').eq('id', session.customer_id).single(),
+        supabase.from('jobs').select('title').eq('id', jobId).single(),
+      ]);
+
+      if (managers && managers.length > 0) {
+        const custName = (cust as { name?: string } | null)?.name || 'A customer';
+        const jobTitle = (jobRow as { title?: string } | null)?.title || 'a job';
+        const when = `${requestedDate}${requestedTimeStart ? ` at ${requestedTimeStart}` : ''}`;
+        const rows = (managers as { id: string }[]).map((m) => ({
+          company_id: session.company_id,
+          user_id: m.id,
+          type: 'reschedule_requested',
+          title: 'Reschedule requested',
+          message: `${custName} requested to reschedule "${jobTitle}" to ${when}.`,
+          link: '/dashboard/schedule',
+        }));
+        await (supabase as any).from('notifications').insert(rows);
+      }
+    } catch (notifyErr) {
+      console.error('Failed to create reschedule notification:', notifyErr);
+    }
+
     return NextResponse.json({ success: true });
   }
 

--- a/src/app/worker/profile/page.tsx
+++ b/src/app/worker/profile/page.tsx
@@ -18,8 +18,10 @@ import {
   Lock,
   Eye,
   EyeOff,
+  LayoutDashboard,
 } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
+import { hasAdminAccess } from '@/lib/permissions';
 import { useTranslations } from 'next-intl';
 
 interface WorkerData {
@@ -333,6 +335,21 @@ export default function WorkerProfilePage() {
       <div className="bg-white rounded-xl shadow-sm p-4">
         <h2 className="font-semibold text-gray-900 mb-4">{t('settings')}</h2>
         <div className="space-y-2">
+          {/* Admin-capable users (worker_admin / admin / owner) can jump to the
+              owner dashboard without logging out and back in via the main app. */}
+          {hasAdminAccess(worker.role) && (
+            <button
+              onClick={() => router.push('/dashboard')}
+              className="w-full flex items-center justify-between p-3 bg-blue-50 rounded-lg hover:bg-blue-100 transition-colors border border-blue-200"
+            >
+              <div className="flex items-center gap-3">
+                <LayoutDashboard className="w-5 h-5 text-blue-600" />
+                <span className="font-medium text-blue-800">{t('switchToDashboard')}</span>
+              </div>
+              <ChevronRight className="w-5 h-5 text-blue-400" />
+            </button>
+          )}
+
           <button className="w-full flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
             <div className="flex items-center gap-3">
               <Bell className="w-5 h-5 text-gray-600" />

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -38,6 +38,7 @@ const TYPE_ICONS: Record<string, { icon: typeof Bell; color: string }> = {
   compliance_alert: { icon: Shield, color: 'text-amber-500' },
   review_received: { icon: Star, color: 'text-yellow-500' },
   booking_received: { icon: CalendarCheck, color: 'text-blue-500' },
+  reschedule_requested: { icon: CalendarCheck, color: 'text-amber-500' },
   worker_clock_in: { icon: Clock, color: 'text-gray-500' },
   quote_accepted: { icon: CheckCircle, color: 'text-green-500' },
   quote_expired: { icon: XCircle, color: 'text-red-500' },


### PR DESCRIPTION
Batch of small, independent fixes surfaced during sandbox QA.

### 1. "Switch to Dashboard" link for admin-capable roles
`worker_admin`/`admin`/`owner` get a **Switch to Dashboard** action in the worker profile Settings (via `hasAdminAccess()`), so a dual-role user doesn't have to log out and use a different login URL. Pure `worker` never sees it → no change to the #644 boundary. i18n en + es.

### 2. Missing `time_entries.total_hours` column (clock-out failed)
Clock-out wrote `total_hours` but the column was never defined → *"Could not find the 'total_hours' column of 'time_entries'."* Adds it to `schema.sql` + `migration 046` (idempotent `ADD COLUMN IF NOT EXISTS` + `NOTIFY pgrst`). **Run the ALTER on sandbox + prod.**

### 3. Portal reschedule request was invisible to the owner (#52/#65)
The portal saved reschedule requests to `reschedule_requests`, but nothing on the business side read them and no notification was created — the owner never saw it. Now `request_reschedule` creates a **notification** for every owner/admin/worker_admin (customer name, job title, requested date/time; links to `/dashboard/schedule`), best-effort so it never fails the request. `NotificationBell` gets an icon for the new type.
- Follow-up (separate): reflect a "reschedule pending" state on the customer's appointment/tracker (#50/#51) + owner approve/deny.

## Testing
- `npm run build` ✓ · `npm run lint` ✓ · `npm test` ✓ (543 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk