### PR TITLE
Align /sms and /privacy with Task Iguana brand for A2P resubmission

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -31,8 +31,7 @@ export default function PrivacyPolicyPage() {
             <h2 className="text-xl font-bold mb-3">1. Introduction</h2>
             <p>
               Task Iguana (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) operates the taskiguana.com website and the Task Iguana
-              platform. Task Iguana was formerly known as ToolTime Pro, and our SMS/A2P messaging program remains
-              registered under that prior name. This Privacy Policy explains how we collect, use, disclose, and
+              platform. This Privacy Policy explains how we collect, use, disclose, and
               safeguard your information when you use our services.
             </p>
           </section>

--- a/src/app/sms/page.tsx
+++ b/src/app/sms/page.tsx
@@ -32,9 +32,9 @@ export default function SmsPage() {
             <p>Task Iguana Service Notifications</p>
             <p className="mt-2 text-sm text-[#0A0C11]/70">
               Task Iguana is the field-service management platform at{' '}
-              <a href="https://taskiguana.com" className="text-[#1FE3C4] underline">taskiguana.com</a>,
-              formerly known as ToolTime Pro. Our A2P messaging brand remains registered
-              under the prior name, ToolTime Pro.
+              <a href="https://taskiguana.com" className="text-[#1FE3C4] underline">taskiguana.com</a>.
+              All SMS messages, opt-in/opt-out flows, Privacy Policy, and Terms &amp; Conditions
+              are operated under the Task Iguana brand.
             </p>
           </section>
 


### PR DESCRIPTION
## Summary

Twilio's A2P 10DLC campaign reviewer (ticket #27622483) rejected the last submission because our opt-in and privacy pages contradicted the Business Profile: both stated that the A2P messaging brand "remains registered under the prior name, ToolTime Pro" while the Brand website, Business Profile, and rest of the site say Task Iguana.

This PR removes those two sentences so brand name, website URL, opt-in page, Privacy Policy, and Terms & Conditions all consistently reference **Task Iguana** at **taskiguana.com** — the alignment Sanjeev asked for.

- `src/app/sms/page.tsx` — dropped the "our A2P messaging brand remains registered under the prior name, ToolTime Pro" sentence from the program-name section
- `src/app/privacy/page.tsx` — dropped the "our SMS/A2P messaging program remains registered under that prior name" sentence from the introduction

Everything else the reviewer's checklist requires was already in place: `/sms` displays the business name, links to Privacy Policy + Terms, and gives clear STOP/HELP opt-out instructions; the 2FA setup form's consent language matches what `/sms` quotes; and the outgoing 2FA SMS body matches the sample messages on `/sms`.

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] Visit `/sms` on the deployed preview — confirm no "ToolTime Pro" references remain
- [ ] Visit `/privacy` — confirm no "ToolTime Pro" references remain
- [ ] `/terms` unchanged — already Task Iguana
- [ ] Submit the fresh A2P campaign in Twilio Console pointing reviewers at `https://www.taskiguana.com/sms`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vata9Ccd4x4uduWEuGyhWc)_