### PR TITLE
Add "formerly ToolTime Pro" brand bridge to SMS + privacy pages (A2P)

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -31,8 +31,9 @@ export default function PrivacyPolicyPage() {
             <h2 className="text-xl font-bold mb-3">1. Introduction</h2>
             <p>
               Task Iguana (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) operates the taskiguana.com website and the Task Iguana
-              platform. This Privacy Policy explains how we collect, use, disclose, and safeguard your information
-              when you use our services.
+              platform. Task Iguana was formerly known as ToolTime Pro, and our SMS/A2P messaging program remains
+              registered under that prior name. This Privacy Policy explains how we collect, use, disclose, and
+              safeguard your information when you use our services.
             </p>
           </section>
 

--- a/src/app/sms/page.tsx
+++ b/src/app/sms/page.tsx
@@ -30,6 +30,12 @@ export default function SmsPage() {
           <section>
             <h2 className="text-xl font-bold mb-3">{t('programName')}</h2>
             <p>Task Iguana Service Notifications</p>
+            <p className="mt-2 text-sm text-[#0A0C11]/70">
+              Task Iguana is the field-service management platform at{' '}
+              <a href="https://taskiguana.com" className="text-[#1FE3C4] underline">taskiguana.com</a>,
+              formerly known as ToolTime Pro. Our A2P messaging brand remains registered
+              under the prior name, ToolTime Pro.
+            </p>
           </section>
 
           <section>


### PR DESCRIPTION
## Why
The A2P Brand in Twilio Trust Hub is registered and **Approved** as **"ToolTime Pro"**, but the site now presents as **"Task Iguana."** An A2P campaign reviewer opens the website and sees no visible relationship between the registered brand name and the site — the same class of mismatch that got the campaign rejected ("no visible relationship between the brand name and your website").

## Change
Adds a short business-identity line to the two compliance pages a reviewer actually checks, stating that **Task Iguana was formerly ToolTime Pro** and the A2P messaging brand remains registered under the prior name:
- `src/app/sms/page.tsx` — the opt-in evidence page (under Program Name)
- `src/app/privacy/page.tsx` — the Introduction section

This creates the traceable chain **approved brand (ToolTime Pro) ↔ website ("Task Iguana, formerly ToolTime Pro")** without renaming/re-vetting the approved brand. No legal entity name is exposed publicly (the LLC stays private, provided only to Twilio in the campaign form).

## Testing
- `npm run build` — passes
- ESLint — clean on both files (pre-existing `<img>` warnings on the SMS page are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ)_