### PR TITLE
Harden 3 save paths against missing-column (schema drift) failures

### DIFF
--- a/src/app/api/jenny-pro/settings/route.js
+++ b/src/app/api/jenny-pro/settings/route.js
@@ -73,27 +73,42 @@ export async function POST(request) {
     review_followup_enabled,
   } = body;
 
-  const { data, error } = await supabase
+  const settingsPayload = {
+    company_id: dbUser.company_id,
+    business_hours_greeting,
+    after_hours_greeting,
+    emergency_keywords,
+    escalation_phone,
+    language,
+    operator_language,
+    auto_booking,
+    business_info,
+    reminders_enabled,
+    review_followup_enabled,
+    updated_at: new Date().toISOString(),
+  };
+
+  let { data, error } = await supabase
     .from('jenny_pro_settings')
-    .upsert(
-      {
-        company_id: dbUser.company_id,
-        business_hours_greeting,
-        after_hours_greeting,
-        emergency_keywords,
-        escalation_phone,
-        language,
-        operator_language,
-        auto_booking,
-        business_info,
-        reminders_enabled,
-        review_followup_enabled,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: 'company_id' }
-    )
+    .upsert(settingsPayload, { onConflict: 'company_id' })
     .select()
     .single();
+
+  // A DB behind on migrations 038/041/042 lacks operator_language/business_info/
+  // reminders_enabled/review_followup_enabled; strip them and retry so settings
+  // still save.
+  if (error && (error.code === '42703' || /operator_language|business_info|reminders_enabled|review_followup_enabled/.test(error.message || ''))) {
+    const retry = { ...settingsPayload };
+    delete retry.operator_language;
+    delete retry.business_info;
+    delete retry.reminders_enabled;
+    delete retry.review_followup_enabled;
+    ({ data, error } = await supabase
+      .from('jenny_pro_settings')
+      .upsert(retry, { onConflict: 'company_id' })
+      .select()
+      .single());
+  }
 
   if (error) {
     console.error('[Jenny Pro Settings] Error:', error);

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -1170,10 +1170,22 @@ function TeamMemberModal({ member, companyId, callerRole, onClose, onSave }: {
         updateData.admin_permissions = null
       }
 
-      const { error } = await supabase
+      let { error } = await supabase
         .from('users')
         .update(updateData)
         .eq('id', member.id)
+
+      // A DB behind on migration 045 lacks notes/home_address/home_city (and
+      // admin_permissions); strip the optional columns and retry so the core
+      // edit still saves.
+      if (error && (error.code === '42703' || /notes|home_address|home_city|admin_permissions/.test(error.message || ''))) {
+        const retryData = { ...updateData }
+        delete retryData.notes
+        delete retryData.home_address
+        delete retryData.home_city
+        delete retryData.admin_permissions
+        ;({ error } = await supabase.from('users').update(retryData).eq('id', member.id))
+      }
 
       if (error) {
         console.error('Error updating team member:', error)

--- a/src/app/worker/timeclock/page.tsx
+++ b/src/app/worker/timeclock/page.tsx
@@ -196,15 +196,25 @@ export default function TimeclockPage() {
     const clockInTime = new Date(currentEntry.clock_in)
     const totalHours = (clockOutTime.getTime() - clockInTime.getTime()) / (1000 * 60 * 60)
 
-    const { error } = await supabase
+    const clockOutData: Record<string, unknown> = {
+      clock_out: clockOutTime.toISOString(),
+      clock_out_location: location,
+      total_hours: Math.round(totalHours * 100) / 100,
+      status: 'completed',
+    }
+
+    let { error } = await supabase
       .from('time_entries')
-      .update({
-        clock_out: clockOutTime.toISOString(),
-        clock_out_location: location,
-        total_hours: Math.round(totalHours * 100) / 100,
-        status: 'completed',
-      })
+      .update(clockOutData)
       .eq('id', currentEntry.id)
+
+    // A DB behind on migration 046 lacks time_entries.total_hours; strip it and
+    // retry so the worker can still clock out.
+    if (error && (error.code === '42703' || /total_hours/.test(error.message || ''))) {
+      const retryData = { ...clockOutData }
+      delete retryData.total_hours
+      ;({ error } = await supabase.from('time_entries').update(retryData).eq('id', currentEntry.id))
+    }
 
     if (error) {
       alert('Failed to clock out: ' + error.message)


### PR DESCRIPTION
Follow-up to the QA sweep (#667). The schema-drift auditor found three save paths that write recently-added columns via a direct Supabase call with **no missing-column fallback**, so they hard-fail with `42703` on any DB behind on migrations — the same class as the already-fixed quote-edit and team-create bugs.

## Fixes — add strip-and-retry (matching the existing pattern)
1. **Team-member EDIT** (`dashboard/team/page.tsx`) — `users.notes` / `home_address` / `home_city` / `admin_permissions` (mig 045). The *create* path already retried; *edit* didn't.
2. **Worker clock-out** (`worker/timeclock/page.tsx`) — `time_entries.total_hours` (mig 046). A behind DB blocked clock-out entirely; now it clocks out and just skips the computed total.
3. **Jenny Pro settings save** (`api/jenny-pro/settings/route.js`) — `operator_language` (038), `business_info` (041), `reminders_enabled` / `review_followup_enabled` (042).

Each catches `42703` (or the column name), strips the optional columns, and retries so the core save still succeeds.

## Note
SBX and prod already have migrations 038–046 applied, so these paths work there today — this is resilience for **new/future environments** (fresh sandbox, rebuilt prod, local dev, or code shipping ahead of a migration), closing the whole schema-drift class.

## Testing
- `npm run build` — passes
- 562 tests pass; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ)_