### PR TITLE
Use Shield Iguana crest on remaining demo surfaces

### DIFF
--- a/src/app/demo/dashboard/page.tsx
+++ b/src/app/demo/dashboard/page.tsx
@@ -452,7 +452,8 @@ export default function DashboardDemoPage() {
             <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
               <div className="p-4 border-b border-gray-200 flex items-center justify-between bg-gradient-to-r from-green-50 to-emerald-50">
                 <div className="flex items-center gap-2">
-                  <span className="text-lg">🛡️</span>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src="/shield-iguana.svg" alt="" className="w-6 h-6" />
                   <h2 className="font-bold text-[#0A0C11]">{t('toolTimeShield')}</h2>
                 </div>
                 <Link href="/demo/shield" className="text-sm text-blue-600 font-medium no-underline hover:underline">{t('viewAll')} →</Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -593,7 +593,14 @@ export default function Home() {
                     {card.badge}
                   </span>
                 )}
-                <div className="text-[2.5rem] mb-3">{card.icon}</div>
+                <div className="mb-3 text-[2.5rem] flex items-center justify-center">
+                  {card.href === '/demo/shield' ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src="/shield-iguana.svg" alt="" className="h-10 w-10" />
+                  ) : (
+                    card.icon
+                  )}
+                </div>
                 <h3 className="text-[1.125rem] font-extrabold text-white mb-2">{card.name}</h3>
                 <p className="text-[0.875rem] text-[#8e8e9f] leading-relaxed mb-3">{card.description}</p>
                 <span className="text-[#1FE3C4] font-semibold text-[0.875rem] group-hover:underline">{t('tryDemo')} →</span>


### PR DESCRIPTION
## Why
A couple of Shield Iguana surfaces still showed the old 🛡️ emoji while the dashboard/demo Shield pages use the crest.

## Changes — swap emoji → crest (`public/shield-iguana.svg`)
- `src/app/page.tsx` — the Shield Iguana card in the homepage demo grid
- `src/app/demo/dashboard/page.tsx` — the "Shield Iguana" compliance card header

## Left as emoji (intentional)
Small, uniform inline emoji where a detailed crest would look muddy or out of place, and consistency with neighbors matters more:
- Demo dashboard **sidebar nav** (a column of emoji icons)
- Homepage **feature-badge pills** (tiny inline "🛡️ Legal Protection" text)
- The **static marketing site** (`tooltimepro/index.html`) — separate deploy, tiny emoji/CSS bullets

## Testing
- `npm run build` — passes, lint clean on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ