### PR TITLE
Update support phone number to (844) 7-IGUANA

### DIFF
--- a/docs/calendly-integration.md
+++ b/docs/calendly-integration.md
@@ -123,7 +123,7 @@ Before your session, please:
 
 If you need to reschedule, use the link in this email.
 
-Questions? Email support@taskiguana.com or call 1-888-980-8665.
+Questions? Email support@taskiguana.com or call 1-844-744-8262.
 
 See you soon!
 — The Task Iguana Team

--- a/messages/en/tools.json
+++ b/messages/en/tools.json
@@ -7,7 +7,7 @@
       "industries": "Industries",
       "pricing": "Pricing",
       "resources": "Resources",
-      "phone": "(888) 980-TOOL",
+      "phone": "(844) 7-IGUANA",
       "heroTitle": "Free Business Tools",
       "heroSubtitle": "Powerful calculators and compliance guides to help California service businesses stay legal - no signup required.",
       "toolsCount": "4 Free Tools",

--- a/messages/es/tools.json
+++ b/messages/es/tools.json
@@ -7,7 +7,7 @@
       "industries": "Industrias",
       "pricing": "Precios",
       "resources": "Recursos",
-      "phone": "(888) 980-TOOL",
+      "phone": "(844) 7-IGUANA",
       "heroTitle": "Herramientas Gratis",
       "heroSubtitle": "Calculadoras y guías de cumplimiento para ayudar a negocios de servicios en California a mantenerse legales - sin registrarte.",
       "toolsCount": "4 Herramientas Gratis",

--- a/scripts/generate-wiki.js
+++ b/scripts/generate-wiki.js
@@ -238,7 +238,7 @@ Extend your plan with powerful add-ons:
 
 Contact us:
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Available in your dashboard
 `;
 

--- a/src/app/industries/page.tsx
+++ b/src/app/industries/page.tsx
@@ -130,7 +130,7 @@ export default function IndustriesPage() {
             <Link href="/pricing" className="text-white/70 font-medium text-base hover:text-white transition-colors no-underline">{t('pricing')}</Link>
             <Link href="/tools" className="text-white/70 font-medium text-base hover:text-white transition-colors no-underline">{t('freeTools')}</Link>
             <span className="text-white/70 text-base flex items-center gap-1">
-              📞 (888) 980-TOOL
+              📞 (844) 7-IGUANA
             </span>
             <Link
               href="/auth/login"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -282,8 +282,8 @@ export default function Home() {
             {/* Language Switcher */}
             <LanguageSwitcher />
 
-            <a href="tel:1-888-980-8665" className="text-white/70 text-base flex items-center gap-2 whitespace-nowrap hover:text-white transition-colors no-underline">
-              📞 <span>(888) 980-TOOL</span>
+            <a href="tel:1-844-744-8262" className="text-white/70 text-base flex items-center gap-2 whitespace-nowrap hover:text-white transition-colors no-underline">
+              📞 <span>(844) 7-IGUANA</span>
             </a>
             <Link
               href="/auth/signup"

--- a/src/components/dashboard/GettingStartedChecklist.tsx
+++ b/src/components/dashboard/GettingStartedChecklist.tsx
@@ -463,7 +463,7 @@ export default function GettingStartedChecklist() {
           Need help setting up?{' '}
           <a href="mailto:support@taskiguana.com" className="text-blue-600 hover:underline">Email us</a>
           {' '}or{' '}
-          <a href="tel:1-888-980-8665" className="text-blue-600 hover:underline">call 1-888-980-8665</a>
+          <a href="tel:1-844-744-8262" className="text-blue-600 hover:underline">call 1-844-744-8262</a>
           {' '}&mdash; we&apos;re happy to walk you through it.
         </p>
       </div>

--- a/src/components/help/HelpButton.tsx
+++ b/src/components/help/HelpButton.tsx
@@ -145,7 +145,7 @@ export default function HelpButton() {
                 <span className="text-xs font-medium text-gray-700">Email Us</span>
               </a>
               <a
-                href="tel:1-888-980-8665"
+                href="tel:1-844-744-8262"
                 className="flex flex-col items-center gap-1.5 p-3 rounded-lg hover:bg-gray-50 transition-colors group"
               >
                 <Phone size={20} className="text-gold-500 group-hover:text-gold-600" />

--- a/tooltimepro/chatbot.html
+++ b/tooltimepro/chatbot.html
@@ -856,7 +856,7 @@
                 console.error('AI error:', error);
                 // Fallback response
                 return {
-                    reply: "I'd be happy to help! For the fastest response, you can reach us at (888) 980-TOOL, or leave your number and we'll call you right back.",
+                    reply: "I'd be happy to help! For the fastest response, you can reach us at (844) 7-IGUANA, or leave your number and we'll call you right back.",
                     quickReplies: ['Leave my number', 'Book appointment'],
                     leadCaptured: false,
                     bookingState: null

--- a/tooltimepro/quote.html
+++ b/tooltimepro/quote.html
@@ -1249,7 +1249,7 @@
                                     <span class="company-name">Pro Landscaping Services</span><br>
                                     456 Business Ave<br>
                                     Austin, TX 78701<br>
-                                    (888) 980-TOOL
+                                    (844) 7-IGUANA
                                 </p>
                             </div>
                             <div class="quote-party">

--- a/tooltimepro/worker-app.html
+++ b/tooltimepro/worker-app.html
@@ -1668,7 +1668,7 @@
                 <div class="detail-section-title" data-i18n="emergency_contacts">Emergency Contacts</div>
                 <div class="checklist-item">
                     <span>📞</span>
-                    <span class="checklist-text">Dispatch: (888) 980-TOOL</span>
+                    <span class="checklist-text">Dispatch: (844) 7-IGUANA</span>
                 </div>
                 <div class="checklist-item">
                     <span>📞</span>
@@ -2221,11 +2221,11 @@
         }
 
         function callCustomer() {
-            window.location.href = 'tel:+18889808665'
+            window.location.href = 'tel:+18447448262'
         }
 
         function textCustomer() {
-            window.location.href = 'sms:+18889808665'
+            window.location.href = 'sms:+18447448262'
         }
 
         function toggleChecklist(item) {

--- a/wiki/Customer-Portal.md
+++ b/wiki/Customer-Portal.md
@@ -97,5 +97,5 @@ Once active, your customers will receive portal access automatically after their
 ## Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Customers-and-Leads.md
+++ b/wiki/Customers-and-Leads.md
@@ -197,5 +197,5 @@ Lead → Convert → Customer → Quote → Job → Invoice
 ## Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -123,7 +123,7 @@ Yes:
 - **Assisted Onboarding** ($199) — Guided setup call, service catalog configuration, team invites, booking page
 - **White-Glove Setup** ($499) — Full configuration, data migration, website build, and training
 
-Contact support@taskiguana.com or call 1-888-980-8665 to book.
+Contact support@taskiguana.com or call 1-844-744-8262 to book.
 
 ### Can I migrate data from another platform?
 Yes! Task Iguana has a **self-service import wizard** built right into your dashboard. Go to **Customers → Import Customers**, select your old CRM (Housecall Pro, Jobber, ServiceTitan, FieldPulse, GorillaDesk, Workiz, or any CSV), upload your export file, and the importer auto-maps your columns. See the full guide: [Customers & Leads → Importing Customers](Customers-and-Leads#importing-customers-crm-migration).
@@ -149,7 +149,7 @@ No. Your data is yours. We do not sell, share, or monetize your business or cust
 
 ### How do I contact support?
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the help icon in your dashboard
 
 ### What are support hours?
@@ -162,4 +162,4 @@ You're looking at it! Browse the [Help Center](Home) for guides on every feature
 
 ## Still Have Questions?
 
-Contact us at support@taskiguana.com or call 1-888-980-8665. We're here to help.
+Contact us at support@taskiguana.com or call 1-844-744-8262. We're here to help.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -86,7 +86,7 @@ Not sure where to start? We offer two onboarding packages:
 | **Assisted Onboarding** | $199 (one-time) | Guided setup call, service catalog configuration, team invites, booking page setup |
 | **White-Glove Setup** | $499 (one-time) | Full account configuration, data migration, custom website build, training session |
 
-Contact support@taskiguana.com or call 1-888-980-8665 to book.
+Contact support@taskiguana.com or call 1-844-744-8262 to book.
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -77,6 +77,6 @@ _These pages are auto-generated from source code and stay up to date automatical
 ## Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard
 - **Onboarding:** [Book Assisted Onboarding ($199)](https://www.taskiguana.com/pricing) or [White-Glove Setup ($499)](https://www.taskiguana.com/pricing)

--- a/wiki/Jenny-AI.md
+++ b/wiki/Jenny-AI.md
@@ -153,5 +153,5 @@ Jenny Exec Admin is your AI-powered executive assistant, built for business owne
 ## Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Jobs-and-Scheduling.md
+++ b/wiki/Jobs-and-Scheduling.md
@@ -185,5 +185,5 @@ Online Booking → Jobs → Schedule → Dispatch → Route Optimizer
 ## Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Online-Booking.md
+++ b/wiki/Online-Booking.md
@@ -128,5 +128,5 @@ See [Jenny AI](Jenny-AI) for more on AI-powered booking.
 ## Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Payment-Plans-Guide.md
+++ b/wiki/Payment-Plans-Guide.md
@@ -86,5 +86,5 @@ Quote → Invoice → Payment Plan
 ## Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Pricing-and-Plans.md
+++ b/wiki/Pricing-and-Plans.md
@@ -111,5 +111,5 @@ Extend your plan with powerful add-ons:
 
 Contact us:
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Available in your dashboard

--- a/wiki/Reports-and-Analytics.md
+++ b/wiki/Reports-and-Analytics.md
@@ -111,5 +111,5 @@ A quick revenue chart also appears on your main **Dashboard** page, showing your
 ## Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Settings-and-Integrations.md
+++ b/wiki/Settings-and-Integrations.md
@@ -153,5 +153,5 @@ Stripe is set up during your initial account configuration. If you need to recon
 ## Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Time-Tracking.md
+++ b/wiki/Time-Tracking.md
@@ -133,5 +133,5 @@ Export time data for payroll processing:
 ## Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-Common issues and solutions for Task Iguana. If your problem isn't listed here, contact support@taskiguana.com or call 1-888-980-8665.
+Common issues and solutions for Task Iguana. If your problem isn't listed here, contact support@taskiguana.com or call 1-844-744-8262.
 
 ---
 
@@ -174,7 +174,7 @@ Common issues and solutions for Task Iguana. If your problem isn't listed here, 
 ## Still Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard
 - **Response time:** We typically respond within 2 hours during business hours
 

--- a/wiki/Website-and-Blog.md
+++ b/wiki/Website-and-Blog.md
@@ -125,5 +125,5 @@ Published blog posts appear on your Task Iguana website automatically, giving yo
 ## Need Help?
 
 - **Email:** support@taskiguana.com
-- **Phone:** 1-888-980-8665
+- **Phone:** 1-844-744-8262
 - **Live Chat:** Click the chat icon in your dashboard


### PR DESCRIPTION
## Summary
Updated all customer-facing support phone numbers and vanity numbers throughout the application from the old number (888) 980-TOOL / 1-888-980-8665 to the new number (844) 7-IGUANA / 1-844-744-8262.

## Changes Made
- **Worker app** (`tooltimepro/worker-app.html`): Updated dispatch emergency contact number and call/text customer functions
- **Chatbot** (`tooltimepro/chatbot.html`): Updated fallback response with new contact number
- **Quote template** (`tooltimepro/quote.html`): Updated company contact number in quote display
- **Main website** (`src/app/page.tsx`): Updated phone link and display text in header
- **Industries page** (`src/app/industries/page.tsx`): Updated phone number display
- **Dashboard components**: Updated phone numbers in Getting Started Checklist and Help Button
- **Internationalization** (`messages/en/tools.json`, `messages/es/tools.json`): Updated phone display in both English and Spanish
- **Documentation** (all wiki files): Updated phone numbers in FAQ, Troubleshooting, Getting Started, and all feature guides
- **Wiki generator** (`scripts/generate-wiki.js`): Updated template with new phone number

## Implementation Details
- All phone number updates maintain the same format and context (tel: links, display text, etc.)
- Both numeric format (1-844-744-8262) and vanity format ((844) 7-IGUANA) updated consistently
- Changes span customer-facing UI, internal tools, documentation, and automated wiki generation
- No functional logic changes—purely contact information updates

https://claude.ai/code/session_01NqFJLQinvBXidbdUdt3adz