### PR TITLE
Fix TC-WORK-04 flake: reset clock state after the timeclock loads

### DIFF
--- a/cypress/e2e/worker-flows.cy.js
+++ b/cypress/e2e/worker-flows.cy.js
@@ -58,11 +58,22 @@ function workerLogin() {
   it('TC-WORK-04: worker can clock in and clock out', () => {
     cy.visit('/worker/timeclock');
     cy.location('pathname', { timeout: 25000 }).should('include', '/worker/timeclock');
-    cy.get('body', { timeout: 20000 }).should('be.visible');
 
-    // Reset to a known state: if a prior run left an open entry, clock out first.
+    // The timeclock renders ONLY a loading spinner until it fetches the current
+    // clock state; a CLOCK IN/OUT button appears only once that resolves. Wait
+    // for a button before the reset check below — otherwise that synchronous
+    // check runs against the spinner (no buttons yet), skips, and the flow times
+    // out whenever a prior attempt left the worker clocked in.
+    cy.contains('button', /clock (in|out)/i, { timeout: 25000 }).should('be.visible');
+
+    // Reset to a known CLOCKED-OUT state. Cypress retries this spec up to 3×, and
+    // an earlier attempt can leave an open time entry — which renders CLOCK OUT.
+    // If so, clock out first so the flow always starts from CLOCK IN. Regex-test
+    // the body text (not jQuery :contains) so it's case-insensitive; the "Clocked
+    // In" status label doesn't contain the substring "clock out", so this is true
+    // only when the CLOCK OUT button is actually present.
     cy.get('body').then(($b) => {
-      if ($b.find('button:contains("CLOCK OUT")').length) {
+      if (/clock out/i.test($b.text())) {
         cy.contains('button', /clock out/i).click();
         cy.contains('button', /clock in/i, { timeout: 20000 }).should('be.visible');
       }


### PR DESCRIPTION
## Summary

Follow-up to #686. On the first worker-credentialed E2E run, **TC-WORK-01** and **TC-WORK-02** passed but **TC-WORK-04** (clock in/out) failed all 3 attempts, timing out looking for a CLOCK IN button.

Root cause is a **test-timing bug, not an app bug**:
- `/worker/timeclock` renders **only a loading spinner** until it fetches the current clock state — no CLOCK IN/OUT button exists yet.
- TC-WORK-04's "reset to a known state" check is synchronous (`cy.get('body').then(...)`), so it ran against that button-less spinner, found no CLOCK OUT button, and skipped the reset.
- An earlier attempt had left the worker **clocked in** (an open `time_entry`), so once loading finished the page showed **CLOCK OUT** — and the test waited 20s for a CLOCK IN button that was never going to appear.

## Fix (test-only)

- Wait for a `CLOCK IN`/`CLOCK OUT` button to render (loading finished) **before** the reset check.
- Detect the clocked-in state via a case-insensitive regex on the body text instead of a case-sensitive jQuery `:contains`, so the reset reliably clocks out first and the flow always starts from CLOCK IN.

No product code changes. The worker account itself is confirmed working (TC-WORK-01/02 pass + verified manual login lands on the timeclock).

## Verification

Targets **`sandbox`** (per the branch workflow — the authenticated Cypress suite runs on push to `sandbox`, not on PRs). Merging this into `sandbox` triggers the authenticated suite against the sandbox deploy, which runs the full worker suite (TC-WORK-01/02/04) with the `E2E_WORKER_EMAIL` / `E2E_WORKER_PASSWORD` secrets. Once green, `promote-sandbox.yml` opens the `sandbox → main` PR automatically.

Spec passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoMwQ1GFeJXBaVuAKLX16s