### PR TITLE
Unify Twilio webhook host fallback to apex taskiguana.com

### DIFF
--- a/scripts/resync-twilio-webhooks.js
+++ b/scripts/resync-twilio-webhooks.js
@@ -16,8 +16,8 @@
  * alone.
  *
  * Target host resolution (same precedence as the app's baseUrl() helper):
- *   PUBLIC_BASE_URL -> URL (Netlify) -> NEXT_PUBLIC_SITE_URL -> https://www.taskiguana.com
- * Override with --base=https://www.taskiguana.com if needed.
+ *   PUBLIC_BASE_URL -> URL (Netlify) -> NEXT_PUBLIC_SITE_URL -> https://taskiguana.com
+ * Override with --base=https://taskiguana.com if needed.
  *
  * Modes:
  *   (default)   Audit only — read-only Twilio API calls, prints what WOULD
@@ -29,7 +29,7 @@
  * Usage:
  *   TWILIO_ACCOUNT_SID=AC... TWILIO_AUTH_TOKEN=... node scripts/resync-twilio-webhooks.js
  *   TWILIO_ACCOUNT_SID=AC... TWILIO_AUTH_TOKEN=... node scripts/resync-twilio-webhooks.js --write
- *   ... node scripts/resync-twilio-webhooks.js --base=https://www.taskiguana.com --write
+ *   ... node scripts/resync-twilio-webhooks.js --base=https://taskiguana.com --write
  *
  * NOTE: numbers attached to a Messaging Service receive INBOUND SMS via the
  * Messaging Service's own inbound webhook, not the number's smsUrl. This script
@@ -51,7 +51,7 @@ function resolveBase(argv) {
     process.env.PUBLIC_BASE_URL ||
     process.env.URL ||
     process.env.NEXT_PUBLIC_SITE_URL ||
-    'https://www.taskiguana.com';
+    'https://taskiguana.com';
   return raw.replace(/\/+$/, '');
 }
 

--- a/src/__tests__/api/jenny-provision-number.test.js
+++ b/src/__tests__/api/jenny-provision-number.test.js
@@ -48,7 +48,7 @@ process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
 process.env.TWILIO_ACCOUNT_SID = 'ACtest';
 process.env.TWILIO_AUTH_TOKEN = 'tok';
 process.env.TWILIO_MESSAGING_SERVICE_SID = 'MGtest';
-process.env.URL = 'https://www.taskiguana.com';
+process.env.URL = 'https://taskiguana.com';
 
 const { POST } = require('@/app/api/jenny-pro/provision-number/route');
 const { authenticateRequest } = require('@/lib/server-auth');
@@ -80,8 +80,8 @@ describe('/api/jenny-pro/provision-number', () => {
     // Webhooks point at Jenny's routes.
     expect(mockIncomingCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        voiceUrl: 'https://www.taskiguana.com/api/jenny-pro/voice',
-        smsUrl: 'https://www.taskiguana.com/api/jenny-pro/sms-webhook',
+        voiceUrl: 'https://taskiguana.com/api/jenny-pro/voice',
+        smsUrl: 'https://taskiguana.com/api/jenny-pro/sms-webhook',
       })
     );
     // Attached to the A2P Messaging Service and mapping saved.

--- a/src/__tests__/lib/jenny-twilio-wire.test.js
+++ b/src/__tests__/lib/jenny-twilio-wire.test.js
@@ -22,15 +22,15 @@ describe('wireNumberToCompany', () => {
       companyId: 'c1',
       phoneNumberSid: 'PN1',
       phoneNumber: '+17657895752',
-      baseUrl: 'https://www.taskiguana.com',
+      baseUrl: 'https://taskiguana.com',
       messagingServiceSid: 'MG1',
     });
 
     expect(incomingPhoneNumbers).toHaveBeenCalledWith('PN1');
     expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
-        voiceUrl: 'https://www.taskiguana.com/api/jenny-pro/voice',
-        smsUrl: 'https://www.taskiguana.com/api/jenny-pro/sms-webhook',
+        voiceUrl: 'https://taskiguana.com/api/jenny-pro/voice',
+        smsUrl: 'https://taskiguana.com/api/jenny-pro/sms-webhook',
       })
     );
     expect(msCreate).toHaveBeenCalledWith({ phoneNumberSid: 'PN1' });

--- a/src/app/api/jenny-pro/port-status/route.js
+++ b/src/app/api/jenny-pro/port-status/route.js
@@ -28,7 +28,7 @@ function getTwilio() {
 
 function baseUrl() {
   const raw =
-    process.env.PUBLIC_BASE_URL || process.env.URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://www.taskiguana.com';
+    process.env.PUBLIC_BASE_URL || process.env.URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://taskiguana.com';
   return raw.replace(/\/$/, '');
 }
 

--- a/src/app/api/jenny-pro/provision-number/route.js
+++ b/src/app/api/jenny-pro/provision-number/route.js
@@ -31,7 +31,7 @@ function baseUrl() {
     process.env.PUBLIC_BASE_URL ||
     process.env.URL ||
     process.env.NEXT_PUBLIC_SITE_URL ||
-    'https://www.taskiguana.com';
+    'https://taskiguana.com';
   return raw.replace(/\/$/, '');
 }
 


### PR DESCRIPTION
## Why
The Twilio number-provisioning and port-status routes fell back to `https://www.taskiguana.com`, while the rest of the app (middleware `MAIN_DOMAIN`, email base URL) uses the apex `https://taskiguana.com`. Confirmed canonical: the logged-in app serves from **`taskiguana.com`** (no `www`). This removes the www-vs-apex drift so number provisioning, port-in wiring, and the re-sync script all default to the same host everything else uses.

## Change
- `src/app/api/jenny-pro/provision-number/route.js` — `baseUrl()` fallback → apex
- `src/app/api/jenny-pro/port-status/route.js` — `baseUrl()` fallback → apex
- `scripts/resync-twilio-webhooks.js` — default target host + doc comments → apex
- `src/__tests__/api/jenny-provision-number.test.js`, `src/__tests__/lib/jenny-twilio-wire.test.js` — updated expectations to apex

## Impact
Production behavior is unchanged in practice — Netlify's `URL` env takes precedence over the hardcoded fallback — so this is drift cleanup, not a runtime fix. Recommendation still stands to set `PUBLIC_BASE_URL=https://taskiguana.com` explicitly in Netlify so nothing relies on a fallback at all.

## Testing
- Full suite — 562 tests pass
- `npm run build` — passes
- `node --check` on the re-sync script — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ)_