### PR TITLE
Warm up deployment before cypress-smoke

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -64,6 +64,23 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      - name: Warm up the deployment (avoid serverless cold-start flakiness)
+        env:
+          BASE_URL: ${{ needs.resolve-url.outputs.base_url }}
+        run: |
+          # A cold Netlify function can take >60s on first hit, which makes the
+          # Cypress smoke run flaky (and painfully slow) right after a deploy.
+          # Pre-warm the public routes the specs visit — two passes, failures
+          # ignored — so Cypress runs against already-warm pages. Best-effort:
+          # this step never fails the job.
+          paths="/ /pricing /jenny /blog /privacy /terms /industries /sms /compare /tools /tools/calculator /auth/login /auth/signup /demo/booking /demo/dashboard /demo/invoicing /quote/demo"
+          for pass in 1 2; do
+            echo "— Warm-up pass $pass —"
+            for p in $paths; do
+              code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 60 "$BASE_URL$p" || echo "ERR")
+              echo "  $p -> $code"
+            done
+          done
       - name: Run Cypress against the deployment
         uses: cypress-io/github-action@v6
         with:


### PR DESCRIPTION
## Summary

Closes the last cold-start gap in the smoke workflow. `http-smoke` was already fixed by the script's retry logic, but `cypress-smoke` still retried *into* cold Netlify functions right after a deploy — one post-merge run dragged ~37 minutes and failed, while the same commit passed on the next (warm) scheduled run.

## Change

Adds a best-effort **warm-up step** to the `cypress-smoke` job that `curl`s the public routes the specs visit (two passes, failures ignored, 60s cap per request) before Cypress runs. By the time Cypress starts, the serverless functions are warm, so the suite runs fast and reliably instead of retrying into cold starts. The warm-up never fails the job.

## Effect

- Kills the ~37-minute retry storm on cold deploys
- Makes `cypress-smoke` reliable even when run immediately after a deploy (not just on the warm daily schedule)

## Verification

`smoke.yml` validated as well-formed YAML. Full behavior is verified by running the Smoke workflow (manual dispatch or the daily schedule) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoMwQ1GFeJXBaVuAKLX16s

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoMwQ1GFeJXBaVuAKLX16s)_