### PR TITLE
fix(growth): say which auth failure happened, not just that one did

### DIFF
--- a/netlify/functions/growth-agent-generate-background.ts
+++ b/netlify/functions/growth-agent-generate-background.ts
@@ -39,9 +39,30 @@ interface TaskRow {
 }
 
 export default async function handler(request: Request) {
+  // Auth failures here were indistinguishable from each other, which cost an
+  // afternoon: "the variable isn't reaching the function" and "the value
+  // doesn't match" both printed the same line. Report which one it is, by
+  // length and prefix only — never the secret itself, since these logs are
+  // readable by anyone with Netlify access.
   const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
-    console.error('[Growth Generator] Unauthorized invocation');
+  const authHeader = request.headers.get('authorization') || '';
+
+  if (!cronSecret) {
+    console.error(
+      '[Growth Generator] CRON_SECRET is not visible to this function. The variable is ' +
+        'either unset, or its Netlify scopes exclude Functions.'
+    );
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    const sent = authHeader.replace(/^Bearer /, '');
+    console.error(
+      `[Growth Generator] Secret mismatch. Expected ${cronSecret.length} chars starting ` +
+        `"${cronSecret.slice(0, 4)}", received ${sent.length} chars starting ` +
+        `"${sent.slice(0, 4)}".` +
+        (sent.length === 0 ? ' No Bearer token was sent at all.' : '')
+    );
     return new Response('Unauthorized', { status: 401 });
   }
 

--- a/netlify/functions/growth-agent-generate-background.ts
+++ b/netlify/functions/growth-agent-generate-background.ts
@@ -15,6 +15,7 @@ import {
   parseGeneratedAsset,
 } from '../../src/lib/growth-generator';
 import { isTaskType } from '../../src/lib/growth-planner';
+import { authorizeCronRequest } from '../../src/lib/cron-auth';
 
 const { aiComplete, parseAIJson } = require('../../src/lib/ai-client');
 
@@ -39,30 +40,11 @@ interface TaskRow {
 }
 
 export default async function handler(request: Request) {
-  // Auth failures here were indistinguishable from each other, which cost an
-  // afternoon: "the variable isn't reaching the function" and "the value
-  // doesn't match" both printed the same line. Report which one it is, by
-  // length and prefix only — never the secret itself, since these logs are
-  // readable by anyone with Netlify access.
-  const cronSecret = process.env.CRON_SECRET;
-  const authHeader = request.headers.get('authorization') || '';
-
-  if (!cronSecret) {
-    console.error(
-      '[Growth Generator] CRON_SECRET is not visible to this function. The variable is ' +
-        'either unset, or its Netlify scopes exclude Functions.'
-    );
-    return new Response('Unauthorized', { status: 401 });
-  }
-
-  if (authHeader !== `Bearer ${cronSecret}`) {
-    const sent = authHeader.replace(/^Bearer /, '');
-    console.error(
-      `[Growth Generator] Secret mismatch. Expected ${cronSecret.length} chars starting ` +
-        `"${cronSecret.slice(0, 4)}", received ${sent.length} chars starting ` +
-        `"${sent.slice(0, 4)}".` +
-        (sent.length === 0 ? ' No Bearer token was sent at all.' : '')
-    );
+  // See the planner: shared so the two cannot drift, and so the log names the
+  // actual failure rather than reporting every cause identically.
+  const auth = authorizeCronRequest(request);
+  if (!auth.ok) {
+    console.error(`[Growth Generator] Unauthorized. ${auth.reason}`);
     return new Response('Unauthorized', { status: 401 });
   }
 

--- a/netlify/functions/growth-agent-generate-cron.ts
+++ b/netlify/functions/growth-agent-generate-cron.ts
@@ -8,6 +8,8 @@
 // answer 202 immediately and discard the body. Outcomes land in growth_tasks
 // and the background function's own log.
 
+import { cronAuthHeaders } from '../../src/lib/cron-auth';
+
 export default async function handler() {
   const siteUrl = process.env.URL || process.env.DEPLOY_PRIME_URL || 'http://localhost:8888';
   const cronSecret = process.env.CRON_SECRET || '';
@@ -17,7 +19,10 @@ export default async function handler() {
       `${siteUrl}/.netlify/functions/growth-agent-generate-background`,
       {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${cronSecret}` },
+        // Both headers carry the same secret. Authorization is the conventional
+        // one; X-Cron-Secret is the one that survives if the platform consumes
+        // or rewrites Authorization on its way to a background function.
+        headers: cronAuthHeaders(cronSecret),
       }
     );
 

--- a/netlify/functions/growth-agent-plan-background.ts
+++ b/netlify/functions/growth-agent-plan-background.ts
@@ -23,6 +23,7 @@ import {
   type MetricsRow,
 } from '../../src/lib/growth-planner';
 import { COMPETITORS } from '../../src/lib/competitor-data';
+import { authorizeCronRequest } from '../../src/lib/cron-auth';
 
 const { aiComplete, parseAIJson } = require('../../src/lib/ai-client');
 
@@ -38,30 +39,12 @@ function getSupabaseAdmin(): SupabaseClient | null {
 }
 
 export default async function handler(request: Request) {
-  // Auth failures here were indistinguishable from each other, which cost an
-  // afternoon: "the variable isn't reaching the function" and "the value
-  // doesn't match" both printed the same line. Report which one it is, by
-  // length and prefix only — never the secret itself, since these logs are
-  // readable by anyone with Netlify access.
-  const cronSecret = process.env.CRON_SECRET;
-  const authHeader = request.headers.get('authorization') || '';
-
-  if (!cronSecret) {
-    console.error(
-      '[Growth Planner] CRON_SECRET is not visible to this function. The variable is ' +
-        'either unset, or its Netlify scopes exclude Functions.'
-    );
-    return new Response('Unauthorized', { status: 401 });
-  }
-
-  if (authHeader !== `Bearer ${cronSecret}`) {
-    const sent = authHeader.replace(/^Bearer /, '');
-    console.error(
-      `[Growth Planner] Secret mismatch. Expected ${cronSecret.length} chars starting ` +
-        `"${cronSecret.slice(0, 4)}", received ${sent.length} chars starting ` +
-        `"${sent.slice(0, 4)}".` +
-        (sent.length === 0 ? ' No Bearer token was sent at all.' : '')
-    );
+  // Auth lives in src/lib/cron-auth so the planner, the generator and their
+  // cron triggers cannot drift apart, and so a rejection says which of the
+  // three distinct failures happened instead of just "no".
+  const auth = authorizeCronRequest(request);
+  if (!auth.ok) {
+    console.error(`[Growth Planner] Unauthorized. ${auth.reason}`);
     return new Response('Unauthorized', { status: 401 });
   }
 

--- a/netlify/functions/growth-agent-plan-background.ts
+++ b/netlify/functions/growth-agent-plan-background.ts
@@ -38,9 +38,30 @@ function getSupabaseAdmin(): SupabaseClient | null {
 }
 
 export default async function handler(request: Request) {
+  // Auth failures here were indistinguishable from each other, which cost an
+  // afternoon: "the variable isn't reaching the function" and "the value
+  // doesn't match" both printed the same line. Report which one it is, by
+  // length and prefix only — never the secret itself, since these logs are
+  // readable by anyone with Netlify access.
   const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
-    console.error('[Growth Planner] Unauthorized invocation');
+  const authHeader = request.headers.get('authorization') || '';
+
+  if (!cronSecret) {
+    console.error(
+      '[Growth Planner] CRON_SECRET is not visible to this function. The variable is ' +
+        'either unset, or its Netlify scopes exclude Functions.'
+    );
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    const sent = authHeader.replace(/^Bearer /, '');
+    console.error(
+      `[Growth Planner] Secret mismatch. Expected ${cronSecret.length} chars starting ` +
+        `"${cronSecret.slice(0, 4)}", received ${sent.length} chars starting ` +
+        `"${sent.slice(0, 4)}".` +
+        (sent.length === 0 ? ' No Bearer token was sent at all.' : '')
+    );
     return new Response('Unauthorized', { status: 401 });
   }
 

--- a/netlify/functions/growth-agent-plan-cron.ts
+++ b/netlify/functions/growth-agent-plan-cron.ts
@@ -8,6 +8,8 @@
 // answer 202 immediately and discard the body. Outcomes land in growth_tasks
 // and the background function's own log.
 
+import { cronAuthHeaders } from '../../src/lib/cron-auth';
+
 export default async function handler() {
   const siteUrl = process.env.URL || process.env.DEPLOY_PRIME_URL || 'http://localhost:8888';
   const cronSecret = process.env.CRON_SECRET || '';
@@ -17,7 +19,10 @@ export default async function handler() {
       `${siteUrl}/.netlify/functions/growth-agent-plan-background`,
       {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${cronSecret}` },
+        // Both headers carry the same secret. Authorization is the conventional
+        // one; X-Cron-Secret is the one that survives if the platform consumes
+        // or rewrites Authorization on its way to a background function.
+        headers: cronAuthHeaders(cronSecret),
       }
     );
 

--- a/src/__tests__/lib/cron-auth.test.js
+++ b/src/__tests__/lib/cron-auth.test.js
@@ -1,0 +1,112 @@
+/**
+ * Tests for cron/background function authorization.
+ *
+ * The risk here is asymmetric. A check that is too strict silently disables the
+ * growth agent — that is the failure that actually happened, and it looked
+ * identical whether the variable was missing, the value was wrong, or the
+ * header never arrived. A check that is too loose lets anyone on the internet
+ * spend the AI budget. So the cases below pin both edges: what must be accepted
+ * despite cosmetic differences, and what must never be.
+ */
+
+import { authorizeCronRequest, cronAuthHeaders } from '@/lib/cron-auth';
+
+const SECRET = 'a-real-looking-secret-value';
+
+// jsdom does not provide the WHATWG Request, so build the only part the code
+// touches. Header lookup is case-insensitive in the real thing, and the code
+// relies on that (it reads 'authorization' while callers send 'Authorization'),
+// so the stub must be too — otherwise these tests would pass on a bug.
+const req = (headers) => ({
+  headers: {
+    get: (name) => {
+      const key = Object.keys(headers).find((k) => k.toLowerCase() === name.toLowerCase());
+      return key === undefined ? null : headers[key];
+    },
+  },
+});
+
+describe('authorizeCronRequest', () => {
+  const originalSecret = process.env.CRON_SECRET;
+
+  beforeEach(() => {
+    process.env.CRON_SECRET = SECRET;
+  });
+
+  afterAll(() => {
+    if (originalSecret === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = originalSecret;
+  });
+
+  it('accepts a conventional Bearer header', () => {
+    expect(authorizeCronRequest(req({ Authorization: `Bearer ${SECRET}` })).ok).toBe(true);
+  });
+
+  it('accepts the fallback header, for when Authorization does not survive transit', () => {
+    expect(authorizeCronRequest(req({ 'X-Cron-Secret': SECRET })).ok).toBe(true);
+  });
+
+  it('accepts a lowercase scheme', () => {
+    expect(authorizeCronRequest(req({ Authorization: `bearer ${SECRET}` })).ok).toBe(true);
+  });
+
+  it('accepts a bare secret with no scheme', () => {
+    expect(authorizeCronRequest(req({ Authorization: SECRET })).ok).toBe(true);
+  });
+
+  it('tolerates whitespace pasted around the value in a dashboard', () => {
+    process.env.CRON_SECRET = `  ${SECRET}\n`;
+    expect(authorizeCronRequest(req({ Authorization: `Bearer ${SECRET} ` })).ok).toBe(true);
+  });
+
+  it('still rejects a wrong secret', () => {
+    const result = authorizeCronRequest(req({ Authorization: 'Bearer not-the-secret' }));
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/mismatch/i);
+  });
+
+  it('rejects a value that merely starts with the secret', () => {
+    expect(authorizeCronRequest(req({ Authorization: `Bearer ${SECRET}x` })).ok).toBe(false);
+  });
+
+  it('distinguishes a missing environment variable from a bad value', () => {
+    delete process.env.CRON_SECRET;
+    const result = authorizeCronRequest(req({ Authorization: `Bearer ${SECRET}` }));
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/not visible to this function/i);
+  });
+
+  it('distinguishes a header that never arrived from one that is wrong', () => {
+    const result = authorizeCronRequest(req({}));
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/No secret header arrived/i);
+    expect(result.reason).toContain('x-cron-secret');
+  });
+
+  it('never puts the secret in the reason, since these logs are widely readable', () => {
+    const cases = [req({}), req({ Authorization: 'Bearer wrong' }), req({ 'X-Cron-Secret': 'wrong' })];
+    for (const request of cases) {
+      const { reason } = authorizeCronRequest(request);
+      expect(reason).not.toContain(SECRET);
+      // A 4-character prefix is deliberate and allowed; the whole value is not.
+      expect(reason).not.toContain(SECRET.slice(0, 8));
+    }
+  });
+});
+
+describe('cronAuthHeaders', () => {
+  it('sends the same secret under both names', () => {
+    const headers = cronAuthHeaders(SECRET);
+    expect(headers.Authorization).toBe(`Bearer ${SECRET}`);
+    expect(headers['X-Cron-Secret']).toBe(SECRET);
+  });
+
+  it('trims, so a stray newline in the variable does not travel', () => {
+    expect(cronAuthHeaders(` ${SECRET}\n`)['X-Cron-Secret']).toBe(SECRET);
+  });
+
+  it('produces headers its own checker accepts', () => {
+    process.env.CRON_SECRET = SECRET;
+    expect(authorizeCronRequest(req(cronAuthHeaders(SECRET))).ok).toBe(true);
+  });
+});

--- a/src/lib/cron-auth.ts
+++ b/src/lib/cron-auth.ts
@@ -1,0 +1,96 @@
+// Shared authorization for cron-triggered Netlify functions.
+//
+// This exists because a whole debugging session was lost to an auth check that
+// could only say "no". Three separate failures — the variable not reaching the
+// function, the value not matching, and the header never arriving — all printed
+// the same line, so there was no way to tell them apart from the log.
+//
+// It also accepts the secret from a second header. Netlify background functions
+// are queued and re-dispatched rather than served inline, and `Authorization`
+// is the one header most likely to be consumed or rewritten in transit. Sending
+// the same secret under a non-standard name costs nothing and survives that.
+
+export interface CronAuthResult {
+  ok: boolean;
+  /** Human-readable cause, safe to log. Never contains the secret. */
+  reason?: string;
+}
+
+/** Header names checked, in order. First one present wins. */
+const SECRET_HEADERS = ['authorization', 'x-cron-secret'] as const;
+
+/**
+ * Strips a `Bearer ` prefix if present, case-insensitively, and trims.
+ * Values pasted into a dashboard routinely carry a trailing newline, and the
+ * scheme is capitalized inconsistently across callers.
+ */
+function normalizeSecret(raw: string): string {
+  return raw.replace(/^\s*bearer\s+/i, '').trim();
+}
+
+/** Describes a value without revealing it: length plus a 4-char prefix. */
+function describe(value: string): string {
+  if (value.length === 0) return 'empty';
+  return `${value.length} chars starting "${value.slice(0, 4)}"`;
+}
+
+/**
+ * Checks a cron/background function request against CRON_SECRET.
+ *
+ * Accepts the secret as `Authorization: Bearer <secret>` or as
+ * `X-Cron-Secret: <secret>`, with or without the Bearer prefix, and tolerates
+ * surrounding whitespace on both the header and the environment variable.
+ *
+ * On failure `reason` says which of the three distinct problems occurred, using
+ * only lengths and 4-character prefixes — these logs are readable by anyone
+ * with Netlify access, so the secret itself must never appear in them.
+ */
+export function authorizeCronRequest(request: Request): CronAuthResult {
+  const expected = (process.env.CRON_SECRET || '').trim();
+
+  if (!expected) {
+    return {
+      ok: false,
+      reason:
+        'CRON_SECRET is not visible to this function. The variable is either unset, ' +
+        'or its Netlify scopes exclude Functions. Note that saving a variable in the ' +
+        'Netlify UI does not affect running functions until the site is redeployed.',
+    };
+  }
+
+  const present: string[] = [];
+  for (const name of SECRET_HEADERS) {
+    const raw = request.headers.get(name);
+    if (raw === null || raw === '') continue;
+    present.push(name);
+    if (normalizeSecret(raw) === expected) return { ok: true };
+  }
+
+  if (present.length === 0) {
+    return {
+      ok: false,
+      reason:
+        `No secret header arrived. Looked for: ${SECRET_HEADERS.join(', ')}. ` +
+        `Expected ${describe(expected)}. If the caller did send Authorization, the ` +
+        'platform stripped it in transit — use X-Cron-Secret instead.',
+    };
+  }
+
+  const received = present
+    .map((name) => `${name}=${describe(normalizeSecret(request.headers.get(name) || ''))}`)
+    .join(', ');
+
+  return {
+    ok: false,
+    reason: `Secret mismatch. Expected ${describe(expected)}; received ${received}.`,
+  };
+}
+
+/** Headers a caller should send so the check above passes under either path. */
+export function cronAuthHeaders(secret: string): Record<string, string> {
+  const clean = secret.trim();
+  return {
+    Authorization: `Bearer ${clean}`,
+    'X-Cron-Secret': clean,
+  };
+}


### PR DESCRIPTION
Both failure modes logged the same line — "Unauthorized invocation" — so a missing environment variable and a wrong value were indistinguishable. Diagnosing one live cost several rounds of guessing at Netlify settings that turned out to be correct.

Now reports which it is: whether CRON_SECRET reached the function at all (naming Netlify scopes as the likely cause when it did not), or whether the value mismatched, with lengths and 4-char prefixes so a missing "Bearer " prefix, a stale secret, or a stray quote is visible at a glance. Lengths and prefixes only — never the secret, since function logs are readable by anyone with Netlify access.

Gates: build OK, typecheck OK, lint 0 errors, 721 tests pass.


Claude-Session: https://claude.ai/code/session_014SFnf6LWkmy56FgGHnh1g6