### PR TITLE
Standardize app-URL/webhook host on www.taskiguana.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # App URL (used for OAuth callbacks, email links, redirects)
-NEXT_PUBLIC_APP_URL=https://app.taskiguana.com
+NEXT_PUBLIC_APP_URL=https://www.taskiguana.com
 
 # Stripe
 STRIPE_SECRET_KEY=sk_live_or_test...

--- a/scripts/generate-wiki.js
+++ b/scripts/generate-wiki.js
@@ -293,7 +293,7 @@ function generateApiReference() {
 
 Complete list of Task Iguana API endpoints, auto-generated from source code.
 
-**Base URL:** \`https://app.taskiguana.com\` (production) or \`http://localhost:3000\` (local dev)
+**Base URL:** \`https://www.taskiguana.com\` (production) or \`http://localhost:3000\` (local dev)
 
 ---
 

--- a/scripts/resync-twilio-webhooks.js
+++ b/scripts/resync-twilio-webhooks.js
@@ -16,8 +16,8 @@
  * alone.
  *
  * Target host resolution (same precedence as the app's baseUrl() helper):
- *   PUBLIC_BASE_URL -> URL (Netlify) -> NEXT_PUBLIC_SITE_URL -> https://taskiguana.com
- * Override with --base=https://taskiguana.com if needed.
+ *   PUBLIC_BASE_URL -> URL (Netlify) -> NEXT_PUBLIC_SITE_URL -> https://www.taskiguana.com
+ * Override with --base=https://www.taskiguana.com if needed.
  *
  * Modes:
  *   (default)   Audit only — read-only Twilio API calls, prints what WOULD
@@ -29,7 +29,7 @@
  * Usage:
  *   TWILIO_ACCOUNT_SID=AC... TWILIO_AUTH_TOKEN=... node scripts/resync-twilio-webhooks.js
  *   TWILIO_ACCOUNT_SID=AC... TWILIO_AUTH_TOKEN=... node scripts/resync-twilio-webhooks.js --write
- *   ... node scripts/resync-twilio-webhooks.js --base=https://taskiguana.com --write
+ *   ... node scripts/resync-twilio-webhooks.js --base=https://www.taskiguana.com --write
  *
  * NOTE: numbers attached to a Messaging Service receive INBOUND SMS via the
  * Messaging Service's own inbound webhook, not the number's smsUrl. This script
@@ -51,7 +51,7 @@ function resolveBase(argv) {
     process.env.PUBLIC_BASE_URL ||
     process.env.URL ||
     process.env.NEXT_PUBLIC_SITE_URL ||
-    'https://taskiguana.com';
+    'https://www.taskiguana.com';
   return raw.replace(/\/+$/, '');
 }
 

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -11,7 +11,7 @@
  * Usage:
  *   node scripts/smoke-test.js [baseUrl]
  *   SMOKE_BASE_URL=https://sandbox--<site>.netlify.app node scripts/smoke-test.js
- *   HEALTH_CHECK_TOKEN=… node scripts/smoke-test.js https://app.taskiguana.com
+ *   HEALTH_CHECK_TOKEN=… node scripts/smoke-test.js https://www.taskiguana.com
  *
  * Resolution order for the base URL: CLI arg > SMOKE_BASE_URL env > localhost.
  *

--- a/src/__tests__/api/jenny-provision-number.test.js
+++ b/src/__tests__/api/jenny-provision-number.test.js
@@ -48,7 +48,7 @@ process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
 process.env.TWILIO_ACCOUNT_SID = 'ACtest';
 process.env.TWILIO_AUTH_TOKEN = 'tok';
 process.env.TWILIO_MESSAGING_SERVICE_SID = 'MGtest';
-process.env.URL = 'https://taskiguana.com';
+process.env.URL = 'https://www.taskiguana.com';
 
 const { POST } = require('@/app/api/jenny-pro/provision-number/route');
 const { authenticateRequest } = require('@/lib/server-auth');
@@ -80,8 +80,8 @@ describe('/api/jenny-pro/provision-number', () => {
     // Webhooks point at Jenny's routes.
     expect(mockIncomingCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        voiceUrl: 'https://taskiguana.com/api/jenny-pro/voice',
-        smsUrl: 'https://taskiguana.com/api/jenny-pro/sms-webhook',
+        voiceUrl: 'https://www.taskiguana.com/api/jenny-pro/voice',
+        smsUrl: 'https://www.taskiguana.com/api/jenny-pro/sms-webhook',
       })
     );
     // Attached to the A2P Messaging Service and mapping saved.

--- a/src/__tests__/lib/jenny-twilio-wire.test.js
+++ b/src/__tests__/lib/jenny-twilio-wire.test.js
@@ -22,15 +22,15 @@ describe('wireNumberToCompany', () => {
       companyId: 'c1',
       phoneNumberSid: 'PN1',
       phoneNumber: '+17657895752',
-      baseUrl: 'https://taskiguana.com',
+      baseUrl: 'https://www.taskiguana.com',
       messagingServiceSid: 'MG1',
     });
 
     expect(incomingPhoneNumbers).toHaveBeenCalledWith('PN1');
     expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
-        voiceUrl: 'https://taskiguana.com/api/jenny-pro/voice',
-        smsUrl: 'https://taskiguana.com/api/jenny-pro/sms-webhook',
+        voiceUrl: 'https://www.taskiguana.com/api/jenny-pro/voice',
+        smsUrl: 'https://www.taskiguana.com/api/jenny-pro/sms-webhook',
       })
     );
     expect(msCreate).toHaveBeenCalledWith({ phoneNumberSid: 'PN1' });

--- a/src/app/api/google-calendar/callback/route.js
+++ b/src/app/api/google-calendar/callback/route.js
@@ -5,7 +5,7 @@ export const dynamic = 'force-dynamic'
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || ''
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || ''
-const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.taskiguana.com'
+const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.taskiguana.com'
 
 export async function GET(request) {
   try {

--- a/src/app/api/google-calendar/connect/route.js
+++ b/src/app/api/google-calendar/connect/route.js
@@ -5,7 +5,7 @@ export const dynamic = 'force-dynamic'
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || ''
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || ''
-const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.taskiguana.com'
+const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.taskiguana.com'
 
 function getSupabaseAdmin() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL

--- a/src/app/api/jenny-actions/route.ts
+++ b/src/app/api/jenny-actions/route.ts
@@ -702,7 +702,7 @@ async function runReviewRequests(
 
   const alreadyRequested = new Set((existingRequests || []).map((r: any) => r.job_id));
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://app.taskiguana.com';
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.taskiguana.com';
   const platformLabel = reviewPlatform === 'google' ? 'Google' : 'Yelp';
 
   for (const job of completedJobs) {

--- a/src/app/api/jenny-pro/port-status/route.js
+++ b/src/app/api/jenny-pro/port-status/route.js
@@ -28,7 +28,7 @@ function getTwilio() {
 
 function baseUrl() {
   const raw =
-    process.env.PUBLIC_BASE_URL || process.env.URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://taskiguana.com';
+    process.env.PUBLIC_BASE_URL || process.env.URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://www.taskiguana.com';
   return raw.replace(/\/$/, '');
 }
 

--- a/src/app/api/jenny-pro/provision-number/route.js
+++ b/src/app/api/jenny-pro/provision-number/route.js
@@ -31,7 +31,7 @@ function baseUrl() {
     process.env.PUBLIC_BASE_URL ||
     process.env.URL ||
     process.env.NEXT_PUBLIC_SITE_URL ||
-    'https://taskiguana.com';
+    'https://www.taskiguana.com';
   return raw.replace(/\/$/, '');
 }
 

--- a/src/app/api/portal/route.ts
+++ b/src/app/api/portal/route.ts
@@ -581,7 +581,7 @@ export async function POST(request: NextRequest) {
     // sandbox branch, prod on prod), so the magic link always lands on the
     // same environment whose DB holds this session token. SITE_URL points at
     // the marketing/prod host and would send sandbox links to production.
-    const portalBase = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://app.taskiguana.com';
+    const portalBase = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://www.taskiguana.com';
     const portalUrl = `${portalBase}/portal?token=${rawToken}`;
 
     // Get company name for email

--- a/src/app/api/quickbooks/callback/route.ts
+++ b/src/app/api/quickbooks/callback/route.ts
@@ -8,7 +8,7 @@ const QUICKBOOKS_CLIENT_ID = process.env.QUICKBOOKS_CLIENT_ID || ''
 const QUICKBOOKS_CLIENT_SECRET = process.env.QUICKBOOKS_CLIENT_SECRET || ''
 const QUICKBOOKS_REDIRECT_URI = process.env.QUICKBOOKS_REDIRECT_URI || ''
 
-const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.taskiguana.com'
+const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.taskiguana.com'
 
 // QuickBooks token endpoint (same for sandbox and production)
 const QBO_TOKEN_URL = 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer'

--- a/src/app/api/quickbooks/connect/route.ts
+++ b/src/app/api/quickbooks/connect/route.ts
@@ -7,7 +7,7 @@ export const dynamic = 'force-dynamic'
 const QUICKBOOKS_CLIENT_ID = process.env.QUICKBOOKS_CLIENT_ID || ''
 const QUICKBOOKS_REDIRECT_URI = process.env.QUICKBOOKS_REDIRECT_URI || ''
 
-const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.taskiguana.com'
+const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.taskiguana.com'
 
 function getSupabaseAdmin() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -5,7 +5,7 @@
 
 Complete list of Task Iguana API endpoints, auto-generated from source code.
 
-**Base URL:** `https://app.taskiguana.com` (production) or `http://localhost:3000` (local dev)
+**Base URL:** `https://www.taskiguana.com` (production) or `http://localhost:3000` (local dev)
 
 ---
 


### PR DESCRIPTION
## Why
The canonical production host is **`www.taskiguana.com`** — that's the value of `NEXT_PUBLIC_APP_URL` in Netlify (confirmed in the dashboard), and the apex `taskiguana.com` redirects to it. Earlier cleanup unified some fallbacks to the bare apex, which was the **wrong direction**. This points every host fallback at `www.taskiguana.com` so code, tests, docs, and the local-run re-sync script all match the real serving host.

## Change — all host fallbacks → `www.taskiguana.com`
- `jenny-pro/provision-number` + `port-status` `baseUrl()` fallbacks
- `scripts/resync-twilio-webhooks.js` target-host fallback
- Google Calendar + QuickBooks OAuth `SITE_URL` fallbacks (the redirect_uri host)
- customer-portal + jenny-actions fallbacks
- `.env.example`, wiki API base URL, smoke-test example
- Jenny provisioning/wire test expectations

The Google Calendar setup docs already specify the `www` redirect URI, so they're unchanged.

## Why the re-sync script default actually matters here
When you run `scripts/resync-twilio-webhooks.js` **locally**, `PUBLIC_BASE_URL`/`URL`/`NEXT_PUBLIC_SITE_URL` are unset, so it uses the hardcoded fallback. With the apex fallback it would have set your Twilio numbers to `https://taskiguana.com/...` — a host that only *redirects* to www, and Twilio does **not** follow redirects on webhook POSTs, so inbound calls/texts would break. Pointing the fallback at `www.taskiguana.com` (the host that actually serves the routes) fixes that. (You can still override with `--base=`.)

## Config reminders (unchanged by code)
- **Google Cloud Console** redirect URI: `https://www.taskiguana.com/api/google-calendar/callback`
- **A2P Brand + Campaign website**: `https://www.taskiguana.com`
- Optionally set `PUBLIC_BASE_URL=https://www.taskiguana.com` in Netlify.

## Testing
- Full suite — 562 tests pass
- `npm run build` — passes
- `node --check` on the re-sync script — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ