### PR TITLE
fix(portal): show customer a "reschedule pending" state (#49/#50/#51)

### DIFF
--- a/messages/en/portal.json
+++ b/messages/en/portal.json
@@ -100,7 +100,9 @@
       "sending": "Sending...",
       "requestSent": "Request Sent!",
       "confirmNewTime": "We'll confirm your new time shortly.",
-      "loading": "Loading appointments..."
+      "loading": "Loading appointments...",
+      "reschedulePending": "Reschedule requested — pending confirmation",
+      "reschedulePendingDate": "You asked to move this to {date}. We’ll confirm shortly."
     },
     "messages": {
       "title": "Messages",
@@ -147,7 +149,8 @@
       "live": "Live",
       "crew": "Crew: {members}",
       "updates": "Updates",
-      "loading": "Loading tracker..."
+      "loading": "Loading tracker...",
+      "reschedulePending": "Reschedule requested — pending confirmation"
     },
     "documents": {
       "title": "Documents",

--- a/messages/es/portal.json
+++ b/messages/es/portal.json
@@ -100,7 +100,9 @@
       "sending": "Enviando...",
       "requestSent": "¡Solicitud enviada!",
       "confirmNewTime": "Confirmaremos tu nuevo horario pronto.",
-      "loading": "Cargando citas..."
+      "loading": "Cargando citas...",
+      "reschedulePending": "Cambio de fecha solicitado — pendiente de confirmación",
+      "reschedulePendingDate": "Solicitaste cambiarlo al {date}. Lo confirmaremos pronto."
     },
     "messages": {
       "title": "Mensajes",
@@ -147,7 +149,8 @@
       "live": "En vivo",
       "crew": "Equipo: {members}",
       "updates": "Actualizaciones",
-      "loading": "Cargando rastreo..."
+      "loading": "Cargando rastreo...",
+      "reschedulePending": "Cambio de fecha solicitado — pendiente"
     },
     "documents": {
       "title": "Documentos",

--- a/src/app/api/portal/route.ts
+++ b/src/app/api/portal/route.ts
@@ -181,6 +181,34 @@ export async function GET(request: NextRequest) {
       .in('status', ['scheduled', 'in_progress'])
       .order('scheduled_date', { ascending: true });
 
+    // Flag jobs with a pending reschedule request so the customer's own view
+    // reflects that their request is in flight (Bugs #50/#51) instead of still
+    // showing the appointment as plainly "confirmed".
+    const upcomingIds = (jobs || []).map((j) => j.id);
+    const pendingByJob: Record<string, { requested_date: string; requested_time_start: string | null }> = {};
+    if (upcomingIds.length > 0) {
+      const { data: pending } = await (supabase as any)
+        .from('reschedule_requests')
+        .select('job_id, requested_date, requested_time_start, created_at')
+        .eq('customer_id', session.customer_id)
+        .eq('status', 'pending')
+        .in('job_id', upcomingIds)
+        .order('created_at', { ascending: false });
+      for (const r of (pending || []) as { job_id: string; requested_date: string; requested_time_start: string | null }[]) {
+        // Keep the most recent pending request per job (ordered desc above)
+        if (!pendingByJob[r.job_id]) {
+          pendingByJob[r.job_id] = { requested_date: r.requested_date, requested_time_start: r.requested_time_start };
+        }
+      }
+    }
+
+    const upcoming = (jobs || []).map((j) => ({
+      ...j,
+      reschedule_pending: !!pendingByJob[j.id],
+      reschedule_requested_date: pendingByJob[j.id]?.requested_date ?? null,
+      reschedule_requested_time: pendingByJob[j.id]?.requested_time_start ?? null,
+    }));
+
     const { data: pastJobs } = await supabase
       .from('jobs')
       .select('id, title, scheduled_date, status, total_amount')
@@ -190,7 +218,7 @@ export async function GET(request: NextRequest) {
       .order('scheduled_date', { ascending: false })
       .limit(10);
 
-    return NextResponse.json({ upcoming: jobs || [], past: pastJobs || [] });
+    return NextResponse.json({ upcoming, past: pastJobs || [] });
   }
 
   // Fetch invoices
@@ -253,6 +281,19 @@ export async function GET(request: NextRequest) {
       latestNotes = data || [];
     }
 
+    // Pending reschedule requests, so the tracker reflects that a change was
+    // requested rather than still reading as "confirmed" (Bug #51).
+    const pendingReschedule = new Set<string>();
+    if (jobIds.length > 0) {
+      const { data } = await (supabase as any)
+        .from('reschedule_requests')
+        .select('job_id')
+        .eq('customer_id', session.customer_id)
+        .eq('status', 'pending')
+        .in('job_id', jobIds);
+      for (const r of (data || []) as { job_id: string }[]) pendingReschedule.add(r.job_id);
+    }
+
     // Merge crew + notes into jobs
     const enrichedJobs = (activeJobs || []).map((job: { id: string }) => {
       const crew = assignments
@@ -262,7 +303,7 @@ export async function GET(request: NextRequest) {
           return user?.full_name || 'Team member';
         });
       const notes = latestNotes.filter(n => n.job_id === job.id).slice(0, 3);
-      return { ...job, crew, statusUpdates: notes };
+      return { ...job, crew, statusUpdates: notes, reschedule_pending: pendingReschedule.has(job.id) };
     });
 
     return NextResponse.json({ jobs: enrichedJobs });

--- a/src/app/portal/appointments/page.tsx
+++ b/src/app/portal/appointments/page.tsx
@@ -22,6 +22,9 @@ interface Job {
   scheduled_time_end: string | null;
   status: string;
   address: string | null;
+  reschedule_pending?: boolean;
+  reschedule_requested_date?: string | null;
+  reschedule_requested_time?: string | null;
 }
 
 interface PastJob {
@@ -149,7 +152,21 @@ export default function PortalAppointments() {
                   )}
                 </div>
 
-                {job.status === 'scheduled' && (
+                {job.reschedule_pending ? (
+                  <div className="mt-4 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
+                    <CalendarClock className="w-4 h-4 text-amber-600 mt-0.5 flex-shrink-0" />
+                    <div className="text-sm">
+                      <p className="font-medium text-amber-800">{t('reschedulePending')}</p>
+                      {job.reschedule_requested_date && (
+                        <p className="text-amber-700">
+                          {t('reschedulePendingDate', {
+                            date: new Date(job.reschedule_requested_date + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }),
+                          })}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ) : job.status === 'scheduled' ? (
                   <button
                     onClick={() => setRescheduleJob(job)}
                     className="mt-4 text-sm text-blue-600 font-medium flex items-center gap-1 hover:text-blue-700"
@@ -157,7 +174,7 @@ export default function PortalAppointments() {
                     <CalendarClock className="w-4 h-4" />
                     {t('requestReschedule')}
                   </button>
-                )}
+                ) : null}
               </div>
             ))}
           </div>

--- a/src/app/portal/tracker/page.tsx
+++ b/src/app/portal/tracker/page.tsx
@@ -31,6 +31,7 @@ interface TrackedJob {
   state: string | null;
   crew: string[];
   statusUpdates: StatusUpdate[];
+  reschedule_pending?: boolean;
 }
 
 export default function PortalTracker() {
@@ -108,6 +109,13 @@ export default function PortalTracker() {
                       {job.scheduled_time_start && ` at ${job.scheduled_time_start}`}
                       {job.scheduled_time_end && ` — ${job.scheduled_time_end}`}
                     </div>
+
+                    {job.reschedule_pending && (
+                      <div className="inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-800">
+                        <Calendar className="w-3.5 h-3.5" />
+                        {t('reschedulePending')}
+                      </div>
+                    )}
 
                     {job.address && (
                       <div className="flex items-center gap-2 text-sm text-gray-600">


### PR DESCRIPTION
## Summary

Completes the reschedule loop. After a customer requested a reschedule, **their own views still showed the appointment as plainly "confirmed"** — nothing signalled the request was in flight, so it looked like nothing happened (#50/#51).

## Changes
- **Appointments API** (`action=appointments`): flag each upcoming job that has a `pending` `reschedule_requests` row, with the requested date.
- **Appointments page**: show a **"Reschedule requested — pending confirmation"** badge (with the requested date) in place of the Request-reschedule button while a request is pending — so the customer sees their request landed and can't silently re-request.
- **Tracker API + page**: surface the same pending badge, so the tracker no longer reads as "confirmed" (#51).
- New i18n keys in **en + es**.

Pairs with the earlier **owner-notification** fix (#52/#65) to close the reschedule flow end-to-end: customer requests → customer sees "pending" → owner gets notified.

## Testing
- `npm run build` ✓ · `npm run lint` ✓ · `npm test` ✓ (562 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk

---
_Generated by [Claude Code](https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk)_