### PR TITLE
fix(e2e): stop the authenticated suite racing the sandbox deploy

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,12 @@ on:
     branches: [main, sandbox]
   workflow_dispatch:
 
+# The authenticated job reads the back-sync workflow's run status to know when
+# the sandbox branch has been updated for this commit.
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   # Public / unauthenticated E2E — builds and serves the app locally, no secrets
   # needed. This is the always-on regression gate.
@@ -54,6 +60,60 @@ jobs:
           else
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
+      # A push to main immediately triggers backsync-sandbox.yml, which pushes
+      # main -> sandbox and starts a Netlify sandbox build. Without this gate the
+      # suite races that deploy: Netlify serves the OLD build until the new one
+      # publishes, then swaps atomically mid-run, killing in-flight requests and
+      # failing cy.login()'s `before each` hook. Work out which commit the
+      # sandbox is supposed to be serving so the next step can wait for it.
+      - name: Resolve the commit the sandbox should be serving
+        id: target
+        if: steps.guard.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ "$GITHUB_EVENT_NAME" != "push" ]; then
+            echo "::notice::${GITHUB_EVENT_NAME} run — the sandbox is on its own commit, so waiting only for a steady deploy."
+            echo "commit=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$GITHUB_REF_NAME" = "sandbox" ]; then
+            echo "Push to sandbox — waiting for $GITHUB_SHA to go live."
+            echo "commit=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Push to main: the sandbox tip is whatever back-sync lands, which is
+          # this SHA on a fast-forward or a merge commit when sandbox carries
+          # unpromoted work. Wait for that workflow, then read the real tip.
+          api="/repos/$GITHUB_REPOSITORY/actions/workflows/backsync-sandbox.yml/runs?head_sha=$GITHUB_SHA"
+          conclusion=""
+          for _ in $(seq 1 40); do   # up to ~10 min
+            conclusion=$(gh api "$api" --jq '.workflow_runs[0] | select(.status == "completed") | .conclusion' 2>/dev/null || echo "")
+            [ -n "$conclusion" ] && break
+            sleep 15
+          done
+
+          if [ "$conclusion" != "success" ]; then
+            echo "::warning::Back-sync to sandbox did not complete successfully for $GITHUB_SHA (conclusion: ${conclusion:-none yet}). Falling back to waiting for a steady deploy of whatever the sandbox is serving."
+            echo "commit=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          tip=$(git ls-remote origin refs/heads/sandbox | cut -f1)
+          echo "Back-sync succeeded — sandbox tip is $tip."
+          echo "commit=$tip" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the sandbox deploy to publish
+        if: steps.guard.outputs.run == 'true'
+        env:
+          BASE_URL: ${{ secrets.E2E_BASE_URL }}
+          EXPECT_COMMIT: ${{ steps.target.outputs.commit }}
+        run: node scripts/wait-for-deploy.js
+
       - name: Warm up the deployment (avoid serverless cold-start flakiness)
         if: steps.guard.outputs.run == 'true'
         env:
@@ -75,6 +135,21 @@ jobs:
               echo "  $p -> $code"
             done
           done
+
+          # The login chain is more than the login page: after Supabase accepts
+          # the password the app calls these routes, and the 2FA check fails
+          # CLOSED — a cold-start timeout there signs the user straight back out
+          # and leaves Cypress sitting on /auth/login. Warm them too. They 401
+          # without a token, which is fine: the function boots either way.
+          echo "— Warming the login-chain API routes —"
+          for p in /api/auth/check-needs-password /api/auth/session-guard; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 60 "$BASE_URL$p" || echo "ERR")
+            echo "  GET $p -> $code"
+          done
+          code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 60 -X POST \
+            -H 'Content-Type: application/json' -d '{}' \
+            "$BASE_URL/api/auth/2fa/check-device" || echo "ERR")
+          echo "  POST /api/auth/2fa/check-device -> $code"
       - name: Cypress run (authenticated, against the sandbox)
         if: steps.guard.outputs.run == 'true'
         uses: cypress-io/github-action@v6

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -13,7 +13,32 @@ Cypress.Commands.add('login', () => {
     cy.get('input[name="email"]').clear().type(email);
     cy.get('input[name="password"]').clear().type(password, { log: false });
     cy.get('input[name="password"]').parents('form').first().find('button[type="submit"]').click();
-    // Successful login lands somewhere under /dashboard.
-    cy.location('pathname', { timeout: 25000 }).should('include', '/dashboard');
+
+    // Successful login lands somewhere under /dashboard. Assert against the
+    // page rather than the URL alone so a failure says WHY: submitting the form
+    // is only the start of the chain (Supabase auth -> /api/auth/2fa/check-device
+    // -> the post-login redirect), and every way that chain can break leaves the
+    // browser sitting on /auth/login — which as a bare URL assertion reads
+    // "expected '/auth/login/' to include '/dashboard'" and names no cause.
+    // 45s because that chain includes two serverless round-trips, and the 2FA
+    // check fails closed: a cold-start timeout there signs the user back out.
+    cy.get('body', { timeout: 45000 }).should(($body) => {
+      const { pathname } = $body[0].ownerDocument.location;
+      if (pathname.includes('/dashboard')) return;
+
+      const alert = $body.find('.bg-red-50, [role="alert"]').first().text().trim();
+      const needs2fa = $body.find('#twofa-code').length > 0;
+      throw new Error(
+        `Login did not reach /dashboard — still at ${pathname}.`
+        + (needs2fa
+          ? ' The app is asking for a 2FA code, so the E2E account cannot log in unattended:'
+            + ' disable 2FA for it, or mark the CI device as trusted.'
+          : '')
+        + (alert
+          ? ` The page is showing: "${alert}".`
+          : ' The page is showing no error, so the login chain is still in flight'
+            + ' or a request timed out (check the deployment is warm and finished publishing).')
+      );
+    });
   });
 });

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -49,6 +49,42 @@ CYPRESS_E2E_EMAIL=you@example.com CYPRESS_E2E_PASSWORD=secret \
   --config baseUrl=https://sandbox--lively-yeot-c640cd.netlify.app
 ```
 
+## Why the authenticated job waits before it runs
+
+The authenticated suite runs against the **deployed sandbox**, and a push to
+`main` starts two things at once: `backsync-sandbox.yml` pushes `main` →
+`sandbox` (which starts a Netlify sandbox build), and this job starts hitting
+the sandbox URL. Netlify keeps the previous deploy live until the new one
+publishes, then swaps atomically — so "the site returns 200" is not the same as
+"the site is done deploying". A swap landing mid-run kills in-flight requests,
+and the failure surfaces in `cy.login()`'s `before each` hook as
+`expected '/auth/login/' to include '/dashboard'`, which looks like a broken
+login but is a deploy race.
+
+So the job now, before running Cypress:
+
+1. **Resolves the commit the sandbox should be serving** — waits for the
+   back-sync workflow for this SHA, then reads the `sandbox` branch tip.
+2. **Waits for that commit to actually be live** (`scripts/wait-for-deploy.js`),
+   polling `/api/health`, which reports the build's `COMMIT_REF`. It requires
+   several consecutive fast responses on the same commit, so a mid-flight deploy
+   restarts the wait instead of poisoning the run. If the deployment can't
+   report its commit (or is too old to have `/api/health`), it falls back to
+   waiting for a steady, responsive build.
+3. **Warms the login-chain API routes** as well as the pages — after Supabase
+   accepts the password the app calls `/api/auth/check-needs-password` and
+   `/api/auth/2fa/check-device`, and **the 2FA check fails closed**: if it
+   cold-starts past its timeout the app signs the user back out and stays on
+   `/auth/login`.
+
+### If the login step fails anyway
+
+`cy.login()` reports what the page was showing when it gave up — the red error
+box's text, or "asking for a 2FA code" (the E2E account must have 2FA disabled),
+or "no error shown" when a request simply timed out. Read that message first; it
+names the cause. If the gate itself fails with "never became ready", the Netlify
+deploy for that commit is stuck or failed — check the deploy, not the tests.
+
 ## Adding more coverage
 
 The authenticated specs are intentionally a small, reliable starting set. Grow

--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,11 @@ const serverEnvVars = [
   'GOOGLE_CLIENT_SECRET',
   'STRIPE_CONNECT_WEBHOOK_SECRET',
   'TWILIO_2FA_MESSAGING_SERVICE_SID',
+  // Netlify build metadata — surfaced by /api/health so CI can tell which
+  // commit a deployment is actually serving.
+  'COMMIT_REF',
+  'BRANCH',
+  'CONTEXT',
 ];
 
 const nextConfig = {

--- a/scripts/wait-for-deploy.js
+++ b/scripts/wait-for-deploy.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Wait until a deployment is finished publishing and is serving traffic.
+ *
+ * WHY THIS EXISTS
+ * A push to `main` fans out into two things that race each other:
+ *   1. `backsync-sandbox.yml` pushes main -> sandbox, which starts a Netlify
+ *      sandbox build.
+ *   2. `e2e.yml`'s authenticated job starts hitting that same sandbox URL.
+ * Netlify keeps the previous deploy live until the new one publishes, so a
+ * plain 200 means nothing: CI warms up the old build, and the atomic swap then
+ * lands mid-run. Requests in flight during the swap hang or reset, the login
+ * chain (Supabase auth -> /api/auth/2fa/check-device -> /dashboard) blows its
+ * budget, and the suite fails in `cy.login()`'s `before each` hook with
+ * "expected '/auth/login/' to include '/dashboard'" — a deploy race wearing a
+ * test failure's clothes.
+ *
+ * This gate polls /api/health (which reports the build's COMMIT_REF) and only
+ * returns once the deployment has settled:
+ *   • EXPECT_COMMIT set  -> wait for that exact commit to be live, then confirm
+ *                           it stays live and responsive across a few probes.
+ *   • EXPECT_COMMIT unset -> wait for any commit to hold steady and respond
+ *                           quickly across a few consecutive probes.
+ *
+ * Usage:
+ *   BASE_URL=https://sandbox--<site>.netlify.app node scripts/wait-for-deploy.js
+ *   BASE_URL=… EXPECT_COMMIT=<sha> node scripts/wait-for-deploy.js
+ *
+ * Exits 0 when the deployment is ready, 1 when it never became ready — a real
+ * failure worth a red X (the deploy broke, or took longer than any deploy
+ * should).
+ */
+
+const baseUrl = (process.argv[2] || process.env.BASE_URL || '').replace(/\/$/, '');
+// Mutable: a build that doesn't report its commit (COMMIT_REF unset in the
+// deploy environment) can't be matched, so the gate drops back to waiting for
+// a steady build rather than failing on something it cannot verify.
+let expectCommit = (process.env.EXPECT_COMMIT || '').trim();
+const TIMEOUT_MS = Number(process.env.WAIT_TIMEOUT_MS || 900000); // 15 min
+const POLL_INTERVAL_MS = Number(process.env.WAIT_POLL_INTERVAL_MS || 10000);
+const PROBE_TIMEOUT_MS = Number(process.env.WAIT_PROBE_TIMEOUT_MS || 30000);
+// How many consecutive good probes mean "settled". Netlify's swap is atomic but
+// the first hits afterwards are cold, so one good response isn't proof.
+const REQUIRED_STREAK = Number(process.env.WAIT_REQUIRED_STREAK || 3);
+// A probe this slow means the function is still cold — it counts as not-ready
+// rather than ready, so the streak restarts.
+const SLOW_PROBE_MS = Number(process.env.WAIT_SLOW_PROBE_MS || 15000);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const short = (sha) => (sha && sha !== 'unknown' ? sha.slice(0, 8) : sha);
+
+async function probe(path) {
+  const started = Date.now();
+  try {
+    const res = await fetch(`${baseUrl}${path}`, {
+      redirect: 'follow',
+      headers: { 'Cache-Control': 'no-cache' },
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    const text = await res.text();
+    return { status: res.status, ms: Date.now() - started, text };
+  } catch (err) {
+    return { status: 0, ms: Date.now() - started, error: err.message };
+  }
+}
+
+// The health endpoint is new; a deployment built before it existed 404s. Fall
+// back to probing the login page so this gate still helps on older builds
+// instead of blocking forever on a route that will never appear.
+async function probeFallback() {
+  const res = await probe('/auth/login');
+  const ok = res.status >= 200 && res.status < 400 && res.ms < SLOW_PROBE_MS;
+  return { ok, commit: 'unknown', detail: `/auth/login -> ${res.status || res.error} in ${res.ms}ms` };
+}
+
+async function probeHealth() {
+  const res = await probe('/api/health');
+  if (res.status === 404) return { missing: true };
+  if (res.status !== 200) {
+    return { ok: false, commit: null, detail: `/api/health -> ${res.status || res.error} in ${res.ms}ms` };
+  }
+  let body;
+  try {
+    body = JSON.parse(res.text);
+  } catch {
+    return { ok: false, commit: null, detail: `/api/health -> 200 but unparseable body in ${res.ms}ms` };
+  }
+  const commit = body.commit || 'unknown';
+  const fast = res.ms < SLOW_PROBE_MS;
+  const matches = !expectCommit || commit === expectCommit;
+  return {
+    ok: fast && matches,
+    commit,
+    detail: `/api/health -> 200 in ${res.ms}ms, serving ${short(commit)} (${body.branch || '?'})`
+      + (matches ? '' : `, waiting for ${short(expectCommit)}`)
+      + (fast ? '' : ', still cold'),
+  };
+}
+
+async function main() {
+  if (!baseUrl) {
+    console.error('wait-for-deploy: no BASE_URL given — nothing to wait for.');
+    process.exit(1);
+  }
+
+  console.log(`Waiting for ${baseUrl} to finish deploying`);
+  console.log(
+    expectCommit
+      ? `  target commit: ${short(expectCommit)} (${expectCommit})`
+      : '  target commit: any (no expected commit given — waiting for a steady, responsive build)'
+  );
+  console.log(`  need ${REQUIRED_STREAK} consecutive good probes, giving up after ${Math.round(TIMEOUT_MS / 60000)} min\n`);
+
+  const deadline = Date.now() + TIMEOUT_MS;
+  let streak = 0;
+  let lastCommit = null;
+  let useFallback = false;
+
+  while (Date.now() < deadline) {
+    const result = useFallback ? await probeFallback() : await probeHealth();
+
+    if (result.missing) {
+      console.log('  /api/health is not on this deployment yet — falling back to a plain reachability check.');
+      useFallback = true;
+      continue;
+    }
+
+    // A build that doesn't know its own commit can't be matched against the
+    // expected one — say so once and fall back instead of burning the timeout.
+    if (expectCommit && result.commit === 'unknown') {
+      console.log(
+        '  this deployment does not report a commit (COMMIT_REF unset at build time) — '
+          + 'cannot verify which build is live, waiting for a steady one instead.'
+      );
+      expectCommit = '';
+    }
+
+    // A commit change mid-streak means the swap just happened; start over so we
+    // never hand Cypress a deployment that is still moving underneath it.
+    if (result.commit && lastCommit && result.commit !== lastCommit) {
+      console.log(`  deploy swapped: ${short(lastCommit)} -> ${short(result.commit)} — restarting the streak.`);
+      streak = 0;
+    }
+    lastCommit = result.commit || lastCommit;
+
+    streak = result.ok ? streak + 1 : 0;
+    console.log(`  ${result.ok ? 'ok  ' : 'wait'} ${result.detail} [${streak}/${REQUIRED_STREAK}]`);
+
+    if (streak >= REQUIRED_STREAK) {
+      console.log(`\nDeployment is ready${lastCommit && lastCommit !== 'unknown' ? ` (serving ${short(lastCommit)})` : ''}.`);
+      process.exit(0);
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  console.error(
+    `\nwait-for-deploy: ${baseUrl} never became ready within ${Math.round(TIMEOUT_MS / 60000)} minutes.`
+  );
+  if (expectCommit) {
+    console.error(
+      `Expected commit ${short(expectCommit)}; last seen ${short(lastCommit) || 'nothing'}. `
+        + 'Check the Netlify deploy for that commit — a failed or stuck build looks exactly like this.'
+    );
+  }
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(`wait-for-deploy: ${err.message}`);
+  process.exit(1);
+});

--- a/src/app/api/health/route.js
+++ b/src/app/api/health/route.js
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+// Tiny public build-identity probe. It answers one question: *which* build is
+// this deployment currently serving?
+//
+// CI uses it to tell "the sandbox is up" apart from "the sandbox is up but
+// still serving the previous deploy" — Netlify keeps the old deploy live until
+// the new one publishes, so a plain 200 says nothing about whether the commit
+// under test is live yet. Without this, the authenticated E2E suite races the
+// deploy: it warms up the old build, then Netlify swaps in the new one
+// mid-run and every in-flight request dies (see scripts/wait-for-deploy.js).
+//
+// COMMIT_REF / BRANCH / CONTEXT are Netlify build-time vars, inlined into the
+// server bundle by the DefinePlugin list in next.config.js. Locally they're
+// undefined and this reports "unknown".
+export async function GET() {
+  return NextResponse.json(
+    {
+      ok: true,
+      commit: process.env.COMMIT_REF || 'unknown',
+      branch: process.env.BRANCH || 'unknown',
+      context: process.env.CONTEXT || 'unknown',
+      appEnv: process.env.NEXT_PUBLIC_APP_ENV || 'unknown',
+      time: new Date().toISOString(),
+    },
+    { headers: { 'Cache-Control': 'no-store, max-age=0' } }
+  );
+}


### PR DESCRIPTION
The e2e-authenticated job fails intermittently on pushes to main (3 of the last 10) with the same signature: cy.login()'s `before each` hook times out on `expected '/auth/login/' to include '/dashboard'`, sometimes with ETIMEDOUT page loads in the same run.

It isn't the login. A push to main triggers backsync-sandbox.yml, which pushes main -> sandbox and starts a Netlify sandbox build, while this job is already hitting that sandbox URL. Netlify serves the previous deploy until the new one publishes, then swaps atomically — so the warm-up warms the old build and the swap lands mid-run, killing requests in flight. On the failing run the merge landed at 05:49:11 and Cypress ran 05:50:10-05:56:00, squarely inside that window.

- Add GET /api/health, a public probe reporting the build's COMMIT_REF (via the next.config.js DefinePlugin list, which is how server env vars reach the Netlify function runtime here), so CI can tell "the site is up" from "the site is serving the commit under test".
- Add scripts/wait-for-deploy.js: poll that endpoint until the expected commit is live and holds steady across several fast probes, restarting the streak whenever the deploy swaps. Falls back to a plain reachability wait when the deployment predates /api/health or doesn't report a commit, and exits non-zero (loudly) if the deploy never lands.
- Wire both into e2e.yml: resolve the sandbox tip once back-sync for this SHA has completed, wait for that commit to publish, then warm up and run.
- Warm the login-chain API routes too. The 2FA check fails closed, so a cold start on /api/auth/2fa/check-device signs the user back out and parks Cypress on /auth/login — indistinguishable from a bad password.
- Make cy.login() report why it gave up (the page's error text, a 2FA prompt, or "no error shown") instead of only the URL that didn't change, and give the chain 45s since it spans two serverless round-trips.

No test is skipped or loosened: the suite still has to log in for real.


Claude-Session: https://claude.ai/code/session_016jvsEkmzgdA4sQwsiCxQoM