### PR TITLE
Read Claude's text block by type, not by index

### DIFF
--- a/netlify/functions/growth-agent-plan-background.ts
+++ b/netlify/functions/growth-agent-plan-background.ts
@@ -104,7 +104,11 @@ export default async function handler(request: Request) {
     const aiResult = await aiComplete({
       systemPrompt: PLANNER_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: buildPlannerPrompt(context) }],
-      maxTokens: 4000,
+      // 16000, not 4000. The reasoning tier is Opus 5, which runs extended
+      // thinking by default, and thinking tokens are drawn from max_tokens.
+      // A week's plan needs perhaps 2k of JSON, but the reasoning that gets
+      // there can exceed 4k on its own and leave nothing for the answer.
+      maxTokens: 16000,
       tier: 'reasoning',
     });
 

--- a/src/__tests__/lib/ai-client-response.test.js
+++ b/src/__tests__/lib/ai-client-response.test.js
@@ -1,0 +1,107 @@
+/**
+ * Reading Claude's response content.
+ *
+ * This pins a bug that cost a full planner run. The old code read
+ * `data.content[0].text`, which works only when the first block happens to be
+ * text. Claude Opus 5 runs extended thinking by default, so the first block is
+ * a `thinking` block with no `.text` field — the answer was discarded, reported
+ * as "empty response", and the request fell through to the other provider.
+ *
+ * The failure is silent by construction: callClaude returns an error object
+ * rather than throwing, so nothing surfaces until someone reads a log.
+ */
+
+// The module reads ANTHROPIC_API_KEY at load time and callClaude returns null
+// without it, so this has to be set before the require, not in a beforeEach.
+const originalKey = process.env.ANTHROPIC_API_KEY;
+process.env.ANTHROPIC_API_KEY = 'test-key';
+
+const { callClaude } = require('@/lib/ai-client');
+
+const originalFetch = global.fetch;
+
+/** Stubs one Claude API response body. */
+const respondWith = (body) => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => body,
+  });
+};
+
+const call = (overrides = {}) =>
+  callClaude({
+    systemPrompt: 'sys',
+    messages: [{ role: 'user', content: 'hi' }],
+    tier: 'reasoning',
+    ...overrides,
+  });
+
+afterAll(() => {
+  if (originalKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+  else process.env.ANTHROPIC_API_KEY = originalKey;
+  global.fetch = originalFetch;
+});
+
+describe('callClaude response parsing', () => {
+  it('reads the text block when a thinking block comes first', async () => {
+    respondWith({
+      stop_reason: 'end_turn',
+      content: [
+        { type: 'thinking', thinking: 'considering the funnel numbers' },
+        { type: 'text', text: '{"tasks": []}' },
+      ],
+    });
+    await expect(call()).resolves.toMatchObject({
+      content: '{"tasks": []}',
+      provider: 'claude',
+    });
+  });
+
+  it('still reads a plain text-first response', async () => {
+    respondWith({ stop_reason: 'end_turn', content: [{ type: 'text', text: 'hello' }] });
+    await expect(call()).resolves.toMatchObject({ content: 'hello' });
+  });
+
+  it('joins multiple text blocks rather than taking only the first', async () => {
+    respondWith({
+      stop_reason: 'end_turn',
+      content: [
+        { type: 'thinking', thinking: '...' },
+        { type: 'text', text: 'part one ' },
+        { type: 'text', text: 'part two' },
+      ],
+    });
+    await expect(call()).resolves.toMatchObject({ content: 'part one part two' });
+  });
+
+  it('names truncation rather than calling it empty', async () => {
+    // Thinking tokens draw from max_tokens, so a low ceiling can consume the
+    // whole budget before any text is produced. That is a different fix from
+    // a refusal or a malformed response, so it must read differently.
+    respondWith({
+      stop_reason: 'max_tokens',
+      content: [{ type: 'thinking', thinking: 'long reasoning that never finished' }],
+    });
+    const result = await call({ maxTokens: 4000 });
+    expect(result.content).toBeUndefined();
+    expect(result.error).toMatch(/4000-token limit/);
+  });
+
+  it('names a refusal and its category', async () => {
+    respondWith({
+      stop_reason: 'refusal',
+      stop_details: { type: 'refusal', category: 'cyber' },
+      content: [],
+    });
+    const result = await call();
+    expect(result.error).toMatch(/declined/i);
+    expect(result.error).toContain('cyber');
+  });
+
+  it('reports the block types it did get when no text is present', async () => {
+    respondWith({ stop_reason: 'end_turn', content: [{ type: 'thinking', thinking: 'x' }] });
+    const result = await call();
+    expect(result.error).toContain('thinking');
+    expect(result.error).toContain('end_turn');
+  });
+});

--- a/src/lib/ai-client.js
+++ b/src/lib/ai-client.js
@@ -140,8 +140,35 @@ async function callClaude({ systemPrompt, messages, maxTokens = 1024, temperatur
     }
 
     const data = await response.json();
-    const text = data.content?.[0]?.text?.trim();
-    if (!text) return { error: 'Claude returned empty response' };
+
+    // Find the text block by type, never by index. Claude Opus 5 runs extended
+    // thinking by default, so content[0] is a `thinking` block with no `.text`
+    // field — reading index 0 discarded a perfectly good answer and reported it
+    // as an empty response, which then fell through to the other provider.
+    const text = data.content
+      ?.filter((block) => block?.type === 'text')
+      .map((block) => block.text)
+      .join('')
+      .trim();
+
+    if (!text) {
+      // Say why it was empty. These three causes need different responses:
+      // a refusal is a prompt problem, truncation is a max_tokens problem, and
+      // anything else is worth seeing the actual block types for.
+      if (data.stop_reason === 'refusal') {
+        const category = data.stop_details?.category || 'unspecified';
+        return { error: `Claude declined the request (category: ${category})` };
+      }
+      if (data.stop_reason === 'max_tokens') {
+        return {
+          error:
+            `Claude hit the ${maxTokens}-token limit before producing any text. ` +
+            'Thinking tokens count against max_tokens — raise it for this call.',
+        };
+      }
+      const kinds = (data.content || []).map((block) => block?.type).join(', ') || 'none';
+      return { error: `Claude returned no text block (stop_reason: ${data.stop_reason}, blocks: ${kinds})` };
+    }
 
     return { content: text, provider: 'claude', model };
   } catch (err) {


### PR DESCRIPTION
The growth agent planner reached the model, got a usable plan back, and discarded it:

```
[Growth Planner] Error: Claude returned empty response | OpenAI API error 429: ...
```

## Cause

`callClaude` read the response as `data.content[0].text`. That works only when the first content block happens to be text. Claude Opus 5 — what the `reasoning` tier points at — runs extended thinking by default, so `content[0]` is a `thinking` block with no `.text` field. The answer sat at index 1, unread.

The request then fell through to OpenAI, which is out of credits, so the log showed two errors and neither named the real problem. The ~56s duration was the model reasoning and answering normally.

## Changes

**Select text blocks by type and join them** (`src/lib/ai-client.js`). No longer depends on block order or on how many text blocks the model emits.

**Replace the single "empty response" message with the three causes that need different fixes:**

| Cause | Message | What it means |
|---|---|---|
| `stop_reason: "refusal"` | names the refusal category | prompt problem |
| `stop_reason: "max_tokens"` | names the actual limit | budget problem |
| anything else | lists the block types received | unexpected shape |

**Raise the planner's `max_tokens` from 4000 to 16000** (`netlify/functions/growth-agent-plan-background.ts`). Thinking tokens draw from the same budget, so even with the parse fixed, a week's plan could spend the whole allowance reasoning and never reach the answer. The generator is unchanged — it runs on the `high` tier, where thinking is off unless explicitly requested.

## Scope

`callClaude` is shared, so the parsing fix applies to every Claude-backed route, not just the growth agent. Existing callers on the `high` and `fast` tiers were unaffected by the bug (those models don't think by default) and stay unaffected — a text-first response still parses identically, which the tests pin.

## Testing

- 763 tests pass, including 6 new ones in `src/__tests__/lib/ai-client-response.test.js` covering thinking-block-first, text-first, multiple text blocks, truncation, refusal, and the no-text-block case
- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean
- `npm run build` — clean

## Not addressed here

The OpenAI fallback reports `credit_balance_exhausted`. It only fired because Claude was wrongly judged to have failed, so it isn't on the critical path — but it does mean there is currently no working fallback provider if Anthropic is unavailable. Worth a deliberate decision (top up, or drop the fallback) rather than leaving it as-is.

---
_Generated by [Claude Code](https://claude.ai/code/session_014SFnf6LWkmy56FgGHnh1g6)_