### PR TITLE
Stabilize authenticated E2E and automate three more P0 QA cases

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,27 @@ jobs:
           else
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
+      - name: Warm up the deployment (avoid serverless cold-start flakiness)
+        if: steps.guard.outputs.run == 'true'
+        env:
+          BASE_URL: ${{ secrets.E2E_BASE_URL }}
+        run: |
+          # Right after a deploy every Netlify function is cold, and the first
+          # hit to a heavy page can exceed 60s. cy.login() only allows 25s to
+          # reach /dashboard, so a cold sandbox fails the `before each` hook and
+          # takes the whole authenticated suite down with it — which is exactly
+          # what happened on the Next 16 merge. Pre-warm the routes the specs
+          # visit (two passes, failures ignored, 60s cap per request) so Cypress
+          # runs against warm pages. Mirrors the same step in smoke.yml.
+          # Best-effort: this step never fails the job.
+          paths="/auth/login /dashboard /dashboard/customers /dashboard/jobs /dashboard/quotes /dashboard/invoices /quote/demo"
+          for pass in 1 2; do
+            echo "— Warm-up pass $pass —"
+            for p in $paths; do
+              code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 60 "$BASE_URL$p" || echo "ERR")
+              echo "  $p -> $code"
+            done
+          done
       - name: Cypress run (authenticated, against the sandbox)
         if: steps.guard.outputs.run == 'true'
         uses: cypress-io/github-action@v6

--- a/cypress/e2e/authenticated-flows.cy.js
+++ b/cypress/e2e/authenticated-flows.cy.js
@@ -118,8 +118,14 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
       cy.get('input[placeholder="john@email.com"]').clear().type(`${uid}@example.com`);
 
       cy.get('input[placeholder="Description"]').first().clear().type('E2E line item');
-      cy.get('input[placeholder="Qty"]').first().clear().type(`${QTY}`);
-      cy.get('input[placeholder="Price"]').first().clear().type(`${PRICE}`);
+      // `{selectall}` rather than .clear() on these two: they are controlled
+      // number inputs seeded with 1 and 0. Clearing fires onChange('') -> Number('')
+      // -> 0, which re-renders "0" back into the field with the caret at the start,
+      // so a following .type('2') lands as "20". Selecting first replaces cleanly.
+      // The value assertions keep any future regression pointing at the input
+      // rather than surfacing as a confusing totals mismatch.
+      cy.get('input[placeholder="Qty"]').first().type(`{selectall}${QTY}`).should('have.value', `${QTY}`);
+      cy.get('input[placeholder="Price"]').first().type(`{selectall}${PRICE}`).should('have.value', `${PRICE}`);
 
       // TC-QUOTE-01's core assertion: the total actually calculates.
       cy.contains('Tax (8.75%)').should('be.visible'); // fails loudly if the rate moves

--- a/cypress/e2e/authenticated-flows.cy.js
+++ b/cypress/e2e/authenticated-flows.cy.js
@@ -80,11 +80,114 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
     cy.contains(/create new invoice|new invoice/i, { timeout: 10000 }).should('be.visible');
   });
 
+  it('TC-JOB-02: scheduled times render in 12-hour AM/PM, never 24-hour', () => {
+    cy.visit('/dashboard/jobs');
+    cy.location('pathname', { timeout: 25000 }).should('include', '/dashboard/jobs');
+    // Wait for the list to settle before scraping text, so we don't assert on a
+    // skeleton. Any visible job time must read like "2:30 PM" — a 24-hour clock
+    // (13:00–23:59) is the regression this guards against.
+    cy.get('body', { timeout: 20000 }).should('be.visible');
+    cy.get('body')
+      .invoke('text')
+      .should((text) => {
+        const twentyFourHour = text.match(/\b(1[3-9]|2[0-3]):[0-5]\d\b/g);
+        expect(twentyFourHour, `24-hour times found: ${twentyFourHour}`).to.be.null;
+      });
+  });
+
+  it('TC-QUOTE-01: builds a quote, totals calculate, then self-cleans', () => {
+    // Unique per run so repeat/parallel CI runs never collide, and any rare
+    // leftover is findable by the "e2e-" prefix (same convention as TC-CUST-01).
+    const uid = `e2e-${Date.now()}-${Cypress._.random(1e9)}`;
+    const name = `E2E Quote ${uid}`;
+    const QTY = 2;
+    const PRICE = 100;
+    const SUBTOTAL = '$200.00'; // QTY * PRICE — pure math, independent of tax
+    const TOTAL = '$217.50'; // + 8.75% tax; the label assert below pins the rate
+
+    cy.visit('/dashboard/quotes');
+    cy.location('pathname', { timeout: 25000 }).should('include', '/dashboard/quotes');
+    cy.contains('button', /new quote/i, { timeout: 20000 }).click();
+    cy.contains(/quick quote/i, { timeout: 10000 }).click();
+
+    // Attach to a brand-new customer so the spec never depends on seed data.
+    cy.get('.fixed.inset-0', { timeout: 10000 }).within(() => {
+      cy.get('select').first().select('__new__');
+      cy.contains('New Customer Info').should('be.visible');
+      cy.get('input[placeholder="John Smith"]').clear().type(name);
+      cy.get('input[placeholder="john@email.com"]').clear().type(`${uid}@example.com`);
+
+      cy.get('input[placeholder="Description"]').first().clear().type('E2E line item');
+      cy.get('input[placeholder="Qty"]').first().clear().type(`${QTY}`);
+      cy.get('input[placeholder="Price"]').first().clear().type(`${PRICE}`);
+
+      // TC-QUOTE-01's core assertion: the total actually calculates.
+      cy.contains('Tax (8.75%)').should('be.visible'); // fails loudly if the rate moves
+      cy.contains(SUBTOTAL).should('be.visible');
+      cy.contains(TOTAL).should('be.visible');
+
+      // "Save Quote" only — deliberately NOT "Save & Send", which would fire a
+      // real customer email/SMS from the sandbox.
+      cy.contains('button', /^\s*save quote\s*$/i).click();
+    });
+
+    // Saved quote shows up in the list, keyed by our unique customer name.
+    cy.contains('tr', name, { timeout: 25000 }).should('exist');
+
+    // Self-cleanup: delete the quote first (FK), then the customer it created.
+    cy.on('window:confirm', () => true);
+    cy.contains('tr', name).within(() => {
+      cy.contains('button', /^\s*delete\s*$/i).click();
+    });
+    cy.contains('tr', name).should('not.exist');
+
+    cy.visit('/dashboard/customers');
+    cy.get('input[placeholder*="Search customers"]', { timeout: 20000 }).clear().type(name);
+    cy.contains(name).should('be.visible');
+    cy.contains('button', /^\s*delete\s*$/i).click();
+    cy.contains(name).should('not.exist');
+  });
+
   it('TC-SEC-06: protected dashboard route requires auth (logged-out is redirected)', () => {
     cy.clearCookies();
     cy.clearLocalStorage();
-    cy.visit('/dashboard/customers', { failOnStatusCode: false });
-    // Either redirected to login, or a login form is shown — never the customer data.
+    // Cover the routes that expose the most sensitive tenant data, not just one —
+    // gating is per-route middleware, so one passing route proves little.
+    ['/dashboard/customers', '/dashboard/invoices', '/dashboard/team', '/dashboard/settings'].forEach(
+      (route) => {
+        cy.clearCookies();
+        cy.clearLocalStorage();
+        cy.visit(route, { failOnStatusCode: false });
+        // Either redirected to login, or a login form is shown — never the data.
+        cy.location('pathname', { timeout: 15000 }).should('match', /\/auth\/login|\/login/);
+      }
+    );
+  });
+});
+
+// Logged-out auth behavior. Deliberately a separate describe: the suite above
+// logs in via `beforeEach`, and these cases need to start signed out.
+(hasCreds ? describe : describe.skip)('Auth error handling', () => {
+  it('TC-AUTH-04: wrong password shows a clear error and does not sign the user in', () => {
+    // A deliberately unknown address, not E2E_EMAIL. Supabase returns the same
+    // "Invalid login credentials" for an unknown email as for a bad password, so
+    // the assertion is identical — but repeatedly failing against the real CI
+    // account risks tripping Supabase rate limiting and taking the whole
+    // authenticated suite down with it.
+    const email = `e2e-nobody-${Date.now()}-${Cypress._.random(1e9)}@example.com`;
+
+    cy.clearCookies();
+    cy.clearLocalStorage();
+    cy.visit('/auth/login');
+    cy.get('input[name="email"]').clear().type(email);
+    cy.get('input[name="password"]').clear().type('definitely-the-wrong-password', { log: false });
+    cy.get('input[name="password"]').parents('form').first().find('button[type="submit"]').click();
+
+    // Clear, human error message — not a raw Supabase string or a silent no-op.
+    cy.contains(/incorrect email or password/i, { timeout: 20000 }).should('be.visible');
+    // And still signed out: no dashboard, no session.
+    cy.location('pathname').should('match', /\/auth\/login|\/login/);
+    cy.visit('/dashboard', { failOnStatusCode: false });
     cy.location('pathname', { timeout: 15000 }).should('match', /\/auth\/login|\/login/);
   });
 });


### PR DESCRIPTION
## Summary

Two things, both aimed at making the pre-Beta QA pass smaller and CI trustworthy:

1. **Stop the authenticated E2E going red for no reason** after every deploy.
2. **Convert three more P0 cases** from the manual matrix into automated specs.

## 1. Warm up the sandbox before the authenticated E2E run

`e2e-authenticated` runs against the deployed sandbox, so right after a deploy it races the cold start of every Netlify function. `cy.login()` gives the dashboard 25s to appear; a cold sandbox blows past that, fails the `before each` hook, and skips the entire suite.

That is exactly what happened on the Next 16 merge (`2a75a93`) — the suite went red while login itself was fine. The same commit passed twice once the sandbox was warm.

`smoke.yml` got this treatment in `00df905` but `e2e.yml` was left behind. This adds the same best-effort warm-up, covering the routes the authenticated and portal specs actually visit. Two passes, failures ignored, 60s cap per request; the step never fails the job (verified it exits 0 even when every request fails).

## 2. Three more P0 cases automated

| Case | What it now covers |
|---|---|
| **TC-AUTH-04** | Wrong password shows the real "Incorrect email or password" copy and leaves the user signed out |
| **TC-JOB-02** | No 24-hour clock times (13:00–23:59) render on the jobs list — the actual regression behind "times show 12-hour" |
| **TC-QUOTE-01** | Builds a Quick Quote against a fresh customer, asserts the subtotal and total calculate, then deletes both the quote and the customer it created |

**TC-SEC-06** was also widened from one protected route to four — gating is per-route middleware, so one passing route proved very little.

### Notes on the approach

- **TC-AUTH-04 lives in its own `describe`** because the main suite logs in via `beforeEach` and this case has to start signed out. It uses a throwaway unknown address rather than `E2E_EMAIL`: Supabase returns the same "Invalid login credentials" either way, but repeatedly failing against the CI account risks tripping rate limiting and taking the whole authenticated suite down with it.
- **TC-QUOTE-01 clicks "Save Quote", never "Save & Send"** — that second button fires a real customer email/SMS from the sandbox. It also pins the `Tax (8.75%)` label so a rate change fails loudly instead of silently invalidating the expected total, and self-cleans (quote first, then customer, for the FK order).
- **Nothing here sends SMS or takes a real card.** A2P registration is still pending, so send-triggering and real-payment cases were deliberately left to the manual pass.

## Testing

- `npm run lint` — 0 errors
- `npm test` — 580/580 passing
- `npm run build` — succeeds, 194 pages
- Warm-up step syntax-checked and confirmed to exit 0 on total failure
- New specs: syntax and lint clean, selectors derived from the live components (`.fixed.inset-0` is the QuoteModal root, `tr` is the quote row, `__new__` is the new-customer option)

**The Cypress specs have not been executed** — the binary download is blocked in the authoring environment, so this PR's `e2e-authenticated` run is their first real exercise. Expect the possibility of a selector tweak on the first run.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172kz8cT81U9saoVpZaCefk)_