### PR TITLE
Fix off-by-one dates app-wide (UTC vs local parsing of DATE fields)

### DIFF
--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -369,7 +369,7 @@ function InvoicesContent() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           to: phone,
-          customMessage: `Hi ${invoice.customer?.name}, this is a friendly reminder that invoice ${invoice.invoice_number || `INV-${invoice.id.slice(0, 8)}`} for $${invoice.total.toLocaleString()} is due${invoice.due_date ? ` on ${new Date(invoice.due_date).toLocaleDateString()}` : ''}. Please contact us if you have any questions.`,
+          customMessage: `Hi ${invoice.customer?.name}, this is a friendly reminder that invoice ${invoice.invoice_number || `INV-${invoice.id.slice(0, 8)}`} for $${invoice.total.toLocaleString()} is due${invoice.due_date ? ` on ${new Date(invoice.due_date + 'T00:00:00').toLocaleDateString()}` : ''}. Please contact us if you have any questions.`,
           companyId,
           customerId: invoice.customer?.id,
         }),
@@ -573,7 +573,7 @@ function InvoicesContent() {
                       </span>
                     </td>
                     <td className="px-6 py-4 text-sm text-gray-500">
-                      {invoice.due_date ? new Date(invoice.due_date).toLocaleDateString() : '-'}
+                      {invoice.due_date ? new Date(invoice.due_date + 'T00:00:00').toLocaleDateString() : '-'}
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex gap-2">

--- a/src/app/dashboard/payment-plans/page.tsx
+++ b/src/app/dashboard/payment-plans/page.tsx
@@ -353,7 +353,7 @@ export default function PaymentPlansPage() {
                             )}
                             <div>
                               <p className="text-sm font-medium">Installment {inst.installment_number}</p>
-                              <p className="text-xs text-gray-500">Due {new Date(inst.due_date).toLocaleDateString()}</p>
+                              <p className="text-xs text-gray-500">Due {new Date(inst.due_date + 'T00:00:00').toLocaleDateString()}</p>
                             </div>
                           </div>
                           <div className="flex items-center gap-3">

--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -7,6 +7,20 @@ import Link from 'next/link'
 import { useAuth } from '@/contexts/AuthContext'
 import JennyReschedule from '@/components/JennyReschedule'
 
+// Dates are handled as local "YYYY-MM-DD" strings. `new Date("YYYY-MM-DD")`
+// parses as UTC midnight, which renders as the PREVIOUS day in timezones behind
+// UTC (e.g. US Pacific), so parse/format in LOCAL time instead.
+function parseLocalDate(s: string): Date {
+  const [y, m, d] = s.split('-').map(Number)
+  return new Date(y, m - 1, d)
+}
+function toISODate(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
 interface Job {
   id: string
   title: string
@@ -22,7 +36,7 @@ interface Job {
 export default function SchedulePage() {
   const [jobs, setJobs] = useState<Job[]>([])
   const [loading, setLoading] = useState(true)
-  const [selectedDate, setSelectedDate] = useState(new Date().toISOString().split('T')[0])
+  const [selectedDate, setSelectedDate] = useState(toISODate(new Date()))
   const [viewMode, setViewMode] = useState<'day' | 'week'>('day')
 
   const router = useRouter()
@@ -38,12 +52,12 @@ export default function SchedulePage() {
     let endDate = date
 
     if (viewMode === 'week') {
-      const d = new Date(date)
+      const d = parseLocalDate(date)
       const day = d.getDay()
       const weekStart = new Date(d.getFullYear(), d.getMonth(), d.getDate() - day)
       const weekEnd = new Date(d.getFullYear(), d.getMonth(), d.getDate() - day + 6)
-      startDate = weekStart.toISOString().split('T')[0]
-      endDate = weekEnd.toISOString().split('T')[0]
+      startDate = toISODate(weekStart)
+      endDate = toISODate(weekEnd)
     }
 
     const { data, error } = await supabase
@@ -92,13 +106,13 @@ export default function SchedulePage() {
   }, [selectedDate, viewMode, companyId, fetchJobs])
 
   const changeDate = (days: number) => {
-    const newDate = new Date(selectedDate)
+    const newDate = parseLocalDate(selectedDate)
     newDate.setDate(newDate.getDate() + days)
-    setSelectedDate(newDate.toISOString().split('T')[0])
+    setSelectedDate(toISODate(newDate))
   }
 
   const goToToday = () => {
-    setSelectedDate(new Date().toISOString().split('T')[0])
+    setSelectedDate(toISODate(new Date()))
   }
 
   const statusColors: Record<string, string> = {
@@ -118,7 +132,7 @@ export default function SchedulePage() {
   }
 
   const formatDate = (date: string) => {
-    return new Date(date).toLocaleDateString('en-US', {
+    return parseLocalDate(date).toLocaleDateString('en-US', {
       weekday: 'long',
       month: 'long',
       day: 'numeric',
@@ -296,12 +310,12 @@ export default function SchedulePage() {
         // Week View
         <div className="grid grid-cols-7 gap-2">
           {Array.from({ length: 7 }).map((_, i) => {
-            const base = new Date(selectedDate)
+            const base = parseLocalDate(selectedDate)
             const day = base.getDay()
             const date = new Date(base.getFullYear(), base.getMonth(), base.getDate() - day + i)
-            const dateStr = date.toISOString().split('T')[0]
+            const dateStr = toISODate(date)
             const dayJobs = jobsByDate[dateStr] || []
-            const isToday = dateStr === new Date().toISOString().split('T')[0]
+            const isToday = dateStr === toISODate(new Date())
 
             return (
               <div key={i} className={`bg-white rounded-lg border min-h-[200px] ${isToday ? 'ring-2 ring-blue-500' : ''}`}>

--- a/src/app/invoice/[id]/InvoiceViewClient.tsx
+++ b/src/app/invoice/[id]/InvoiceViewClient.tsx
@@ -140,7 +140,11 @@ export default function InvoiceViewClient({ params }: { params: { id: string } }
 
   const formatDate = (dateStr: string | null) => {
     if (!dateStr) return 'N/A';
-    return new Date(dateStr).toLocaleDateString('en-US', {
+    // due_date is a DATE column ('YYYY-MM-DD'); new Date() parses it as UTC
+    // midnight and renders a day early in timezones behind UTC. Append a local
+    // time for date-only strings; leave full timestamps (created_at) untouched.
+    const d = /^\d{4}-\d{2}-\d{2}$/.test(dateStr) ? new Date(dateStr + 'T00:00:00') : new Date(dateStr);
+    return d.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',

--- a/src/app/portal/invoices/page.tsx
+++ b/src/app/portal/invoices/page.tsx
@@ -138,7 +138,7 @@ export default function PortalInvoices() {
                         <p>{t('sent', { date: new Date(inv.sent_at).toLocaleDateString() })}</p>
                       )}
                       {inv.due_date && inv.status !== 'paid' && (
-                        <p>{t('due', { date: new Date(inv.due_date).toLocaleDateString() })}</p>
+                        <p>{t('due', { date: new Date(inv.due_date + 'T00:00:00').toLocaleDateString() })}</p>
                       )}
                       {inv.paid_at && (
                         <p className="text-green-600">{t('paidDate', { date: new Date(inv.paid_at).toLocaleDateString() })}</p>

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -138,7 +138,7 @@ export default function PortalDashboard() {
                   <div>
                     <p className="font-medium text-gray-900">{t('invoiceNumber', { number: inv.invoice_number })}</p>
                     <p className="text-xs text-gray-500">
-                      {inv.due_date ? t('dueDate', { date: new Date(inv.due_date).toLocaleDateString() }) : t('noDueDate')}
+                      {inv.due_date ? t('dueDate', { date: new Date(inv.due_date + 'T00:00:00').toLocaleDateString() }) : t('noDueDate')}
                     </p>
                   </div>
                 </div>

--- a/src/app/quote/[id]/QuoteViewClient.tsx
+++ b/src/app/quote/[id]/QuoteViewClient.tsx
@@ -325,7 +325,11 @@ export default function CustomerQuoteView({ quoteId }: { quoteId: string }) {
   // Format date
   const formatDate = (dateStr: string | null) => {
     if (!dateStr) return 'N/A';
-    return new Date(dateStr).toLocaleDateString('en-US', {
+    // valid_until is a DATE column ('YYYY-MM-DD'); new Date() parses it as UTC
+    // midnight and renders a day early in timezones behind UTC. Append a local
+    // time for date-only strings; leave full timestamps (created_at) untouched.
+    const d = /^\d{4}-\d{2}-\d{2}$/.test(dateStr) ? new Date(dateStr + 'T00:00:00') : new Date(dateStr);
+    return d.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',


### PR DESCRIPTION
## Bug (found in QA)
The Schedule page date picker set to `07/31/2026` displayed **"Thursday, July 30, 2026"** — one day behind — while Route Optimizer showed the same date correctly as "Friday, July 31." A scan found the same class of bug on several **`DATE`-column** displays (invoice/quote/payment due dates).

## Cause
`DATE` columns come back as `"YYYY-MM-DD"` strings. `new Date("YYYY-MM-DD")` parses as **UTC midnight**, which renders as the **previous day** in timezones behind UTC (the test data is Newark, CA → US Pacific).

## Fix
**Schedule page** (`dashboard/schedule/page.tsx`): added `parseLocalDate()` / `toISODate()` helpers and used them for the header, day/week navigation, the week fetch range, week-grid keys, and the initial date.

**Invoice / quote / payment due dates** (`DATE` columns `invoices.due_date`, `quotes.valid_until`, `payment_plan_installments.due_date`):
- `InvoiceViewClient` / `QuoteViewClient` `formatDate`: parse date-only strings as local (append `T00:00:00`); full timestamps like `created_at` are left untouched via a `YYYY-MM-DD` regex check.
- `dashboard/invoices`, `dashboard/payment-plans`, `portal/invoices`, `portal` home: append `T00:00:00` to the `due_date` render, matching the convention already used for `scheduled_date` across the app.

## Not changed
`TIMESTAMP`/`TIMESTAMPTZ` fields (`sms_consent_date`, `next_review_date`) carry a time component and parse correctly, so they're left as-is. Pages already appending `T00:00:00` (jobs, recurring-jobs, booking, most portal pages) were already correct.

## Testing
- Full suite — 562 tests pass
- `npm run build` — passes, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ