### PR TITLE
Warm /worker routes + widen TC-WORK-04 clock-button budget

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -197,7 +197,7 @@ jobs:
           # visit (two passes, failures ignored, 60s cap per request) so Cypress
           # runs against warm pages. Mirrors the same step in smoke.yml.
           # Best-effort: this step never fails the job.
-          paths="/auth/login /dashboard /dashboard/customers /dashboard/jobs /dashboard/quotes /dashboard/invoices /quote/demo"
+          paths="/auth/login /dashboard /dashboard/customers /dashboard/jobs /dashboard/quotes /dashboard/invoices /quote/demo /worker/login /worker /worker/timeclock"
           for pass in 1 2; do
             echo "— Warm-up pass $pass —"
             for p in $paths; do

--- a/cypress/e2e/worker-flows.cy.js
+++ b/cypress/e2e/worker-flows.cy.js
@@ -60,11 +60,12 @@ function workerLogin() {
     cy.location('pathname', { timeout: 25000 }).should('include', '/worker/timeclock');
 
     // The timeclock renders ONLY a loading spinner until it fetches the current
-    // clock state; a CLOCK IN/OUT button appears only once that resolves. Wait
-    // for a button before the reset check below — otherwise that synchronous
-    // check runs against the spinner (no buttons yet), skips, and the flow times
-    // out whenever a prior attempt left the worker clocked in.
-    cy.contains('button', /clock (in|out)/i, { timeout: 25000 }).should('be.visible');
+    // clock state (auth + users + open time_entry); a CLOCK IN/OUT button appears
+    // only once that resolves. Wait for a button before the reset check below —
+    // otherwise that synchronous check runs against the spinner (no buttons yet),
+    // skips, and the flow times out. The /worker routes aren't always warm (see
+    // the warm-up step in e2e.yml), so give this the full cold-start budget.
+    cy.contains('button', /clock (in|out)/i, { timeout: 40000 }).should('be.visible');
 
     // Reset to a known CLOCKED-OUT state. Cypress retries this spec up to 3×, and
     // an earlier attempt can leave an open time entry — which renders CLOCK OUT.


### PR DESCRIPTION
## Summary

Follow-up to #700. The first real sandbox run of the worker suite (after the worker account + secrets were wired up) surfaced **two cold/slow-deploy failures, not logic bugs**:

- **TC-X-01** — `cy.visit('/dashboard/customers')` failed with a network-level **`ETIMEDOUT`** (request failed without a response). Pure sandbox-infra flakiness; TC-X-01 was green on prior runs.
- **TC-WORK-04** — no `CLOCK IN`/`CLOCK OUT` button appeared within 25s. The timeclock renders only a loading spinner until its auth + `users` + open-`time_entry` fetch resolves, and the CI **warm-up step never warmed the `/worker` routes** (only `/dashboard/*`), so the worker function was cold when the spec hit it.

## Fix (CI/test-only)

- Add `/worker/login`, `/worker`, `/worker/timeclock` to the warm-up path list in `e2e.yml`, so the worker functions are warm before the worker specs run.
- Give TC-WORK-04's wait-for-clock-button the full cold-start budget (25s → 40s), matching the create-flow budgets in `authenticated-flows`.

No product code changes. The worker account itself is confirmed working — TC-WORK-01 and TC-WORK-02 passed on that same run, and manual login lands on the timeclock.

## Verification

Targets `sandbox`; merging triggers the authenticated suite (push to sandbox) against a warmed deploy, which re-runs the full worker suite. `node --check` passes; `e2e.yml` is valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoMwQ1GFeJXBaVuAKLX16s

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoMwQ1GFeJXBaVuAKLX16s)_