### PR TITLE
Commit the Next.js-managed agent rules block in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,3 +51,13 @@ When adding new products or add-ons:
 - Don't forget to update BOTH `tooltimepro/index.html` AND `src/app/page.tsx` when adding features
 - Don't push without verifying `npm run build` succeeds
 - Always add `customer_portal_pro` when listing add-ons (it's new and easy to forget)
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->


### PR DESCRIPTION
## Why

`next dev` appends a managed `<!-- BEGIN:nextjs-agent-rules -->` block to `CLAUDE.md` on every run, via `node_modules/next/dist/server/lib/generate-agent-files.js`. Because that block was never committed, **every local dev run left the working tree dirty** and the change had to be reverted by hand each time.

Committing it stops the recurring churn.

## Why it actually fixes the churn

The generator's `hasCurrentAgentRules()` compares the installed block against the one it would write and skips the write when they match. Verified directly rather than assumed — calling the exported `writeAgentFiles()` twice in a row:

```
1st call: {"agentsMd":"skipped","claudeMd":"updated"}
2nd call: {"agentsMd":"skipped","claudeMd":"unchanged"}
```

So once this is on `main`, `next dev` leaves `CLAUDE.md` alone.

## How the block was produced

By calling the generator's exported `writeAgentFiles()` directly, **not** by retyping the text — so it matches what `next dev` writes byte for byte. A near-miss would silently reintroduce the churn this PR exists to remove.

It lands in `CLAUDE.md` rather than `AGENTS.md` only because this repo has no `AGENTS.md`. Per the generator's precedence logic, if an `AGENTS.md` is ever added it will host the block instead, and this one should move.

## Verification

- `npm run build` — passes
- `npm test` — 734 tests across 47 suites pass
- Docs only: `grep` confirms nothing in `src/`, `scripts/`, `next.config.js`, or `netlify.toml` imports or reads `CLAUDE.md`

## Note on the block's own wording

The text is written by the Next.js tooling, not by me, and it does argue for its own persistence (*"committing it with your work keeps the tree clean"*). I raised that before committing rather than acting on tool-authored instructions unprompted — this PR exists because the repo owner made that call. The underlying advice is legitimate: this repo is on Next.js 16.3.1, which does differ substantially from older conventions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Whzn9LBSCPnxXznombrc3Q)_