### PR TITLE
fix(portal): paid-invoice balance (#101) + messages empty state (#59)

### DIFF
--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -172,13 +172,18 @@ function InvoicesContent() {
 
   const updateInvoiceStatus = async (invoiceId: string, newStatus: string) => {
     try {
-      const updates: { status: string; updated_at: string; paid_at?: string } = {
+      const updates: { status: string; updated_at: string; paid_at?: string; amount_paid?: number } = {
         status: newStatus,
         updated_at: new Date().toISOString()
       }
 
       if (newStatus === 'paid') {
         updates.paid_at = new Date().toISOString()
+        // Mark the invoice fully paid so balance (total - amount_paid) reads $0
+        // everywhere (portal, invoice detail). Without this, a manually-paid
+        // invoice kept amount_paid = 0 and still showed the full total owed.
+        const inv = invoices.find(i => i.id === invoiceId)
+        if (inv) updates.amount_paid = inv.total
       }
 
       const { error } = await supabase.from('invoices').update(updates).eq('id', invoiceId)

--- a/src/app/portal/invoices/page.tsx
+++ b/src/app/portal/invoices/page.tsx
@@ -120,7 +120,9 @@ export default function PortalInvoices() {
           {filtered.map(inv => {
             const badge = getStatusBadge(inv);
             const StatusIcon = badge.icon;
-            const balance = inv.total - inv.amount_paid;
+            // A paid invoice always reads $0 owed, even if amount_paid wasn't
+            // backfilled on older records.
+            const balance = inv.status === 'paid' ? 0 : inv.total - inv.amount_paid;
             const canPay = ['sent', 'viewed', 'partial', 'overdue'].includes(inv.status) && balance > 0;
 
             return (

--- a/src/app/portal/messages/page.tsx
+++ b/src/app/portal/messages/page.tsx
@@ -141,13 +141,13 @@ export default function PortalMessages() {
           )}
         </div>
 
-        {threads.length === 0 ? (
+        {threads.length === 0 && jobs.length === 0 ? (
           <div className="bg-white rounded-xl p-8 shadow-sm text-center">
             <MessageSquare className="w-10 h-10 text-gray-300 mx-auto mb-3" />
             <h3 className="font-medium text-gray-700">{t('noMessages')}</h3>
             <p className="text-sm text-gray-500 mt-1">{t('noMessagesDescription')}</p>
           </div>
-        ) : (
+        ) : threads.length > 0 ? (
           <div className="space-y-2">
             {threads.map(([key, thread]) => (
               <button
@@ -177,7 +177,7 @@ export default function PortalMessages() {
               </button>
             ))}
           </div>
-        )}
+        ) : null}
 
         {/* Start new message if there are jobs */}
         {jobs.length > 0 && threads.length === 0 && (


### PR DESCRIPTION
## Summary

Two portal fixes.

### #101 — Paid-invoice balance inconsistent with the invoice amount
The dashboard **"Mark as Paid"** set `status='paid'` and `paid_at` but **never updated `amount_paid`**. Since balance is computed as `total - amount_paid` everywhere (portal invoice list, portal home, invoice detail), a manually-paid invoice kept `amount_paid = 0` and still showed the **full total owed** — a "Paid" invoice with a non-zero balance. (The Stripe payment path already set `amount_paid` correctly; only the manual path was broken.)
- `dashboard/invoices`: `updateInvoiceStatus` now sets `amount_paid = invoice.total` when marking paid (covers both the button and the status dropdown).
- `portal/invoices`: a `paid` invoice displays **$0 owed** even if `amount_paid` was never backfilled on older records.

**Optional data cleanup** for existing records marked paid the old way:
```sql
UPDATE public.invoices SET amount_paid = total WHERE status = 'paid' AND amount_paid < total;
```

### #59 — Messages "No messages yet" while conversations present
The page showed a dead-end **"No messages yet"** card *and* a "start a conversation" card simultaneously — contradictory. Now the dead-end card only appears when there are genuinely no jobs to message about; otherwise the start-a-conversation card stands on its own.

## Testing
- `npm run build` ✓ · `npm run lint` ✓ · `npm test` ✓ (562 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk

---
_Generated by [Claude Code](https://claude.ai/code/session_0159ehES8Qig4F2ixiHt1vCk)_