### PR TITLE
Add worker-app E2E (TC-WORK-01/02/04)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,7 +80,7 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           install: true
-          spec: cypress/e2e/authenticated-flows.cy.js,cypress/e2e/customer-portal.cy.js,cypress/e2e/multi-tenant-isolation.cy.js,cypress/e2e/quote-public-link.cy.js
+          spec: cypress/e2e/authenticated-flows.cy.js,cypress/e2e/customer-portal.cy.js,cypress/e2e/multi-tenant-isolation.cy.js,cypress/e2e/quote-public-link.cy.js,cypress/e2e/worker-flows.cy.js
           config: baseUrl=${{ secrets.E2E_BASE_URL }}
         env:
           CYPRESS_E2E_EMAIL: ${{ secrets.E2E_EMAIL }}
@@ -89,3 +89,7 @@ jobs:
           # spec skips itself; forwarding these activates it.
           CYPRESS_E2E_EMAIL_2: ${{ secrets.E2E_EMAIL_2 }}
           CYPRESS_E2E_PASSWORD_2: ${{ secrets.E2E_PASSWORD_2 }}
+          # Worker account for the worker-app specs (TC-WORK-*). When unset, that
+          # spec skips itself; forwarding these activates it.
+          CYPRESS_E2E_WORKER_EMAIL: ${{ secrets.E2E_WORKER_EMAIL }}
+          CYPRESS_E2E_WORKER_PASSWORD: ${{ secrets.E2E_WORKER_PASSWORD }}

--- a/cypress/e2e/authenticated-flows.cy.js
+++ b/cypress/e2e/authenticated-flows.cy.js
@@ -52,7 +52,7 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
     // window.confirm. Isolate the row via search, accept the confirm, delete,
     // and assert it's gone — so the test leaves no data behind.
     cy.on('window:confirm', () => true);
-    cy.get('input[placeholder*="Search customers"]', { timeout: 10000 }).clear().type(name);
+    cy.get('input[placeholder*="Search customers"]', { timeout: 10000 }).should('not.be.disabled').clear().type(name);
     cy.contains(name).should('be.visible');
     cy.contains('button', /^\s*delete\s*$/i).click();
     cy.contains(name).should('not.exist');
@@ -143,7 +143,7 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
     cy.contains('tr', name).should('not.exist');
 
     cy.visit('/dashboard/customers');
-    cy.get('input[placeholder*="Search customers"]', { timeout: 20000 }).clear().type(name);
+    cy.get('input[placeholder*="Search customers"]', { timeout: 20000 }).should('not.be.disabled').clear().type(name);
     cy.contains(name).should('be.visible');
     cy.contains('button', /^\s*delete\s*$/i).click();
     cy.contains(name).should('not.exist');
@@ -219,7 +219,7 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
     cy.contains('tr', name).should('not.exist');
 
     cy.visit('/dashboard/customers');
-    cy.get('input[placeholder*="Search customers"]', { timeout: 20000 }).clear().type(name);
+    cy.get('input[placeholder*="Search customers"]', { timeout: 20000 }).should('not.be.disabled').clear().type(name);
     cy.contains(name).should('be.visible');
     cy.contains('button', /^\s*delete\s*$/i).click();
     cy.contains(name).should('not.exist');

--- a/cypress/e2e/authenticated-flows.cy.js
+++ b/cypress/e2e/authenticated-flows.cy.js
@@ -39,7 +39,9 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
     // `.fixed`/`form`, which can match a toast or chat widget rendered later in
     // the DOM. Residential (default) shows Name as the first text input.
     cy.get('.fixed.inset-0').within(() => {
-      cy.get('input[type="text"]').first().clear().type(name);
+      // Wait for the modal's inputs to enable (they load disabled on a cold
+      // function) before typing, else cy.type() fails "targeted a disabled element".
+      cy.get('input[type="text"]').first().should('not.be.disabled').clear().type(name);
       cy.get('input[type="email"]').first().clear().type(email);
       cy.get('input[type="tel"]').first().clear().type('5551234567');
       cy.contains('button', /save customer|save|add|create/i).click();
@@ -68,21 +70,23 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
     // service and worker are optional, so this needs no seed data. A unique
     // title makes the row findable; 14:30 also exercises the 12-hour render.
     cy.get('.fixed.inset-0', { timeout: 10000 }).within(() => {
-      cy.get('input[placeholder="e.g., Weekly pool cleaning"]').clear().type(title);
+      cy.get('input[placeholder="e.g., Weekly pool cleaning"]').should('not.be.disabled').clear().type(title);
       cy.get('input[placeholder="123 Main St"]').clear().type('123 E2E Test St');
       cy.get('input[type="date"]').first().type('2027-01-15');
       cy.get('input[type="time"]').first().type('14:30');
       cy.contains('button', /^\s*save job\s*$/i).click();
     });
 
-    cy.contains('tr', title, { timeout: 25000 }).should('exist');
+    cy.contains('tr', title, { timeout: 40000 }).should('exist');
 
     // Self-cleanup (row Delete is guarded by window.confirm).
     cy.on('window:confirm', () => true);
     cy.contains('tr', title).within(() => {
       cy.contains('button', /^\s*delete\s*$/i).click();
     });
-    cy.contains('tr', title).should('not.exist');
+    // A cold delete endpoint can take a beat to remove the row; give the
+    // disappearance the same cold-start budget as the appearance above.
+    cy.contains('tr', title, { timeout: 20000 }).should('not.exist');
   });
 
   it('TC-QUOTE-01: opens the New Quote menu and the Quick Quote modal', () => {
@@ -107,7 +111,7 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
     cy.contains('button', /add (your first )?customer/i, { timeout: 20000 }).first().click();
     cy.contains(/Add New Customer/i, { timeout: 10000 }).should('be.visible');
     cy.get('.fixed.inset-0').within(() => {
-      cy.get('input[type="text"]').first().clear().type(name);
+      cy.get('input[type="text"]').first().should('not.be.disabled').clear().type(name);
       cy.get('input[type="email"]').first().clear().type(`${uid}@example.com`);
       cy.get('input[type="tel"]').first().clear().type('5551234567');
       cy.contains('button', /save customer|save|add|create/i).click();
@@ -119,7 +123,7 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
     cy.location('pathname', { timeout: 25000 }).should('include', '/dashboard/invoices');
     cy.contains('button', /new invoice/i, { timeout: 20000 }).click();
     cy.get('.fixed.inset-0', { timeout: 10000 }).within(() => {
-      cy.get('select').first().select(name); // customer select (first in the modal)
+      cy.get('select').first().should('not.be.disabled').select(name); // customer select (first in the modal)
       cy.get('input[placeholder="Description"]').first().clear().type('E2E line item');
       cy.get('input[placeholder="Qty"]').first().type('{selectall}1').should('have.value', '1');
       cy.get('input[placeholder="Price"]').first().type('{selectall}100').should('have.value', '100');
@@ -128,7 +132,8 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
     });
 
     // Invoice shows up in the list keyed by the customer name — number generated.
-    cy.contains('tr', name, { timeout: 25000 }).should('exist');
+    // Same cold-start budget as the quote/job create flows above.
+    cy.contains('tr', name, { timeout: 40000 }).should('exist');
 
     // Cleanup: delete the invoice, then the customer it was for.
     cy.on('window:confirm', () => true);
@@ -176,7 +181,7 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
 
     // Attach to a brand-new customer so the spec never depends on seed data.
     cy.get('.fixed.inset-0', { timeout: 10000 }).within(() => {
-      cy.get('select').first().select('__new__');
+      cy.get('select').first().should('not.be.disabled').select('__new__');
       cy.contains('New Customer Info').should('be.visible');
       cy.get('input[placeholder="John Smith"]').clear().type(name);
       cy.get('input[placeholder="john@email.com"]').clear().type(`${uid}@example.com`);
@@ -202,7 +207,9 @@ const hasCreds = !!Cypress.env('E2E_EMAIL') && !!Cypress.env('E2E_PASSWORD');
     });
 
     // Saved quote shows up in the list, keyed by our unique customer name.
-    cy.contains('tr', name, { timeout: 25000 }).should('exist');
+    // A cold quote-save endpoint (the warm-up only touches GET routes) can run
+    // long on the first hit, so allow a full cold-start budget here.
+    cy.contains('tr', name, { timeout: 40000 }).should('exist');
 
     // Self-cleanup: delete the quote first (FK), then the customer it created.
     cy.on('window:confirm', () => true);

--- a/cypress/e2e/multi-tenant-isolation.cy.js
+++ b/cypress/e2e/multi-tenant-isolation.cy.js
@@ -69,14 +69,14 @@ function loginAs(email, password) {
     cy.visit('/dashboard/customers');
     // Guard against a false pass: confirm B's own customers page actually loaded
     // (search box present) before asserting the absence of A's record.
-    cy.get('input[placeholder*="Search customers"]', { timeout: 20000 }).clear().type(name);
+    cy.get('input[placeholder*="Search customers"]', { timeout: 20000 }).should('not.be.disabled').clear().type(name);
     cy.contains(name).should('not.exist');
 
     // ── Cleanup: Company A deletes the customer ──────────────────────────────
     loginAs(A.email, A.password);
     cy.visit('/dashboard/customers');
     cy.on('window:confirm', () => true);
-    cy.get('input[placeholder*="Search customers"]', { timeout: 20000 }).clear().type(name);
+    cy.get('input[placeholder*="Search customers"]', { timeout: 20000 }).should('not.be.disabled').clear().type(name);
     cy.contains(name, { timeout: 20000 }).should('be.visible');
     cy.contains('button', /^\s*delete\s*$/i).click();
     cy.contains(name).should('not.exist');

--- a/cypress/e2e/multi-tenant-isolation.cy.js
+++ b/cypress/e2e/multi-tenant-isolation.cy.js
@@ -54,7 +54,10 @@ function loginAs(email, password) {
     cy.contains('button', /add (your first )?customer/i, { timeout: 20000 }).first().click();
     cy.contains(/Add New Customer/i, { timeout: 10000 }).should('be.visible');
     cy.get('.fixed.inset-0').within(() => {
-      cy.get('input[type="text"]').first().clear().type(name);
+      // The modal disables its inputs while it loads company data on a cold
+      // function; wait for the first field to enable before typing, or cy.type()
+      // fails "targeted a disabled element". Once it's enabled the rest are too.
+      cy.get('input[type="text"]').first().should('not.be.disabled').clear().type(name);
       cy.get('input[type="email"]').first().clear().type(custEmail);
       cy.get('input[type="tel"]').first().clear().type('5551234567');
       cy.contains('button', /save customer|save|add|create/i).click();

--- a/cypress/e2e/worker-flows.cy.js
+++ b/cypress/e2e/worker-flows.cy.js
@@ -1,0 +1,76 @@
+/**
+ * Worker app E2E (TC-WORK-01 / 02 / 04).
+ *
+ * Needs a sandbox WORKER account (a `worker`-role user attached to a company).
+ * The app has no in-UI worker invite, so create one via Supabase Auth and link
+ * it to an existing (onboarded) company — see database/TEST_ACCOUNT_SETUP.md
+ * ("Adding Test Workers"). Then add its login as GitHub Actions secrets:
+ *
+ *   E2E_WORKER_EMAIL / E2E_WORKER_PASSWORD
+ *
+ * The suite SKIPS until both are set, so it never breaks CI before the worker
+ * account exists. (TC-WORK-03 "On my way" fires a real SMS and stays manual.)
+ */
+
+const worker = {
+  email: Cypress.env('E2E_WORKER_EMAIL'),
+  password: Cypress.env('E2E_WORKER_PASSWORD'),
+};
+const hasWorker = !!worker.email && !!worker.password;
+
+function workerLogin() {
+  cy.session(['worker', worker.email], () => {
+    cy.visit('/worker/login');
+    cy.get('input[type="email"]').clear().type(worker.email);
+    cy.get('input[type="password"]').clear().type(worker.password, { log: false });
+    cy.get('form').find('button[type="submit"]').click();
+    // Successful worker login lands under /worker (redirects to /worker/timeclock).
+    cy.location('pathname', { timeout: 25000 }).should('include', '/worker');
+  });
+}
+
+(hasWorker ? describe : describe.skip)('Worker app flows', () => {
+  beforeEach(() => {
+    workerLogin();
+  });
+
+  it('TC-WORK-01: worker logs in and lands in the worker app', () => {
+    cy.visit('/worker/timeclock');
+    cy.location('pathname', { timeout: 25000 }).should('include', '/worker');
+    cy.get('body').should('be.visible');
+  });
+
+  it("TC-WORK-02: worker home loads today's jobs with 12-hour times", () => {
+    cy.visit('/worker');
+    cy.location('pathname', { timeout: 25000 }).should('include', '/worker');
+    cy.get('body', { timeout: 20000 }).should('be.visible');
+    // Any job time shown must read as AM/PM — a 24-hour clock (13:00–23:59) is
+    // the regression this guards against (same check as TC-JOB-02). Vacuously
+    // true if no jobs are assigned to this worker yet.
+    cy.get('body')
+      .invoke('text')
+      .should((text) => {
+        const twentyFourHour = text.match(/\b(1[3-9]|2[0-3]):[0-5]\d\b/g);
+        expect(twentyFourHour, `24-hour times found: ${twentyFourHour}`).to.be.null;
+      });
+  });
+
+  it('TC-WORK-04: worker can clock in and clock out', () => {
+    cy.visit('/worker/timeclock');
+    cy.location('pathname', { timeout: 25000 }).should('include', '/worker/timeclock');
+    cy.get('body', { timeout: 20000 }).should('be.visible');
+
+    // Reset to a known state: if a prior run left an open entry, clock out first.
+    cy.get('body').then(($b) => {
+      if ($b.find('button:contains("CLOCK OUT")').length) {
+        cy.contains('button', /clock out/i).click();
+        cy.contains('button', /clock in/i, { timeout: 20000 }).should('be.visible');
+      }
+    });
+
+    // Clock in → the button flips to Clock Out → clock back out → flips back.
+    cy.contains('button', /clock in/i, { timeout: 20000 }).should('be.visible').click();
+    cy.contains('button', /clock out/i, { timeout: 20000 }).should('be.visible').click();
+    cy.contains('button', /clock in/i, { timeout: 20000 }).should('be.visible');
+  });
+});


### PR DESCRIPTION
## Summary

Step 3 — automates the worker flows so they come off the manual checklist:
- **TC-WORK-01** — worker logs in (`/worker/login`) and lands in the worker app.
- **TC-WORK-02** — worker home loads "today's jobs" and renders **12-hour (AM/PM)** times (same regression guard as TC-JOB-02; vacuously true until a job is assigned to the worker).
- **TC-WORK-04** — worker can **clock in and clock out** (verifies the CLOCK IN → CLOCK OUT → CLOCK IN button cycle; clock-in works without geolocation, so no stubbing needed).

`TC-WORK-03` ("On my way" → real SMS) intentionally stays manual.

## Activation — needs a sandbox worker account

The app has no in-UI worker invite, so create a `worker`-role user via Supabase Auth linked to an existing (onboarded) company — see `database/TEST_ACCOUNT_SETUP.md` ("Adding Test Workers"). Then add its login as GitHub Actions secrets:

| Secret | Value |
|---|---|
| `E2E_WORKER_EMAIL` | the worker account's email |
| `E2E_WORKER_PASSWORD` | its password |

The spec **skips until both are set**, so this PR is safe to merge now. The workflow already forwards them to Cypress as `CYPRESS_E2E_WORKER_EMAIL` / `CYPRESS_E2E_WORKER_PASSWORD` (the secret-forwarding is included this time, unlike TC-X-01's first pass).

## Verification

Spec passes `node --check`; `e2e.yml` is valid YAML. Full run verifies in CI once the worker secrets are set (skips cleanly until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoMwQ1GFeJXBaVuAKLX16s

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoMwQ1GFeJXBaVuAKLX16s)_