### PR TITLE
Fix dispatch time formatter showing "12:undefined"

### DIFF
--- a/src/app/dashboard/dispatch/page.tsx
+++ b/src/app/dashboard/dispatch/page.tsx
@@ -34,11 +34,12 @@ const WORKER_STATUS_CONFIG: Record<string, { label: string; color: string }> = {
 
 function formatTime(timeStr: string | null): string {
   if (!timeStr) return '';
-  const [hours, minutes] = timeStr.split(':');
+  const [hours, minutes = '00'] = timeStr.split(':');
   const hour = parseInt(hours);
+  if (Number.isNaN(hour)) return timeStr;
   const ampm = hour >= 12 ? 'PM' : 'AM';
   const displayHour = hour % 12 || 12;
-  return `${displayHour}:${minutes} ${ampm}`;
+  return `${displayHour}:${(minutes || '00').slice(0, 2)} ${ampm}`;
 }
 
 function formatCurrency(amount: number | null): string {


### PR DESCRIPTION
Last mop-up item from the QA audit. The dispatch page's `formatTime` split `'HH:MM'` without guarding a missing minutes segment, so a time value stored without a colon rendered literal `12:undefined`. Now defaults minutes to `00` and guards a non-numeric hour, matching the other `formatTime` helpers in the app.

Only triggers on malformed time data, so low severity — closing it for completeness.

## Testing
- Lint clean; part of the standard build/test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J387m2eiQvRRMhJjp22WWQ)_