### PR TITLE
Rebrand completion: quote-edit save fallback + Twilio webhook re-sync script

### DIFF
--- a/src/app/dashboard/quotes/page.tsx
+++ b/src/app/dashboard/quotes/page.tsx
@@ -1487,8 +1487,23 @@ function QuoteModal({ quote, companyId, userId, customers, defaultQuoteTerms, is
         deposit_percentage: quote.deposit_percentage,
       }
 
-      // Update existing quote
-      const { error: updateError } = await supabase.from('quotes').update(quoteData).eq('id', quote.id)
+      // Update existing quote. Some deployments may be behind on migrations
+      // (e.g. the `frequency` or deposit columns). Mirror the create path
+      // (/api/quote/save): if the failure is a missing column, strip the
+      // optional fields and retry so the core edit still saves.
+      let updateError = (await supabase.from('quotes').update(quoteData).eq('id', quote.id)).error
+      if (
+        updateError &&
+        (updateError.code === '42703' || /frequency|terms|deposit_/.test(updateError.message || ''))
+      ) {
+        const retryData = { ...quoteData }
+        delete retryData.frequency
+        delete retryData.terms
+        delete retryData.deposit_required
+        delete retryData.deposit_amount
+        delete retryData.deposit_percentage
+        updateError = (await supabase.from('quotes').update(retryData).eq('id', quote.id)).error
+      }
       if (updateError) {
         console.error('Error updating quote:', updateError)
         setSaveError(friendlySaveError(updateError.message))


### PR DESCRIPTION
Two rebrand-remediation fixes on the completion branch.

## 1. Quote edit fails when frequency/deposit columns are missing
Editing an existing quote could fail with **"We couldn't save this quote"** on any deployment whose database is behind on migrations — notably production, which doesn't have migration `047` (the `frequency` column) applied yet.

The **create** path (`/api/quote/save`) already tolerates missing columns (retries without them on a `42703` error); the **edit** path did not — it wrote the full `quoteData` (including `frequency` and `deposit_*`) via a direct Supabase `update` with no fallback, so a missing column blocked all edits.

**Fix** (`src/app/dashboard/quotes/page.tsx`): mirror the create path — on a missing-column error, strip the optional columns and retry so the core edit still saves. The permanent fix remains applying migration `047` to prod.

## 2. Twilio webhook re-sync script
Phone numbers provisioned/ported **before** the rebrand keep the old host baked into their `voiceUrl`/`smsUrl` on Twilio (confirmed in the Console: both active numbers still POST to `https://www.tooltimepro.com/api/jenny-pro/voice`). Nothing in the codebase ever rewrites those, so inbound calls/texts hit the dead old domain and silently fail.

**Fix** (`scripts/resync-twilio-webhooks.js`): a one-off maintenance script that sweeps every `IncomingPhoneNumber` and repoints any Jenny webhook whose host doesn't match the target. Audit-only by default; `--write` applies. Target host mirrors the app's `baseUrl()` precedence (`PUBLIC_BASE_URL → URL → NEXT_PUBLIC_SITE_URL → www.taskiguana.com`), overridable with `--base=`. Only touches numbers already carrying a Jenny webhook, so unrelated numbers are left alone.

Run it with:
```
TWILIO_ACCOUNT_SID=AC... TWILIO_AUTH_TOKEN=... node scripts/resync-twilio-webhooks.js         # audit
TWILIO_ACCOUNT_SID=AC... TWILIO_AUTH_TOKEN=... node scripts/resync-twilio-webhooks.js --write # apply
```
Note: numbers on a Messaging Service receive inbound SMS via the service's own webhook, so the Messaging Service inbound URL must also be verified in the Twilio Console.

## Testing
- `npm run build` — passes
- Quote test suites — 187 tests pass
- Re-sync script — `node --check` clean, lint clean, detection logic verified against the two real number URLs (both repoint correctly; already-correct and unrelated numbers are skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ