### PR TITLE
Validate EMAIL_FROM env var to prevent email send failures

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -14,7 +14,35 @@ function getResend() {
 
 // Default to the verified root domain. Once send.taskiguana.com is added
 // and verified in Resend, set EMAIL_FROM=Task Iguana <no-reply@send.taskiguana.com>
-const FROM_EMAIL = process.env.EMAIL_FROM || 'Task Iguana <no-reply@taskiguana.com>';
+const DEFAULT_FROM_EMAIL = 'Task Iguana <no-reply@taskiguana.com>';
+
+// Every transactional email (invoices, quotes, password resets, confirmations,
+// team invites) shares this single `from`. A malformed EMAIL_FROM env value —
+// e.g. wrapping quotes pasted into the env var, a smart quote/em-dash, or a
+// bare display name with no address — makes Resend reject EVERY send with
+// "Invalid `from` field". Validate it and fall back to the known-good default
+// so one bad env value can't take down all email.
+function resolveFromEmail(): string {
+  const raw = process.env.EMAIL_FROM?.trim();
+  if (!raw) return DEFAULT_FROM_EMAIL;
+
+  // Strip a single pair of wrapping quotes accidentally included in the value.
+  const value = raw.replace(/^(['"])([\s\S]*)\1$/, '$2').trim();
+
+  // Accept either `email@example.com` or `Display Name <email@example.com>`.
+  const bareEmail = /^[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+$/;
+  const namedEmail = /^.+\s+<[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+>$/;
+  if (bareEmail.test(value) || namedEmail.test(value)) return value;
+
+  console.error(
+    `[email] EMAIL_FROM is not a valid address ("${raw}"); ` +
+      `falling back to ${DEFAULT_FROM_EMAIL}. Expected "email@example.com" ` +
+      'or "Name <email@example.com>" with no wrapping quotes.'
+  );
+  return DEFAULT_FROM_EMAIL;
+}
+
+const FROM_EMAIL = resolveFromEmail();
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://taskiguana.com';
 
 function formatPlanName(plan: string): string {


### PR DESCRIPTION
## Summary
Added validation for the `EMAIL_FROM` environment variable to prevent malformed values from breaking all transactional emails. The system now gracefully falls back to a known-good default address when the env var is invalid, with detailed error logging.

## Changes
- Extracted `FROM_EMAIL` constant into a `resolveFromEmail()` function that validates the email address format
- Added logic to strip accidentally-included wrapping quotes from the env var value
- Implemented regex validation for two accepted formats:
  - Bare email: `email@example.com`
  - Named email: `Display Name <email@example.com>`
- Falls back to `DEFAULT_FROM_EMAIL` ('Task Iguana <no-reply@taskiguana.com>') if validation fails
- Added console error logging with helpful guidance when an invalid `EMAIL_FROM` is detected

## Implementation Details
- The validation regex patterns reject common mistakes like smart quotes, em-dashes, and bare display names without addresses
- Single wrapping quotes are automatically stripped before validation (e.g., `'email@example.com'` → `email@example.com`)
- Error message clearly explains the expected format and why the fallback is being used
- This prevents a single malformed env var from causing all email sends to fail with "Invalid `from` field" errors from Resend

https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ