### PR TITLE
fix(portal): stop silently succeeding when the login session insert fails

### DIFF
--- a/src/app/api/portal/route.ts
+++ b/src/app/api/portal/route.ts
@@ -541,12 +541,6 @@ export async function POST(request: NextRequest) {
 
     const customer = customers[0];
 
-    // Deactivate any existing active sessions for this customer (single session)
-    await (supabase as any).from('customer_sessions')
-      .update({ is_active: false })
-      .eq('customer_id', customer.id)
-      .eq('is_active', true);
-
     // Generate crypto-secure token
     const rawToken = generateSecureToken();
     const hashedToken = await hashToken(rawToken);
@@ -554,13 +548,33 @@ export async function POST(request: NextRequest) {
     const expiresAt = new Date();
     expiresAt.setDate(expiresAt.getDate() + 30);
 
-    await (supabase as any).from('customer_sessions').insert({
+    // Create the new session FIRST and verify it persisted. This insert used
+    // to be fire-and-forget: if it failed, the endpoint still returned success
+    // and emailed a token whose session never existed, so every magic link
+    // bounced to login. Insert-then-deactivate also avoids leaving the customer
+    // with zero active sessions if the insert fails.
+    const { error: sessionError } = await (supabase as any).from('customer_sessions').insert({
       customer_id: customer.id,
       company_id: customer.company_id,
       token: hashedToken, // Store HASHED token, not raw
       email: customer.email,
       expires_at: expiresAt.toISOString(),
     });
+
+    if (sessionError) {
+      console.error('[Portal] Failed to create customer session:', sessionError);
+      return NextResponse.json(
+        { error: 'Could not start a login session. Please try again, or contact support if it continues.' },
+        { status: 500 }
+      );
+    }
+
+    // Single active session: retire the customer's OTHER active sessions.
+    await (supabase as any).from('customer_sessions')
+      .update({ is_active: false })
+      .eq('customer_id', customer.id)
+      .eq('is_active', true)
+      .neq('token', hashedToken);
 
     // Build portal URL with RAW token (only the customer receives this).
     // Use APP_URL first: it's the per-deploy canonical URL (sandbox on the


### PR DESCRIPTION
## Summary

Portal magic-link login was broken: `send_login_link` generated the token and emailed it, but the `customer_sessions` **INSERT was fire-and-forget**. If the insert failed, the endpoint **still returned success** and mailed a token whose session never existed — so every magic link bounced back to login. (Confirmed on sandbox: the emailed token's hash wasn't in `customer_sessions` at all, and no sessions had been created for days despite repeated requests.)

## Change (`src/app/api/portal/route.ts`)
- Insert the session **first** and **check the error**; on failure, return 500 with an actionable message and log the real error — instead of pretending it worked.
- Reorder to **insert-then-deactivate** so a failed insert never leaves the customer with zero active sessions.

## Note on the root DB cause
The insert failing at runtime points to a `service_role` grant gap on `customer_sessions` on the affected environment (the table schema itself is healthy — a superuser insert succeeds). Re-running `GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;` on sandbox + prod resolves the underlying write; this code change ensures the failure can never again masquerade as success.

## Testing
- `npm run build` ✓ · `npm run lint` ✓ · `npm test` ✓ (543 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk

---
_Generated by [Claude Code](https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk)_