### PR TITLE
fix(smart-quote): voice input can no longer get stuck

### DIFF
--- a/src/app/dashboard/smart-quote/page.tsx
+++ b/src/app/dashboard/smart-quote/page.tsx
@@ -273,10 +273,20 @@ export default function SmartQuotingPage() {
       setIsRecording(false);
     };
 
-    recognition.start();
-
-    // Store recognition instance for stopping
-    (window as any).currentRecognition = recognition;
+    // Stop any lingering recognition from a previous attempt, then start.
+    // recognition.start() throws if one is already running, which would leave
+    // the UI stuck on "Recording…".
+    try {
+      if ((window as any).currentRecognition) {
+        try { (window as any).currentRecognition.stop(); } catch { /* ignore */ }
+      }
+      recognition.start();
+      (window as any).currentRecognition = recognition;
+    } catch (err) {
+      console.error('Could not start voice recognition:', err);
+      setIsRecording(false);
+      alert('Could not start the microphone. Please try again, or use manual entry.');
+    }
   };
 
   const stopVoiceRecording = () => {
@@ -294,6 +304,11 @@ export default function SmartQuotingPage() {
   const processVoiceToLineItems = async (transcript: string) => {
     setIsProcessingVoice(true);
 
+    // Guard against a hung AI request: abort after 30s so the "AI is parsing…"
+    // spinner can never get stuck forever (it falls back to a manual item).
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30000);
+
     try {
       const response = await fetch('/api/ai-quote', {
         method: 'POST',
@@ -305,6 +320,7 @@ export default function SmartQuotingPage() {
           customerAddress: newCustomer.address || '',
           generateTiers: false,
         }),
+        signal: controller.signal,
       });
 
       if (!response.ok) {
@@ -351,6 +367,7 @@ export default function SmartQuotingPage() {
         total: 0,
       }]);
     } finally {
+      clearTimeout(timeoutId);
       setIsProcessingVoice(false);
       setQuoteMode('manual');
     }


### PR DESCRIPTION
## Summary

The Smart Quote **voice** flow could freeze, which is what you hit creating a quote:
- The **"AI is parsing your quote…"** spinner never cleared if the `/api/ai-quote` request hung — there was **no timeout and no cancel**, so a slow/hanging AI call froze the UI permanently.
- Starting the mic could throw *"recognition already running"* and leave the UI stuck on **"Recording…"**.

## Changes (`src/app/dashboard/smart-quote/page.tsx`)
- `processVoiceToLineItems`: abort the AI fetch after **30s** via `AbortController`; on timeout it falls back to adding the transcript as a manual line item and returns to manual mode (the `finally` clears the timer + processing state).
- `startVoiceRecording`: stop any lingering recognition first, and wrap `start()` in try/catch so a failed start resets the state with a clear message instead of hanging.

## Note
If voice keeps falling back to a plain manual item (instead of AI-parsed line items) on sandbox, that points to the **AI API key** (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) not being set for the sandbox branch — the timeout makes the UX safe either way, but real AI parsing needs the key.

## Testing
- `npm run build` ✓ · `npm run lint` ✓ · `npm test` ✓ (543 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk

---
_Generated by [Claude Code](https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk)_