### PR TITLE
Use Shield Iguana crest on the demo Shield hero

### DIFF
--- a/src/app/demo/shield/page.tsx
+++ b/src/app/demo/shield/page.tsx
@@ -85,7 +85,8 @@ export default function ShieldDemoPage() {
             ← {t('backToHome')}
           </Link>
           <div className="flex items-center gap-3 mb-2">
-            <span className="text-4xl">🛡️</span>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="/shield-iguana.svg" alt="Shield Iguana" className="w-11 h-11" />
             <h1 className="text-3xl font-bold text-white">{t('title')}</h1>
             <div className="ml-auto"><LanguageSwitcher /></div>
           </div>


### PR DESCRIPTION
## Why
The demo Shield page hero (`/demo/shield`, "Shield Iguana Demo") still shows the old 🛡️ emoji in prod. The dashboard Shield page got the crest in #664, but this demo-hero change landed just after that PR merged, so it never made it into main.

## Change
Replaces the `🛡️` emoji in `src/app/demo/shield/page.tsx` with the on-brand crest mark (`public/shield-iguana.svg`, already in main from #664) — matching the dashboard Shield header.

## Verified
Rendered `public/shield-iguana.svg` in headless Chromium to confirm the gradients/pattern display correctly (the teal→blue shield, scaled hide, reptile eye, and sail crest all render).

- `npm run build` — passes, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ)_