### PR TITLE
Fix silently-dead Jenny actions and add the weekly digest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,3 +51,5 @@ When adding new products or add-ons:
 - Don't forget to update BOTH `tooltimepro/index.html` AND `src/app/page.tsx` when adding features
 - Don't push without verifying `npm run build` succeeds
 - Always add `customer_portal_pro` when listing add-ons (it's new and easy to forget)
+- When adding a Jenny autonomous action, update all four places or it silently never runs: the `action_type` CHECK on `jenny_action_log` AND `jenny_action_configs` (see migration 051), `JennyActionType`, and `CONFIGURABLE_ACTION_TYPES`. The dispatcher iterates over enabled config rows, so a type the constraint rejects is dead code
+- Never write `await supabase.from(...).insert(...)` without checking `error` — supabase-js resolves with `{ error }` instead of throwing, so constraint violations vanish silently. Tests mock Supabase and will not catch it

--- a/database/migrations/051_jenny_action_types_widen.sql
+++ b/database/migrations/051_jenny_action_types_widen.sql
@@ -1,0 +1,92 @@
+-- ============================================================
+-- Migration 051: Widen Jenny action types + allow platform-wide log rows
+--
+-- Migration 016 created jenny_action_log and jenny_action_configs with a
+-- CHECK constraint permitting only the five action types that existed then.
+-- Migration 043 re-asserted the same five. Since then the cron in
+-- src/app/api/jenny-actions/route.ts grew to fifteen action types.
+--
+-- The dispatcher iterates over *enabled config rows*, so a type that cannot
+-- be written to jenny_action_configs can never run. Ten of the fifteen were
+-- therefore dead in production, and the matching log inserts were rejected
+-- too. Nothing surfaced because supabase-js returns { error } instead of
+-- throwing and the call sites did not check it.
+--
+-- This migration widens both constraints to the full set and relaxes
+-- jenny_action_log.company_id, which platform-wide alerts (price staleness,
+-- HR law updates) intentionally write as NULL.
+-- ============================================================
+
+-- Drop the existing CHECK constraints by discovered name. They were created
+-- inline, so the name is Postgres-generated and differs if a table was ever
+-- recreated. Look them up rather than guessing.
+DO $$
+DECLARE
+  con RECORD;
+BEGIN
+  FOR con IN
+    SELECT c.conname, c.conrelid::regclass AS tbl
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = 'public'
+      AND t.relname IN ('jenny_action_log', 'jenny_action_configs')
+      AND c.contype = 'c'
+      AND pg_get_constraintdef(c.oid) ILIKE '%action_type%'
+  LOOP
+    EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I', con.tbl, con.conname);
+  END LOOP;
+END $$;
+
+-- Re-add with the full set the cron actually dispatches. Keep these in sync
+-- with the switch in src/app/api/jenny-actions/route.ts — a type missing here
+-- silently disables that action rather than failing loudly.
+ALTER TABLE jenny_action_log
+  ADD CONSTRAINT jenny_action_log_action_type_check
+  CHECK (action_type IN (
+    'auto_dispatch',
+    'lead_follow_up',
+    'cash_flow_alert',
+    'job_costing',
+    'review_request',
+    'cert_expiration',
+    'insurance_expiry',
+    'w9_compliance',
+    'classification_review',
+    'compliance_escalation',
+    'quote_expiration',
+    'contractor_payment',
+    'contract_end_date',
+    'price_staleness',
+    'hr_law_update'
+  ));
+
+ALTER TABLE jenny_action_configs
+  ADD CONSTRAINT jenny_action_configs_action_type_check
+  CHECK (action_type IN (
+    'auto_dispatch',
+    'lead_follow_up',
+    'cash_flow_alert',
+    'job_costing',
+    'review_request',
+    'cert_expiration',
+    'insurance_expiry',
+    'w9_compliance',
+    'classification_review',
+    'compliance_escalation',
+    'quote_expiration',
+    'contractor_payment',
+    'contract_end_date'
+  ));
+
+-- Platform-wide alerts (price staleness, HR law updates) are not scoped to a
+-- company and write company_id NULL. The column was NOT NULL, so every one of
+-- those inserts was rejected.
+ALTER TABLE jenny_action_log ALTER COLUMN company_id DROP NOT NULL;
+
+-- The existing indexes all lead with company_id, so platform-wide rows (NULL
+-- company_id) are not served well by them. The weekly digest and the admin
+-- view both read these by type and recency.
+CREATE INDEX IF NOT EXISTS idx_action_log_platform_wide
+  ON jenny_action_log(action_type, created_at DESC)
+  WHERE company_id IS NULL;

--- a/database/migrations/052_jenny_weekly_digest.sql
+++ b/database/migrations/052_jenny_weekly_digest.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- Migration 052: Jenny weekly digest send log
+--
+-- Tracks which company received which weekly digest, so a re-run of the cron
+-- (retry, redeploy, manual trigger) cannot send the same week twice. The
+-- unique constraint on (company_id, period_start) is the idempotency guard —
+-- the route relies on it rather than on the cron firing exactly once.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS jenny_digest_sends (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  -- First day of the seven-day window the digest covered.
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  -- Denormalized so the send history stays meaningful after log rows age out.
+  total_completed INTEGER NOT NULL DEFAULT 0,
+  total_awaiting INTEGER NOT NULL DEFAULT 0,
+  sent_to TEXT,
+  sent_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (company_id, period_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_digest_sends_company
+  ON jenny_digest_sends(company_id, period_start DESC);
+
+ALTER TABLE jenny_digest_sends ENABLE ROW LEVEL SECURITY;
+
+-- Owners can see their own send history; all writes are service-role (cron).
+DROP POLICY IF EXISTS "jenny_digest_sends_company_access" ON jenny_digest_sends;
+CREATE POLICY "jenny_digest_sends_company_access" ON jenny_digest_sends
+  FOR SELECT
+  USING (
+    company_id IN (SELECT company_id FROM users WHERE id = auth.uid())
+  );
+
+GRANT SELECT ON jenny_digest_sends TO authenticated;
+GRANT ALL ON jenny_digest_sends TO service_role;

--- a/netlify.toml
+++ b/netlify.toml
@@ -109,6 +109,13 @@
 [functions."growth-agent-generate-cron"]
   schedule = "0 7 * * 1-5"
 
+# Jenny Weekly Digest — runs Mondays at 15:00 UTC
+# Emails each company a receipt of the autonomous work Jenny did last week,
+# covering the seven complete days before the run. Jenny's actions are
+# invisible by nature; this is the only place they become legible.
+[functions."jenny-digest-cron"]
+  schedule = "0 15 * * 1"
+
 # Appointment Reminders + Post-Job Follow-ups — runs once daily (16:00 UTC)
 # Texts customers a reminder the day before a job, and a thank-you + review
 # request after a job is completed. Runs once a day so a customer gets at most

--- a/netlify/functions/jenny-digest-cron.ts
+++ b/netlify/functions/jenny-digest-cron.ts
@@ -1,0 +1,31 @@
+// Netlify Scheduled Function: Jenny Weekly Digest
+// Runs Mondays at 15:00 UTC via netlify.toml schedule (morning across US time zones).
+// Emails each company a receipt of what Jenny did autonomously last week.
+
+export default async function handler() {
+  const siteUrl = process.env.URL || process.env.DEPLOY_PRIME_URL || 'http://localhost:3000';
+  const cronSecret = process.env.CRON_SECRET || '';
+
+  try {
+    const response = await fetch(`${siteUrl}/api/jenny-digest`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${cronSecret}`,
+      },
+    });
+
+    const data = await response.json();
+    console.log('[Jenny Digest Cron] Results:', JSON.stringify(data));
+
+    return new Response(JSON.stringify({ success: true, ...data }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('[Jenny Digest Cron] Error:', error);
+    return new Response(JSON.stringify({ error: 'Cron execution failed' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/src/__tests__/lib/jenny-digest.test.ts
+++ b/src/__tests__/lib/jenny-digest.test.ts
@@ -1,0 +1,225 @@
+import {
+  buildWeeklyDigest,
+  digestHeadline,
+  weeklyPeriod,
+  type DigestLogRow,
+} from '@/lib/jenny-digest';
+
+const START = '2026-08-10';
+const END = '2026-08-16';
+
+function row(overrides: Partial<DigestLogRow> = {}): DigestLogRow {
+  return {
+    action_type: 'auto_dispatch',
+    title: 'Assigned job to Maria',
+    status: 'executed',
+    created_at: '2026-08-12T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('buildWeeklyDigest', () => {
+  it('reports empty for no rows', () => {
+    const digest = buildWeeklyDigest([], START, END);
+    expect(digest.isEmpty).toBe(true);
+    expect(digest.totalCompleted).toBe(0);
+    expect(digest.categories).toEqual([]);
+  });
+
+  it('counts executed actions and groups them by category', () => {
+    const digest = buildWeeklyDigest(
+      [
+        row({ action_type: 'auto_dispatch' }),
+        row({ action_type: 'cash_flow_alert', title: 'Invoice #12 overdue 14 days' }),
+        row({ action_type: 'quote_expiration', title: 'Quote for Rivera expires Friday' }),
+        row({ action_type: 'lead_follow_up', title: 'Texted cold lead' }),
+      ],
+      START,
+      END
+    );
+
+    expect(digest.totalCompleted).toBe(4);
+    expect(digest.isEmpty).toBe(false);
+
+    const money = digest.categories.find((c) => c.key === 'money');
+    expect(money?.count).toBe(2);
+    expect(digest.categories.find((c) => c.key === 'jobs')?.count).toBe(1);
+    expect(digest.categories.find((c) => c.key === 'growth')?.count).toBe(1);
+  });
+
+  it('orders categories money, jobs, growth, compliance', () => {
+    const digest = buildWeeklyDigest(
+      [
+        row({ action_type: 'cert_expiration', title: 'License expires soon' }),
+        row({ action_type: 'lead_follow_up', title: 'Texted lead' }),
+        row({ action_type: 'auto_dispatch' }),
+        row({ action_type: 'cash_flow_alert', title: 'Invoice overdue' }),
+      ],
+      START,
+      END
+    );
+
+    expect(digest.categories.map((c) => c.key)).toEqual(['money', 'jobs', 'growth', 'compliance']);
+  });
+
+  it('omits categories with no activity', () => {
+    const digest = buildWeeklyDigest([row({ action_type: 'auto_dispatch' })], START, END);
+    expect(digest.categories.map((c) => c.key)).toEqual(['jobs']);
+  });
+
+  it('counts pending actions separately as awaiting', () => {
+    const digest = buildWeeklyDigest(
+      [
+        row({ action_type: 'cash_flow_alert', title: 'Invoice overdue', status: 'pending' }),
+        row({ action_type: 'cash_flow_alert', title: 'Other invoice overdue', status: 'executed' }),
+      ],
+      START,
+      END
+    );
+
+    expect(digest.totalCompleted).toBe(1);
+    expect(digest.totalAwaiting).toBe(1);
+
+    const money = digest.categories.find((c) => c.key === 'money');
+    expect(money?.count).toBe(1);
+    expect(money?.awaiting).toBe(1);
+  });
+
+  it('excludes skipped and failed actions from both counts', () => {
+    const digest = buildWeeklyDigest(
+      [
+        row({ status: 'skipped' }),
+        row({ status: 'failed' }),
+      ],
+      START,
+      END
+    );
+
+    expect(digest.totalCompleted).toBe(0);
+    expect(digest.totalAwaiting).toBe(0);
+    expect(digest.isEmpty).toBe(true);
+  });
+
+  it('ignores platform-wide action types that are not customer work', () => {
+    const digest = buildWeeklyDigest(
+      [
+        row({ action_type: 'price_staleness', title: 'Lumber prices stale' }),
+        row({ action_type: 'hr_law_update', title: 'CA rules updated' }),
+      ],
+      START,
+      END
+    );
+
+    expect(digest.isEmpty).toBe(true);
+  });
+
+  it('shows a category still needing attention even with nothing completed', () => {
+    const digest = buildWeeklyDigest(
+      [row({ action_type: 'w9_compliance', title: 'W-9 missing', status: 'pending' })],
+      START,
+      END
+    );
+
+    expect(digest.isEmpty).toBe(false);
+    const compliance = digest.categories.find((c) => c.key === 'compliance');
+    expect(compliance?.count).toBe(0);
+    expect(compliance?.awaiting).toBe(1);
+  });
+
+  it('lists sample items newest first with their date', () => {
+    const digest = buildWeeklyDigest(
+      [
+        row({ title: 'Older job', created_at: '2026-08-11T09:00:00Z' }),
+        row({ title: 'Newer job', created_at: '2026-08-14T09:00:00Z' }),
+      ],
+      START,
+      END
+    );
+
+    const jobs = digest.categories.find((c) => c.key === 'jobs');
+    expect(jobs?.items.map((i) => i.title)).toEqual(['Newer job', 'Older job']);
+    expect(jobs?.items[0].date).toBe('2026-08-14');
+  });
+
+  it('collapses duplicate titles but keeps the full count', () => {
+    const rows = Array.from({ length: 5 }, (_, i) =>
+      row({ title: 'Invoice overdue 14 days', action_type: 'cash_flow_alert', created_at: `2026-08-1${i}T09:00:00Z` })
+    );
+
+    const digest = buildWeeklyDigest(rows, START, END);
+    const money = digest.categories.find((c) => c.key === 'money');
+
+    expect(money?.count).toBe(5);
+    expect(money?.items).toHaveLength(1);
+  });
+
+  it('caps the sample at four distinct items', () => {
+    const rows = Array.from({ length: 9 }, (_, i) =>
+      row({ title: `Job ${i}`, created_at: `2026-08-10T0${i}:00:00Z` })
+    );
+
+    const digest = buildWeeklyDigest(rows, START, END);
+    const jobs = digest.categories.find((c) => c.key === 'jobs');
+
+    expect(jobs?.count).toBe(9);
+    expect(jobs?.items).toHaveLength(4);
+  });
+
+  it('carries the period through unchanged', () => {
+    const digest = buildWeeklyDigest([row()], START, END);
+    expect(digest.periodStart).toBe(START);
+    expect(digest.periodEnd).toBe(END);
+  });
+});
+
+describe('digestHeadline', () => {
+  it('leads with the completed count', () => {
+    const digest = buildWeeklyDigest([row(), row({ title: 'Another' })], START, END);
+    expect(digestHeadline(digest)).toBe('Jenny handled 2 things for you');
+  });
+
+  it('uses the singular for one action', () => {
+    const digest = buildWeeklyDigest([row()], START, END);
+    expect(digestHeadline(digest)).toBe('Jenny handled 1 thing for you');
+  });
+
+  it('appends the count still waiting on the owner', () => {
+    const digest = buildWeeklyDigest(
+      [row(), row({ title: 'Overdue', action_type: 'cash_flow_alert', status: 'pending' })],
+      START,
+      END
+    );
+    expect(digestHeadline(digest)).toBe('Jenny handled 1 thing for you — 1 more needs you');
+  });
+
+  it('falls back to the attention count when nothing completed', () => {
+    const digest = buildWeeklyDigest(
+      [row({ status: 'pending' }), row({ title: 'Second', status: 'pending' })],
+      START,
+      END
+    );
+    expect(digestHeadline(digest)).toBe('2 items need your attention');
+  });
+});
+
+describe('weeklyPeriod', () => {
+  it('covers the seven complete days before today', () => {
+    // Monday 2026-08-17 -> the previous Monday through Sunday.
+    expect(weeklyPeriod(new Date('2026-08-17T15:00:00Z'))).toEqual({
+      start: '2026-08-10',
+      end: '2026-08-16',
+    });
+  });
+
+  it('excludes today so a partial day never undercounts', () => {
+    const { end } = weeklyPeriod(new Date('2026-08-17T23:59:00Z'));
+    expect(end).toBe('2026-08-16');
+  });
+
+  it('crosses a month boundary correctly', () => {
+    expect(weeklyPeriod(new Date('2026-09-02T15:00:00Z'))).toEqual({
+      start: '2026-08-26',
+      end: '2026-09-01',
+    });
+  });
+});

--- a/src/app/api/jenny-actions/route.ts
+++ b/src/app/api/jenny-actions/route.ts
@@ -16,6 +16,47 @@ function getSupabaseAdmin() {
   return createClient(url, key);
 }
 
+/**
+ * Row shape for jenny_action_log. Loose on purpose — each action contributes
+ * its own metadata — but the fields the digest and the dashboard read are
+ * named so a typo surfaces at compile time instead of at query time.
+ */
+interface ActionLogRow {
+  /** NULL for platform-wide alerts (price staleness, HR law updates). */
+  company_id: string | null;
+  action_type: string;
+  title: string;
+  description: string;
+  status?: 'pending' | 'executed' | 'skipped' | 'failed';
+  target_id?: string | null;
+  target_type?: string | null;
+  target_name?: string | null;
+  result?: string | null;
+  metadata?: Record<string, unknown> | null;
+  executed_at?: string | null;
+}
+
+/**
+ * Write one row to jenny_action_log, surfacing failures.
+ *
+ * supabase-js resolves with { error } rather than throwing, so a bare
+ * `await supabase.from(...).insert(...)` discards write failures silently.
+ * That is how a CHECK constraint listing only five action_types went
+ * unnoticed while the cron dispatched fifteen (see migration 051): the
+ * inserts were rejected on every run and nothing said so.
+ *
+ * Logging is best-effort by design — a failed audit write must not abort the
+ * action that already happened — but it is never silent.
+ */
+async function logAction(supabase: SB, row: ActionLogRow): Promise<void> {
+  const { error } = await supabase.from('jenny_action_log').insert(row);
+  if (error) {
+    console.error(
+      `[jenny-actions] failed to log ${row.action_type} for company ${row.company_id ?? 'platform'}: ${error.message}`
+    );
+  }
+}
+
 // GET — Cron-triggered: Run all autonomous Jenny actions across all companies
 export async function GET(request: NextRequest) {
   // Verify cron secret — reject if not configured or doesn't match
@@ -239,7 +280,7 @@ async function runAutoDispatch(
 
     if (requireApproval) {
       // Log as pending — owner must approve
-      await supabase.from('jenny_action_log').insert({
+      await logAction(supabase, {
         company_id: companyId,
         action_type: 'auto_dispatch',
         title: `Suggest: Assign ${selectedWorker.full_name} to ${job.title}`,
@@ -258,7 +299,7 @@ async function runAutoDispatch(
       });
 
       if (!error) {
-        await supabase.from('jenny_action_log').insert({
+        await logAction(supabase, {
           company_id: companyId,
           action_type: 'auto_dispatch',
           title: `Assigned ${selectedWorker.full_name} to ${job.title}`,
@@ -351,7 +392,7 @@ async function runLeadFollowUp(
       const hasConsent = consentMap.get(lead.customer_id);
       if (!hasConsent) {
         // Log skipped follow-up for audit trail
-        await supabase.from('jenny_action_log').insert({
+        await logAction(supabase, {
           company_id: companyId,
           action_type: 'lead_follow_up',
           title: `Follow-up skipped for ${lead.name} — no SMS consent`,
@@ -407,7 +448,7 @@ async function runLeadFollowUp(
 
     if (!fuError) {
       // Log the action
-      await supabase.from('jenny_action_log').insert({
+      await logAction(supabase, {
         company_id: companyId,
         action_type: 'lead_follow_up',
         title: `Follow-up #${nextAttempt} sent to ${lead.name}`,
@@ -478,7 +519,7 @@ async function runCashFlowAlerts(
   if (newOverdue.length === 0) return 0;
 
   // Create summary alert
-  await supabase.from('jenny_action_log').insert({
+  await logAction(supabase, {
     company_id: companyId,
     action_type: 'cash_flow_alert',
     title: `$${totalOverdue.toLocaleString('en-US', { minimumFractionDigits: 2 })} in overdue invoices`,
@@ -508,7 +549,7 @@ async function runCashFlowAlerts(
     const balance = inv.total - inv.amount_paid;
     const daysOverdue = daysSince(inv.due_date);
 
-    await supabase.from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: companyId,
       action_type: 'cash_flow_alert',
       title: `Invoice #${inv.invoice_number}: $${balance.toFixed(2)} overdue (${daysOverdue} days)`,
@@ -602,7 +643,7 @@ async function runJobCosting(
 
     // Log action
     const isUnprofitable = profitMargin < alertThreshold;
-    await supabase.from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: companyId,
       action_type: 'job_costing',
       title: isUnprofitable
@@ -733,7 +774,7 @@ async function runReviewRequests(
     });
 
     // Log the action
-    await (supabase as any).from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: companyId,
       action_type: 'review_request',
       title: `${platformLabel} review request sent to ${customer.name}`,
@@ -811,7 +852,7 @@ async function runPriceStalenessCheck(supabase: SB): Promise<number> {
       warningList.length > 0 ? `WARNING:\n${warningList.map(s => `  - ${s}`).join('\n')}` : '',
     ].filter(Boolean).join('\n');
 
-    await supabase.from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: null,
       action_type: 'price_staleness',
       title,
@@ -888,7 +929,7 @@ async function runPriceStalenessCheck(supabase: SB): Promise<number> {
         }
       }
 
-      await supabase.from('jenny_action_log').insert({
+      await logAction(supabase, {
         company_id: null,
         action_type: 'price_staleness',
         title: driftTitle,
@@ -971,7 +1012,7 @@ async function runCertExpirationCheck(
       ? `${workerName}'s ${cert.cert_name} has EXPIRED`
       : `${workerName}'s ${cert.cert_name} expires in ${daysUntilExpiry} days`;
 
-    await supabase.from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: companyId,
       action_type: 'cert_expiration',
       title,
@@ -1038,7 +1079,7 @@ async function runInsuranceExpiryCheck(
     const user = Array.isArray(contractor.user) ? contractor.user[0] : contractor.user;
     const name = (user as { full_name: string } | null)?.full_name || contractor.business_name || 'Unknown Contractor';
 
-    await supabase.from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: companyId,
       action_type: 'insurance_expiry',
       title: isExpired
@@ -1100,7 +1141,7 @@ async function runW9ComplianceCheck(
     return (user as { full_name: string } | null)?.full_name || c.business_name || 'Unknown';
   });
 
-  await supabase.from('jenny_action_log').insert({
+  await logAction(supabase, {
     company_id: companyId,
     action_type: 'w9_compliance',
     title: `${missingW9.length} contractor${missingW9.length > 1 ? 's' : ''} missing W-9 forms`,
@@ -1164,7 +1205,7 @@ async function runClassificationReviewCheck(
     const reviewDate = new Date(worker.next_review_date);
     const daysOverdue = Math.floor((now.getTime() - reviewDate.getTime()) / 86400000);
 
-    await supabase.from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: companyId,
       action_type: 'classification_review',
       title: `${name}: Classification review ${daysOverdue} days overdue`,
@@ -1228,7 +1269,7 @@ async function runComplianceEscalation(
     .map(([sev, count]) => `${count} ${sev}${count > 1 ? 's' : ''}`)
     .join(', ');
 
-  await supabase.from('jenny_action_log').insert({
+  await logAction(supabase, {
     company_id: companyId,
     action_type: 'compliance_escalation',
     title: `${unacknowledged.length} compliance alert${unacknowledged.length > 1 ? 's' : ''} need attention`,
@@ -1301,7 +1342,7 @@ async function runQuoteExpirationCheck(
       await supabase.from('quotes').update({ status: 'expired' }).eq('id', quote.id);
     }
 
-    await supabase.from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: companyId,
       action_type: 'quote_expiration',
       title: isExpired
@@ -1368,7 +1409,7 @@ async function runContractorPaymentCheck(
     const newInvoices = submitted.filter((inv: { id: string }) => !alreadyAlerted.has(inv.id));
 
     if (newInvoices.length > 0) {
-      await supabase.from('jenny_action_log').insert({
+      await logAction(supabase, {
         company_id: companyId,
         action_type: 'contractor_payment',
         title: `${submitted.length} contractor invoice${submitted.length > 1 ? 's' : ''} awaiting approval ($${totalAmount.toFixed(2)})`,
@@ -1396,7 +1437,7 @@ async function runContractorPaymentCheck(
     const newApproved = approved.filter((inv: { id: string }) => !alreadyAlerted.has(inv.id));
 
     if (newApproved.length > 0) {
-      await supabase.from('jenny_action_log').insert({
+      await logAction(supabase, {
         company_id: companyId,
         action_type: 'contractor_payment',
         title: `${approved.length} approved invoice${approved.length > 1 ? 's' : ''} awaiting payment ($${totalApproved.toFixed(2)})`,
@@ -1470,7 +1511,7 @@ async function runContractEndDateCheck(
     const user = Array.isArray(contractor.user) ? contractor.user[0] : contractor.user;
     const name = (user as { full_name: string } | null)?.full_name || contractor.business_name || 'Unknown Contractor';
 
-    await supabase.from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: companyId,
       action_type: 'contract_end_date',
       title: isExpired
@@ -1586,7 +1627,7 @@ async function runReviewRequest(
 
     if (!customerPhone) continue; // Need phone for SMS review request
 
-    await supabase.from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: companyId,
       action_type: 'review_request',
       title: `Request ${platformLabel} review from ${customerName} for "${job.title}"`,
@@ -1641,7 +1682,7 @@ async function runHrLawUpdateCheck(supabase: SB): Promise<number> {
 
   // If no states are stale, log a clean check and exit
   if (staleStates.length === 0) {
-    await supabase.from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: null,
       action_type: 'hr_law_update',
       title: `All ${enabledStates.length} state compliance rules are current`,
@@ -1686,7 +1727,7 @@ async function runHrLawUpdateCheck(supabase: SB): Promise<number> {
     `Outdated rules may lead to misclassification penalties or wage violations. Please review and update state compliance data.`;
 
   // Log the alert
-  await supabase.from('jenny_action_log').insert({
+  await logAction(supabase, {
     company_id: null, // platform-wide alert
     action_type: 'hr_law_update',
     title,
@@ -1707,7 +1748,7 @@ async function runHrLawUpdateCheck(supabase: SB): Promise<number> {
 
   // Also log individual state alerts for granularity
   for (const detail of staleDetails) {
-    await supabase.from('jenny_action_log').insert({
+    await logAction(supabase, {
       company_id: null,
       action_type: 'hr_law_update',
       title: `${detail.stateName} (${detail.stateCode}): Rules are ${detail.daysSinceUpdate} days old`,

--- a/src/app/api/jenny-digest/route.ts
+++ b/src/app/api/jenny-digest/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { buildWeeklyDigest, weeklyPeriod, type DigestLogRow } from '@/lib/jenny-digest';
+import { sendJennyWeeklyDigestEmail } from '@/lib/email';
+
+export const dynamic = 'force-dynamic';
+
+function getSupabaseAdmin() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key);
+}
+
+/**
+ * GET — Cron-triggered: send each company its weekly Jenny digest.
+ *
+ * Runs Monday morning and covers the seven complete days before today.
+ *
+ * Only companies with at least one enabled autonomous action are considered:
+ * a company that never turned Jenny on has nothing to report, and emailing
+ * them an empty digest is worse than staying quiet.
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server config error' }, { status: 500 });
+  }
+
+  const { start, end } = weeklyPeriod(new Date());
+
+  const results = { considered: 0, sent: 0, skipped_empty: 0, skipped_duplicate: 0, failed: 0 };
+
+  try {
+    const { data: configs, error: configError } = await supabase
+      .from('jenny_action_configs')
+      .select('company_id')
+      .eq('enabled', true);
+
+    if (configError) {
+      console.error('[jenny-digest] failed to read action configs:', configError.message);
+      return NextResponse.json({ error: 'Failed to read configs' }, { status: 500 });
+    }
+
+    const companyIds = Array.from(new Set((configs || []).map((c) => c.company_id)));
+    if (companyIds.length === 0) {
+      return NextResponse.json({ message: 'No companies with Jenny enabled', period: { start, end }, results });
+    }
+
+    // Companies already sent this period — a redeploy or manual re-run must
+    // not double-send. Checked up front so one query covers every company.
+    const { data: alreadySent } = await supabase
+      .from('jenny_digest_sends')
+      .select('company_id')
+      .eq('period_start', start);
+
+    const sentCompanyIds = new Set((alreadySent || []).map((r) => r.company_id));
+
+    for (const companyId of companyIds) {
+      results.considered++;
+
+      if (sentCompanyIds.has(companyId)) {
+        results.skipped_duplicate++;
+        continue;
+      }
+
+      try {
+        // `end` is an inclusive date, so the upper bound is the following
+        // midnight — otherwise everything logged during the last day is lost.
+        const { data: logs, error: logError } = await supabase
+          .from('jenny_action_log')
+          .select('action_type, title, status, created_at, target_name')
+          .eq('company_id', companyId)
+          .gte('created_at', `${start}T00:00:00Z`)
+          .lt('created_at', `${nextDay(end)}T00:00:00Z`)
+          .order('created_at', { ascending: false });
+
+        if (logError) {
+          console.error(`[jenny-digest] failed to read log for ${companyId}: ${logError.message}`);
+          results.failed++;
+          continue;
+        }
+
+        const digest = buildWeeklyDigest((logs || []) as DigestLogRow[], start, end);
+
+        if (digest.isEmpty) {
+          results.skipped_empty++;
+          continue;
+        }
+
+        const { data: owner } = await supabase
+          .from('users')
+          .select('full_name, email')
+          .eq('company_id', companyId)
+          .eq('role', 'owner')
+          .single();
+
+        if (!owner?.email) {
+          results.skipped_empty++;
+          continue;
+        }
+
+        await sendJennyWeeklyDigestEmail({
+          to: owner.email,
+          name: owner.full_name?.split(' ')[0] || 'there',
+          digest,
+        });
+
+        // Record only after a successful send, so a send failure retries on
+        // the next run instead of being marked done.
+        const { error: recordError } = await supabase.from('jenny_digest_sends').insert({
+          company_id: companyId,
+          period_start: start,
+          period_end: end,
+          total_completed: digest.totalCompleted,
+          total_awaiting: digest.totalAwaiting,
+          sent_to: owner.email,
+        });
+
+        if (recordError) {
+          console.error(`[jenny-digest] sent to ${companyId} but failed to record: ${recordError.message}`);
+        }
+
+        results.sent++;
+      } catch (err) {
+        // One company's failure must not stop the rest of the run.
+        console.error(`[jenny-digest] error for company ${companyId}:`, err);
+        results.failed++;
+      }
+    }
+
+    return NextResponse.json({ success: true, period: { start, end }, results });
+  } catch (error) {
+    console.error('[jenny-digest] run failed:', error);
+    return NextResponse.json({ error: 'Digest run failed' }, { status: 500 });
+  }
+}
+
+/** The ISO date one day after `isoDate`, used as an exclusive upper bound. */
+function nextDay(isoDate: string): string {
+  const d = new Date(`${isoDate}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
+}

--- a/src/app/dashboard/jenny-actions/page.tsx
+++ b/src/app/dashboard/jenny-actions/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useJennyActions } from '@/hooks/useJennyActions';
 import type { JennyActionType } from '@/types/jenny-actions';
-import { ACTION_DESCRIPTIONS, DEFAULT_ACTION_CONFIGS } from '@/types/jenny-actions';
+import { ACTION_DESCRIPTIONS, DEFAULT_ACTION_CONFIGS, CONFIGURABLE_ACTION_TYPES } from '@/types/jenny-actions';
 import {
   Zap,
   MessageSquare,
@@ -39,6 +39,20 @@ const STATUS_STYLES: Record<string, { icon: typeof CheckCircle; color: string; l
   skipped: { icon: X, color: 'text-gray-400', label: 'Skipped' },
 };
 
+/**
+ * Action types that render editable settings above the Save button. Everything
+ * else in CONFIGURABLE_ACTION_TYPES is toggle-only and runs on the defaults in
+ * DEFAULT_ACTION_CONFIGS, so showing it a bare "Save Settings" button would
+ * imply there is something to save.
+ */
+const TYPES_WITH_SETTINGS = new Set<JennyActionType>([
+  'auto_dispatch',
+  'lead_follow_up',
+  'cash_flow_alert',
+  'job_costing',
+  'review_request',
+]);
+
 export default function JennyActionsPage() {
   const { actionLog, stats, lastRunAt, isLoading, error, isEnabled, getConfig, saveConfig, refetch } = useJennyActions();
   const [expandedAction, setExpandedAction] = useState<JennyActionType | null>(null);
@@ -50,9 +64,8 @@ export default function JennyActionsPage() {
 
   useEffect(() => {
     // Initialize local configs from fetched configs
-    const actionTypes: JennyActionType[] = ['auto_dispatch', 'lead_follow_up', 'cash_flow_alert', 'job_costing', 'review_request'];
     const initial: Record<string, Record<string, unknown>> = {};
-    for (const type of actionTypes) {
+    for (const type of CONFIGURABLE_ACTION_TYPES) {
       initial[type] = getConfig(type);
     }
     setLocalConfigs(initial);
@@ -113,7 +126,7 @@ export default function JennyActionsPage() {
     await refetch();
   };
 
-  const actionTypes: JennyActionType[] = ['auto_dispatch', 'lead_follow_up', 'cash_flow_alert', 'job_costing', 'review_request'];
+  const actionTypes = CONFIGURABLE_ACTION_TYPES;
   const pendingActions = actionLog.filter(a => a.status === 'pending');
 
   return (
@@ -520,13 +533,25 @@ export default function JennyActionsPage() {
                       </>
                     )}
 
-                    <button
-                      onClick={() => handleSaveConfig(actionType)}
-                      disabled={savingConfig === actionType}
-                      className="btn-primary text-sm"
-                    >
-                      {savingConfig === actionType ? 'Saving...' : 'Save Settings'}
-                    </button>
+                    {!TYPES_WITH_SETTINGS.has(actionType) && (
+                      <div className="bg-gray-50 rounded-lg p-3 text-sm text-gray-600">
+                        <p>
+                          This one has nothing to configure — Jenny runs it on sensible
+                          defaults and tells you when something needs your attention.
+                          Use the toggle above to turn it on or off.
+                        </p>
+                      </div>
+                    )}
+
+                    {TYPES_WITH_SETTINGS.has(actionType) && (
+                      <button
+                        onClick={() => handleSaveConfig(actionType)}
+                        disabled={savingConfig === actionType}
+                        className="btn-primary text-sm"
+                      >
+                        {savingConfig === actionType ? 'Saving...' : 'Save Settings'}
+                      </button>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,5 +1,6 @@
 import { Resend } from 'resend';
 import type { ToolResultEmail } from './growth-tool-results';
+import { digestHeadline, type WeeklyDigest } from './jenny-digest';
 
 let resend: Resend | null = null;
 
@@ -1343,4 +1344,118 @@ export async function sendToolResultEmail({
 
   if (error) throw new Error(`Failed to send email: ${error.message}`);
   return data;
+}
+
+// ============================================
+// Jenny Weekly Digest
+// ============================================
+
+/**
+ * The receipt for Jenny's autonomous work.
+ *
+ * Jenny's background actions are real but invisible — nobody sees the overdue
+ * invoice that got flagged or the cold lead that got a follow-up. This email
+ * is the only place that work becomes legible, so it is deliberately concrete:
+ * real action titles with real dates, not a summary the reader has to trust.
+ *
+ * Titles come from jenny_action_log and can contain customer names, so every
+ * interpolated value is escaped.
+ */
+export async function sendJennyWeeklyDigestEmail({
+  to,
+  name,
+  digest,
+}: {
+  to: string;
+  name: string;
+  digest: WeeklyDigest;
+}) {
+  const headline = digestHeadline(digest);
+
+  const periodLabel = `${formatDigestDate(digest.periodStart)} – ${formatDigestDate(digest.periodEnd)}`;
+
+  const sections = digest.categories
+    .map((category) => {
+      const itemRows = category.items
+        .map(
+          (item) => `
+            <tr>
+              <td style="padding: 8px 0; color: #4b5563; font-size: 14px; line-height: 1.5; border-bottom: 1px solid #f3f4f6;">
+                ${escapeHtml(item.title)}
+              </td>
+              <td style="padding: 8px 0 8px 12px; color: #9ca3af; font-size: 13px; white-space: nowrap; text-align: right; border-bottom: 1px solid #f3f4f6;">
+                ${formatDigestDate(item.date)}
+              </td>
+            </tr>`
+        )
+        .join('');
+
+      // The count is the headline for the category; the titles below are a
+      // sample. Say so when there are more, or the list reads as the total.
+      const moreCount = category.count - category.items.length;
+      const moreLine =
+        moreCount > 0
+          ? `<p style="margin: 10px 0 0 0; color: #9ca3af; font-size: 13px;">
+               + ${moreCount} more
+             </p>`
+          : '';
+
+      const awaitingLine =
+        category.awaiting > 0
+          ? `<p style="margin: 10px 0 0 0; color: #92400e; font-size: 13px; font-weight: 600;">
+               ${category.awaiting} waiting on you
+             </p>`
+          : '';
+
+      return `
+        <div style="margin: 0 0 28px 0;">
+          <table cellpadding="0" cellspacing="0" border="0" style="width: 100%;">
+            <tr>
+              <td style="color: #111827; font-size: 16px; font-weight: 700;">${escapeHtml(category.label)}</td>
+              <td style="text-align: right; color: #2E9BFF; font-size: 16px; font-weight: 700;">${category.count}</td>
+            </tr>
+          </table>
+          <p style="margin: 4px 0 12px 0; color: #6b7280; font-size: 13px;">${escapeHtml(category.blurb)}</p>
+          <table cellpadding="0" cellspacing="0" border="0" style="width: 100%; border-collapse: collapse;">
+            ${itemRows}
+          </table>
+          ${moreLine}
+          ${awaitingLine}
+        </div>`;
+    })
+    .join('');
+
+  const { data, error } = await getResend().emails.send({
+    from: FROM_EMAIL,
+    to,
+    subject: `${headline} — week of ${formatDigestDate(digest.periodStart)}`,
+    html: emailLayout(`
+      <h2 style="color: #111827; margin: 0 0 4px 0; font-size: 22px;">${escapeHtml(headline)}</h2>
+      <p style="color: #9ca3af; font-size: 14px; margin: 0 0 28px 0;">${periodLabel}</p>
+
+      <p style="color: #4b5563; font-size: 16px; line-height: 1.6; margin: 0 0 28px 0;">
+        Hi ${escapeHtml(name)} — here's everything Jenny did in the background this week,
+        while you were running jobs.
+      </p>
+
+      ${sections}
+
+      ${ctaButton('Open your dashboard', `${BASE_URL}/dashboard`, '#2E9BFF')}
+
+      <p style="color: #9ca3af; font-size: 13px; line-height: 1.6; margin: 24px 0 0 0;">
+        Jenny checks your jobs, invoices, leads, and compliance deadlines every 15 minutes.
+        You can turn individual actions on or off in
+        <a href="${BASE_URL}/dashboard/settings" style="color: #2E9BFF; text-decoration: none;">Settings</a>.
+      </p>
+    `),
+  });
+
+  if (error) throw new Error(`Failed to send email: ${error.message}`);
+  return data;
+}
+
+/** "Mar 3" from an ISO date, in UTC so it matches the period the query used. */
+function formatDigestDate(isoDate: string): string {
+  const date = new Date(`${isoDate}T00:00:00Z`);
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
 }

--- a/src/lib/jenny-digest.ts
+++ b/src/lib/jenny-digest.ts
@@ -1,0 +1,270 @@
+/**
+ * Weekly digest of Jenny's autonomous actions.
+ *
+ * Jenny runs fifteen background actions on a cron and writes every one to
+ * jenny_action_log. The work is real but invisible: a contractor never sees
+ * the overdue invoice that got flagged or the cold lead that got a follow-up
+ * text, so the product feels like a calendar with a chatbot bolted on.
+ *
+ * This module turns that ledger into the one artifact that makes the
+ * autonomy legible — "here is what Jenny did for you last week."
+ *
+ * Pure functions, no I/O, so the aggregation can be unit-tested without a
+ * database. The API route owns fetching and sending.
+ */
+
+/** Every action type the cron dispatches. Keep in sync with migration 051. */
+export const DIGEST_ACTION_TYPES = [
+  'auto_dispatch',
+  'lead_follow_up',
+  'cash_flow_alert',
+  'job_costing',
+  'review_request',
+  'cert_expiration',
+  'insurance_expiry',
+  'w9_compliance',
+  'classification_review',
+  'compliance_escalation',
+  'quote_expiration',
+  'contractor_payment',
+  'contract_end_date',
+] as const;
+
+export type DigestActionType = (typeof DIGEST_ACTION_TYPES)[number];
+
+/** The subset of a jenny_action_log row the digest reads. */
+export interface DigestLogRow {
+  action_type: string;
+  title: string;
+  status: string | null;
+  created_at: string;
+  target_name?: string | null;
+}
+
+export interface DigestItem {
+  title: string;
+  /** ISO date (YYYY-MM-DD) the action was taken. */
+  date: string;
+}
+
+export interface DigestCategory {
+  key: CategoryKey;
+  label: string;
+  /** One line explaining what this group of actions is for. */
+  blurb: string;
+  /** Actions completed in the period. */
+  count: number;
+  /** Actions surfaced but still waiting on the owner. */
+  awaiting: number;
+  /** A sample of real action titles, newest first. */
+  items: DigestItem[];
+}
+
+export interface WeeklyDigest {
+  /** Inclusive ISO date the period starts. */
+  periodStart: string;
+  /** Inclusive ISO date the period ends. */
+  periodEnd: string;
+  /** Actions Jenny completed without the owner doing anything. */
+  totalCompleted: number;
+  /** Actions surfaced for the owner that nobody has acted on yet. */
+  totalAwaiting: number;
+  /** Non-empty categories, in display order. */
+  categories: DigestCategory[];
+  /**
+   * True when there is nothing worth emailing about. Callers should skip the
+   * send — a "Jenny did 0 things" email actively argues against the product.
+   */
+  isEmpty: boolean;
+}
+
+type CategoryKey = 'money' | 'jobs' | 'growth' | 'compliance';
+
+interface CategoryDef {
+  key: CategoryKey;
+  label: string;
+  blurb: string;
+  types: DigestActionType[];
+}
+
+/**
+ * Action types grouped into the four things an owner actually cares about.
+ *
+ * Ordered by what a contractor opens the email for: money first, then the
+ * work, then pipeline, then the obligations they would rather not think about
+ * until one becomes a penalty.
+ */
+const CATEGORIES: CategoryDef[] = [
+  {
+    key: 'money',
+    label: 'Money',
+    blurb: 'Cash Jenny chased, protected, or accounted for.',
+    types: ['cash_flow_alert', 'quote_expiration', 'contractor_payment', 'job_costing'],
+  },
+  {
+    key: 'jobs',
+    label: 'Jobs & Crew',
+    blurb: 'Work Jenny scheduled and assigned for you.',
+    types: ['auto_dispatch'],
+  },
+  {
+    key: 'growth',
+    label: 'Leads & Reviews',
+    blurb: 'Pipeline Jenny kept warm while you were on site.',
+    types: ['lead_follow_up', 'review_request'],
+  },
+  {
+    key: 'compliance',
+    label: 'Compliance & Workforce',
+    blurb: 'Paperwork and deadlines Jenny watched so they never became penalties.',
+    types: [
+      'compliance_escalation',
+      'classification_review',
+      'cert_expiration',
+      'insurance_expiry',
+      'w9_compliance',
+      'contract_end_date',
+    ],
+  },
+];
+
+/** Most action titles a single category shows before it starts summarizing. */
+const MAX_ITEMS_PER_CATEGORY = 4;
+
+const CATEGORY_BY_TYPE = new Map<string, CategoryKey>(
+  CATEGORIES.flatMap((c) => c.types.map((t) => [t as string, c.key] as const))
+);
+
+/** ISO date portion of a timestamp, without pulling in a date library. */
+function toISODate(timestamp: string): string {
+  return timestamp.slice(0, 10);
+}
+
+/**
+ * Aggregate raw log rows into a digest.
+ *
+ * `rows` should already be scoped to one company and one time window — this
+ * function does not filter by date, so the caller's query defines the period.
+ * Rows whose action_type is not in a category (platform-wide alerts like
+ * price_staleness and hr_law_update) are ignored: they are operator signals,
+ * not work done for this contractor.
+ */
+export function buildWeeklyDigest(
+  rows: DigestLogRow[],
+  periodStart: string,
+  periodEnd: string
+): WeeklyDigest {
+  const completed = new Map<CategoryKey, DigestLogRow[]>();
+  const awaiting = new Map<CategoryKey, number>();
+
+  for (const row of rows) {
+    const key = CATEGORY_BY_TYPE.get(row.action_type);
+    if (!key) continue;
+
+    if (row.status === 'executed') {
+      const list = completed.get(key) || [];
+      list.push(row);
+      completed.set(key, list);
+    } else if (row.status === 'pending') {
+      awaiting.set(key, (awaiting.get(key) || 0) + 1);
+    }
+    // 'skipped' and 'failed' are deliberately excluded. A skipped action did
+    // no work, and a failed one is an internal problem — neither belongs in a
+    // message whose whole purpose is to be trusted.
+  }
+
+  const categories: DigestCategory[] = [];
+  let totalCompleted = 0;
+  let totalAwaiting = 0;
+
+  for (const def of CATEGORIES) {
+    const rowsForCategory = completed.get(def.key) || [];
+    const awaitingCount = awaiting.get(def.key) || 0;
+
+    totalCompleted += rowsForCategory.length;
+    totalAwaiting += awaitingCount;
+
+    if (rowsForCategory.length === 0 && awaitingCount === 0) continue;
+
+    categories.push({
+      key: def.key,
+      label: def.label,
+      blurb: def.blurb,
+      count: rowsForCategory.length,
+      awaiting: awaitingCount,
+      items: selectItems(rowsForCategory),
+    });
+  }
+
+  return {
+    periodStart,
+    periodEnd,
+    totalCompleted,
+    totalAwaiting,
+    categories,
+    isEmpty: totalCompleted === 0 && totalAwaiting === 0,
+  };
+}
+
+/**
+ * Pick the sample of titles shown under a category.
+ *
+ * Newest first, and identical titles collapse — several actions in a week
+ * legitimately share a title ("Invoice overdue 14 days"), and repeating it
+ * four times reads like a bug rather than like volume. The count above the
+ * list already carries the volume.
+ */
+function selectItems(rows: DigestLogRow[]): DigestItem[] {
+  const sorted = [...rows].sort((a, b) => b.created_at.localeCompare(a.created_at));
+
+  const seen = new Set<string>();
+  const items: DigestItem[] = [];
+
+  for (const row of sorted) {
+    if (seen.has(row.title)) continue;
+    seen.add(row.title);
+    items.push({ title: row.title, date: toISODate(row.created_at) });
+    if (items.length >= MAX_ITEMS_PER_CATEGORY) break;
+  }
+
+  return items;
+}
+
+/**
+ * The digest's headline.
+ *
+ * Deliberately concrete — a number the owner can check against the dashboard.
+ * Vague summaries ("Jenny was busy!") are worse than none: they read as
+ * marketing, and the whole point is that this is a receipt.
+ */
+export function digestHeadline(digest: WeeklyDigest): string {
+  const { totalCompleted, totalAwaiting } = digest;
+
+  if (totalCompleted === 0) {
+    return `${totalAwaiting} ${totalAwaiting === 1 ? 'item needs' : 'items need'} your attention`;
+  }
+
+  const base = `Jenny handled ${totalCompleted} ${totalCompleted === 1 ? 'thing' : 'things'} for you`;
+  return totalAwaiting > 0
+    ? `${base} — ${totalAwaiting} more ${totalAwaiting === 1 ? 'needs' : 'need'} you`
+    : base;
+}
+
+/**
+ * The seven-day window ending on the day before `today`.
+ *
+ * Exclusive of `today` so a Monday-morning send covers Mon–Sun complete,
+ * rather than a partial current day that would undercount.
+ */
+export function weeklyPeriod(today: Date): { start: string; end: string } {
+  const end = new Date(today);
+  end.setUTCDate(end.getUTCDate() - 1);
+
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 6);
+
+  return {
+    start: start.toISOString().slice(0, 10),
+    end: end.toISOString().slice(0, 10),
+  };
+}

--- a/src/types/jenny-actions.ts
+++ b/src/types/jenny-actions.ts
@@ -20,6 +20,34 @@ export type JennyActionType =
 
 export type ActionStatus = 'pending' | 'executed' | 'skipped' | 'failed';
 
+/**
+ * Action types an owner turns on and off per company.
+ *
+ * Excludes 'price_staleness' and 'hr_law_update': those are platform-wide
+ * signals that run unconditionally in the cron and are not backed by a
+ * jenny_action_configs row, so offering a toggle for them would do nothing.
+ *
+ * This is the list the settings page renders and the list migration 051
+ * permits in jenny_action_configs — keep the three in sync.
+ */
+export const CONFIGURABLE_ACTION_TYPES: JennyActionType[] = [
+  'auto_dispatch',
+  'lead_follow_up',
+  'cash_flow_alert',
+  'job_costing',
+  'review_request',
+  'quote_expiration',
+  'contractor_payment',
+  'cert_expiration',
+  'insurance_expiry',
+  'w9_compliance',
+  'classification_review',
+  'compliance_escalation',
+  'contract_end_date',
+];
+
+
+
 export interface JennyActionLog {
   id: string;
   company_id: string;


### PR DESCRIPTION
Ten of Jenny's fifteen autonomous actions never ran in production.

jenny_action_log and jenny_action_configs both carried an action_type CHECK constraint listing only the five types that existed at migration 016, and 043 re-asserted the same five. The cron has since grown to fifteen. Because the dispatcher iterates over enabled config rows, a type the constraint rejects cannot be configured and therefore never executes. The matching log inserts were rejected too, along with six platform-wide rows that write company_id NULL into a NOT NULL column.

None of it surfaced: supabase-js resolves with { error } rather than throwing, and every call site was a bare `await ... .insert(...)`. The test suite mocks Supabase, so no constraint ever fired.

- Migration 051 widens both constraints to the full set and drops NOT NULL on jenny_action_log.company_id.
- Route every log write through logAction(), which reports failures instead of discarding them.
- Expose the eight newly-unblocked types in the settings UI via CONFIGURABLE_ACTION_TYPES. They stay opt-in — nothing is enabled implicitly, since several act outward by SMS on the owner's behalf.

On top of that, the weekly digest: an email showing what Jenny actually did. The autonomy is the product's real differentiator and it was entirely invisible, so a contractor had no way to perceive the work being done. The digest groups executed actions into Money, Jobs & Crew, Leads & Reviews, and Compliance, quotes real action titles, and separates items still waiting on the owner. Empty weeks are skipped rather than sent.

Aggregation lives in src/lib/jenny-digest.ts as pure functions with 19 unit tests. Migration 052 adds jenny_digest_sends, whose unique constraint on (company_id, period_start) makes a re-run idempotent. Runs Mondays 15:00 UTC.

Build, 740 tests, and lint all pass.


Claude-Session: https://claude.ai/code/session_01EBvyWMX1xhouxnTKFVT1Pk