### PR TITLE
rebrand: fix Shield demo lead tag "Compliance Shield" → "Task Iguana Shield"

### DIFF
--- a/src/app/demo/shield/page.tsx
+++ b/src/app/demo/shield/page.tsx
@@ -455,7 +455,7 @@ export default function ShieldDemoPage() {
           </div>
         )}
 
-        <DemoLeadCapture featureName="Compliance Shield" source="shield_demo" />
+        <DemoLeadCapture featureName="Task Iguana Shield" source="shield_demo" />
 
         {/* Bottom CTA */}
         <div className="mt-8 bg-gradient-to-r from-[#0A0C11] to-[#2d2d4a] rounded-2xl p-8 text-center text-white">


### PR DESCRIPTION
## Summary

The rebrand to **Task Iguana** was already completed on `main` (via #659). While reconciling, one leftover inconsistency remained: the **Shield demo page's lead-capture form** tagged leads with `featureName="Compliance Shield"` (`src/app/demo/shield/page.tsx:458`), out of step with the product name **"Task Iguana Shield"** used everywhere else.

## Change
- `src/app/demo/shield/page.tsx`: `featureName="Compliance Shield"` → `"Task Iguana Shield"`, so leads from that demo are attributed to the correct product name.

## Testing
- `npm run build` ✓ · `npm test` ✓ (562 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk

---
_Generated by [Claude Code](https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk)_