### PR TITLE
fix(worker): stop the timeclock wedging on a spinner, and reset TC-WORK-04 from any state

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,19 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder
 
+      # Cypress writes a screenshot of the exact DOM at the moment of failure.
+      # Without this they die with the runner, and a red run leaves only the
+      # assertion text — which says what was missing, never what was on screen
+      # instead. That cost a full debugging round on TC-WORK-04.
+      - name: Upload Cypress screenshots (public)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots-public
+          path: cypress/screenshots
+          if-no-files-found: ignore
+          retention-days: 14
+
   # Authenticated E2E — runs against the deployed sandbox with a real login.
   # Skips automatically until the E2E_* secrets are configured, so it never
   # breaks CI before you wire them up.
@@ -238,3 +251,16 @@ jobs:
           # spec skips itself; forwarding these activates it.
           CYPRESS_E2E_WORKER_EMAIL: ${{ secrets.E2E_WORKER_EMAIL }}
           CYPRESS_E2E_WORKER_PASSWORD: ${{ secrets.E2E_WORKER_PASSWORD }}
+
+      # See the note on the public job above. This one matters more: these specs
+      # run against the deployed sandbox, so the failure is not reproducible
+      # from the checkout afterwards — the screenshot is the only record of what
+      # the page actually rendered.
+      - name: Upload Cypress screenshots (authenticated)
+        if: failure() && steps.guard.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots-authenticated
+          path: cypress/screenshots
+          if-no-files-found: ignore
+          retention-days: 14

--- a/cypress/e2e/worker-flows.cy.js
+++ b/cypress/e2e/worker-flows.cy.js
@@ -29,8 +29,50 @@ function workerLogin() {
   });
 }
 
+// The timeclock has THREE action states, not two, and only one action button
+// is mounted at a time:
+//
+//   clocked out            → CLOCK IN
+//   clocked in             → CLOCK OUT
+//   clocked in + on break  → END BREAK   (neither clock button is in the DOM)
+//
+// Until the page resolves its clock state it renders a bare spinner with no
+// button at all, and while a write is in flight every label reads "Please
+// wait...". So: wait for a real label, then walk whatever state we found back
+// to clocked out. This spec shares its worker account with manual sandbox
+// smoke-testing and retries itself up to 3×, so it cannot assume how the
+// account was left — an unhandled on-break state wedges it permanently.
+const CLOCK_IN = /clock in/i;
+const CLOCK_OUT = /clock out/i;
+const END_BREAK = /end break/i;
+const ANY_ACTION = /clock in|clock out|end break/i;
+
+function resetToClockedOut() {
+  // 40s, not the usual 20: the /worker routes are warmed by e2e.yml but the
+  // sandbox can still be cold here, and this gate covers auth + the users row +
+  // the open time_entry lookup before any button mounts.
+  cy.contains('button', ANY_ACTION, { timeout: 40000 })
+    .should('be.visible')
+    .invoke('text')
+    .then((label) => {
+      if (END_BREAK.test(label)) {
+        cy.contains('button', END_BREAK).click();
+        cy.contains('button', CLOCK_OUT, { timeout: 20000 }).should('be.visible').click();
+      } else if (CLOCK_OUT.test(label)) {
+        cy.contains('button', CLOCK_OUT).click();
+      }
+    });
+
+  // Whichever branch ran, the flow under test starts from here.
+  cy.contains('button', CLOCK_IN, { timeout: 20000 }).should('be.visible');
+}
+
 (hasWorker ? describe : describe.skip)('Worker app flows', () => {
+  let alerts = [];
+
   beforeEach(() => {
+    alerts = [];
+    cy.on('window:alert', (msg) => alerts.push(msg));
     workerLogin();
   });
 
@@ -59,30 +101,18 @@ function workerLogin() {
     cy.visit('/worker/timeclock');
     cy.location('pathname', { timeout: 25000 }).should('include', '/worker/timeclock');
 
-    // The timeclock renders ONLY a loading spinner until it fetches the current
-    // clock state (auth + users + open time_entry); a CLOCK IN/OUT button appears
-    // only once that resolves. Wait for a button before the reset check below —
-    // otherwise that synchronous check runs against the spinner (no buttons yet),
-    // skips, and the flow times out. The /worker routes aren't always warm (see
-    // the warm-up step in e2e.yml), so give this the full cold-start budget.
-    cy.contains('button', /clock (in|out)/i, { timeout: 40000 }).should('be.visible');
-
-    // Reset to a known CLOCKED-OUT state. Cypress retries this spec up to 3×, and
-    // an earlier attempt can leave an open time entry — which renders CLOCK OUT.
-    // If so, clock out first so the flow always starts from CLOCK IN. Regex-test
-    // the body text (not jQuery :contains) so it's case-insensitive; the "Clocked
-    // In" status label doesn't contain the substring "clock out", so this is true
-    // only when the CLOCK OUT button is actually present.
-    cy.get('body').then(($b) => {
-      if (/clock out/i.test($b.text())) {
-        cy.contains('button', /clock out/i).click();
-        cy.contains('button', /clock in/i, { timeout: 20000 }).should('be.visible');
-      }
-    });
+    resetToClockedOut();
 
     // Clock in → the button flips to Clock Out → clock back out → flips back.
-    cy.contains('button', /clock in/i, { timeout: 20000 }).should('be.visible').click();
-    cy.contains('button', /clock out/i, { timeout: 20000 }).should('be.visible').click();
-    cy.contains('button', /clock in/i, { timeout: 20000 }).should('be.visible');
+    cy.contains('button', CLOCK_IN, { timeout: 20000 }).should('be.visible').click();
+    cy.contains('button', CLOCK_OUT, { timeout: 20000 }).should('be.visible').click();
+    cy.contains('button', CLOCK_IN, { timeout: 20000 }).should('be.visible');
+
+    // The page reports write failures through window.alert, which Cypress stubs
+    // and swallows. Without this the DB error behind a failed clock-in surfaces
+    // only as "timed out retrying" 20 seconds later, naming the wrong cause.
+    cy.then(() => {
+      expect(alerts, 'timeclock reported no errors').to.deep.equal([]);
+    });
   });
 });

--- a/messages/en/worker.json
+++ b/messages/en/worker.json
@@ -59,7 +59,10 @@
       "jobForShift": "Job for this shift",
       "generalShift": "General shift (no job)",
       "workingOn": "Working on",
-      "noCustomer": "No customer"
+      "noCustomer": "No customer",
+      "loadFailed": "Couldn't load your timeclock",
+      "tryAgain": "Try Again",
+      "clockInFailed": "Failed to clock in: "
     },
     "time": {
       "weekOf": "Week of",

--- a/messages/es/worker.json
+++ b/messages/es/worker.json
@@ -59,7 +59,10 @@
       "jobForShift": "Trabajo para este turno",
       "generalShift": "Turno general (sin trabajo)",
       "workingOn": "Trabajando en",
-      "noCustomer": "Sin cliente"
+      "noCustomer": "Sin cliente",
+      "loadFailed": "No se pudo cargar tu reloj",
+      "tryAgain": "Reintentar",
+      "clockInFailed": "No se pudo registrar la entrada: "
     },
     "time": {
       "weekOf": "Semana del",

--- a/src/__tests__/components/worker-timeclock.test.jsx
+++ b/src/__tests__/components/worker-timeclock.test.jsx
@@ -1,0 +1,181 @@
+/**
+ * Worker timeclock page — load-state and button-state regressions.
+ *
+ * The page renders ONE action button at a time, and TC-WORK-04 (cypress/e2e/
+ * worker-flows.cy.js) drives it by that button's label. Every case below is a
+ * state where the button the E2E expects is not the one on screen, which is
+ * indistinguishable from "the app is broken" when it happens in CI against the
+ * sandbox. They are asserted here, where the failure names its own cause.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Real English strings, so a label change that would break the E2E breaks here
+// first rather than at 3am against the sandbox.
+jest.mock('next-intl', () => {
+  const messages = require('../../../messages/en/worker.json');
+  return {
+    useTranslations: (namespace) => (key) =>
+      `${namespace}.${key}`
+        .split('.')
+        .reduce((node, part) => (node == null ? node : node[part]), messages) ?? `${namespace}.${key}`,
+  };
+});
+
+// ── Supabase mock ────────────────────────────────────────────────────────────
+// Chainable builder: every filter returns itself, `.single()` resolves, and the
+// builder is thenable so `await supabase.from(t).select()...` works too.
+
+let results = {};
+
+function makeBuilder(table) {
+  let mode = 'select';
+  const resolve = () =>
+    results[`${table}.${mode}`] ?? results[table] ?? { data: null, error: null };
+  const builder = {
+    select: () => builder,
+    insert: () => {
+      mode = 'insert';
+      return builder;
+    },
+    update: () => {
+      mode = 'update';
+      return builder;
+    },
+    eq: () => builder,
+    is: () => builder,
+    gte: () => builder,
+    in: () => builder,
+    order: () => builder,
+    limit: () => builder,
+    single: () => Promise.resolve(resolve()),
+    then: (onFulfilled, onRejected) => Promise.resolve(resolve()).then(onFulfilled, onRejected),
+  };
+  return builder;
+}
+
+const mockGetUser = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: { getUser: (...args) => mockGetUser(...args) },
+    from: (table) => makeBuilder(table),
+  },
+}));
+
+import TimeclockPage from '@/app/worker/timeclock/page';
+
+// `.single()` with no matching row — the ordinary clocked-out case, not a fault.
+const NO_ROWS = { data: null, error: { code: 'PGRST116', message: 'no rows' } };
+
+const OPEN_ENTRY = {
+  id: 'entry-1',
+  job_id: null,
+  clock_in: new Date().toISOString(),
+  clock_out: null,
+  clock_in_location: null,
+  clock_out_location: null,
+};
+
+beforeEach(() => {
+  jest.spyOn(window, 'alert').mockImplementation(() => {});
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+  results = {
+    users: { data: { company_id: 'company-1' }, error: null },
+    time_entries: NO_ROWS,
+    breaks: NO_ROWS,
+    job_assignments: { data: [], error: null },
+    jobs: { data: [], error: null },
+  };
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('worker timeclock — load states', () => {
+  it('renders CLOCK IN once the clock state resolves', async () => {
+    render(<TimeclockPage />);
+
+    expect(await screen.findByRole('button', { name: /clock in/i })).toBeInTheDocument();
+  });
+
+  it('shows an error with a retry instead of spinning forever when the profile lookup fails', async () => {
+    // The regression: setLoading(false) used to live only on the happy path, so
+    // this left a bare spinner — no error, no button, no way out.
+    results.users = { data: null, error: { code: '500', message: 'boom' } };
+
+    render(<TimeclockPage />);
+
+    expect(await screen.findByText(/couldn't load your timeclock/i)).toBeInTheDocument();
+    // Supabase rejects with a plain object; the underlying message has to make
+    // it to the screen, not "[object Object]".
+    expect(screen.getByText('boom')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clock (in|out)/i })).not.toBeInTheDocument();
+  });
+
+  it('recovers when the retry succeeds', async () => {
+    results.users = { data: null, error: { code: '500', message: 'boom' } };
+
+    render(<TimeclockPage />);
+    const retry = await screen.findByRole('button', { name: /try again/i });
+
+    results.users = { data: { company_id: 'company-1' }, error: null };
+    fireEvent.click(retry);
+
+    expect(await screen.findByRole('button', { name: /clock in/i })).toBeInTheDocument();
+  });
+
+  it('does not report clocked-out when the time-entry query fails', async () => {
+    // Rendering CLOCK IN here is the dangerous wrong answer: the worker taps it
+    // and opens a second concurrent entry.
+    results.time_entries = { data: null, error: { code: '500', message: 'boom' } };
+
+    render(<TimeclockPage />);
+
+    expect(await screen.findByText(/couldn't load your timeclock/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clock (in|out)/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('worker timeclock — which action button renders', () => {
+  it('renders CLOCK OUT when an entry is open', async () => {
+    results.time_entries = { data: OPEN_ENTRY, error: null };
+
+    render(<TimeclockPage />);
+
+    expect(await screen.findByRole('button', { name: /clock out/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clock in/i })).not.toBeInTheDocument();
+  });
+
+  it('renders END BREAK — and NEITHER clock button — while on a break', async () => {
+    // The third state. TC-WORK-04 has to clear the break before it can clock
+    // out, and a reset that only knows clocked-in/clocked-out wedges here.
+    results.time_entries = { data: OPEN_ENTRY, error: null };
+    results.breaks = {
+      data: { id: 'break-1', time_entry_id: 'entry-1', break_type: 'meal', break_start: new Date().toISOString() },
+      error: null,
+    };
+
+    render(<TimeclockPage />);
+
+    expect(await screen.findByRole('button', { name: /end break/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clock (in|out)/i })).not.toBeInTheDocument();
+  });
+
+  it('surfaces a failed clock-in instead of silently doing nothing', async () => {
+    results['time_entries.insert'] = { data: null, error: { code: '500', message: 'insert denied' } };
+
+    render(<TimeclockPage />);
+    fireEvent.click(await screen.findByRole('button', { name: /clock in/i }));
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('insert denied'));
+    });
+    // Still clocked out, and now the worker knows why.
+    expect(screen.getByRole('button', { name: /clock in/i })).toBeInTheDocument();
+  });
+});

--- a/src/app/worker/timeclock/page.tsx
+++ b/src/app/worker/timeclock/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useTranslations } from 'next-intl'
 
@@ -36,6 +36,7 @@ export default function TimeclockPage() {
   const [currentEntry, setCurrentEntry] = useState<TimeEntry | null>(null)
   const [activeBreak, setActiveBreak] = useState<ActiveBreak | null>(null)
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [actionLoading, setActionLoading] = useState(false)
   const [currentTime, setCurrentTime] = useState(new Date())
   const [location, setLocation] = useState<{ lat: number; lng: number } | null>(null)
@@ -66,27 +67,55 @@ export default function TimeclockPage() {
     }
   }, [])
 
-  useEffect(() => {
-    const init = async () => {
-      const { data: { user } } = await supabase.auth.getUser()
-      if (!user) return
+  // Every exit from this has to clear `loading` — the page renders nothing but
+  // a spinner while it is set, and no clock button exists in that state. When
+  // only the happy path cleared it, a worker whose session or profile lookup
+  // hiccuped was left on a spinner forever, with no error and no way to retry.
+  const init = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const { data: { user }, error: authError } = await supabase.auth.getUser()
+      if (authError) throw authError
+      if (!user) throw new Error('Not signed in')
 
       setUserId(user.id)
 
-      const { data: userData } = await supabase
+      const { data: userData, error: userError } = await supabase
         .from('users')
         .select('company_id')
         .eq('id', user.id)
         .single()
 
-      if (userData) {
-        setCompanyId(userData.company_id)
-        fetchCurrentEntry(user.id)
-        fetchTodaysJobs(user.id, userData.company_id)
-      }
+      if (userError) throw userError
+      if (!userData) throw new Error('No worker profile found for this account')
+
+      setCompanyId(userData.company_id)
+
+      // Clock state decides which button renders, so it must resolve before the
+      // spinner clears. Today's jobs only fill a dropdown — load them in the
+      // background instead of holding the whole page behind them.
+      await fetchCurrentEntry(user.id)
+      void fetchTodaysJobs(user.id, userData.company_id)
+    } catch (err) {
+      console.error('Error initializing timeclock:', err)
+      // Supabase rejects with a plain `{ code, message }`, not an Error, so
+      // String(err) here would put "[object Object]" on screen.
+      const message =
+        err instanceof Error
+          ? err.message
+          : typeof err === 'object' && err !== null && 'message' in err
+            ? String((err as { message: unknown }).message)
+            : String(err)
+      setLoadError(message)
+    } finally {
+      setLoading(false)
     }
-    init()
   }, [])
+
+  useEffect(() => {
+    void init()
+  }, [init])
 
   // Today's jobs assigned to this worker, so clocked time attaches to a real
   // job + customer instead of being orphaned ("Unknown Customer" / "No job").
@@ -121,49 +150,48 @@ export default function TimeclockPage() {
     }
   }
 
+  // Throws on a real failure so init() can show an error instead of guessing.
+  // Reporting "clocked out" when the query actually failed is the dangerous
+  // wrong answer: the worker clocks in again and opens a second entry.
   const fetchCurrentEntry = async (uId: string) => {
-    try {
-      // Get today's open time entry (no clock_out)
-      const today = new Date().toISOString().split('T')[0]
+    // Today's open time entry (no clock_out). PGRST116 is .single()'s "no rows",
+    // which is the ordinary clocked-out case rather than an error.
+    const today = new Date().toISOString().split('T')[0]
 
-      const { data: entry, error: entryError } = await supabase
-        .from('time_entries')
-        .select('*')
-        .eq('user_id', uId)
-        .is('clock_out', null)
-        .gte('clock_in', today)
-        .order('clock_in', { ascending: false })
-        .limit(1)
-        .single()
+    const { data: entry, error: entryError } = await supabase
+      .from('time_entries')
+      .select('*')
+      .eq('user_id', uId)
+      .is('clock_out', null)
+      .gte('clock_in', today)
+      .order('clock_in', { ascending: false })
+      .limit(1)
+      .single()
 
-      if (entryError && entryError.code !== 'PGRST116') {
-        console.error('Error fetching time entry:', entryError.message)
-      }
+    if (entryError && entryError.code !== 'PGRST116') throw entryError
 
-      if (entry) {
-        setCurrentEntry(entry)
+    setCurrentEntry(entry || null)
 
-        // Check for active break
-        const { data: breakData, error: breakError } = await supabase
-          .from('breaks')
-          .select('*')
-          .eq('time_entry_id', entry.id)
-          .is('break_end', null)
-          .single()
-
-        if (breakError && breakError.code !== 'PGRST116') {
-          console.error('Error fetching active break:', breakError.message)
-        }
-
-        if (breakData) {
-          setActiveBreak(breakData)
-        }
-      }
-    } catch (err) {
-      console.error('Error initializing timeclock:', err)
+    if (!entry) {
+      setActiveBreak(null)
+      return
     }
 
-    setLoading(false)
+    // The break lookup stays best-effort: unlike the entry above it only drives
+    // a label and the break buttons, and clockOut() clears breaks regardless —
+    // not worth blocking the page (and the clock-out it offers) over.
+    const { data: breakData, error: breakError } = await supabase
+      .from('breaks')
+      .select('*')
+      .eq('time_entry_id', entry.id)
+      .is('break_end', null)
+      .single()
+
+    if (breakError && breakError.code !== 'PGRST116') {
+      console.error('Error fetching active break:', breakError.message)
+    }
+
+    setActiveBreak(breakData || null)
   }
 
   const clockIn = async () => {
@@ -182,7 +210,16 @@ export default function TimeclockPage() {
       .select()
       .single()
 
-    if (!error && data) {
+    if (error) {
+      // Silently ignoring this left the button reading CLOCK IN with no entry
+      // created and nothing said — the worker taps again and again, and the
+      // shift never starts. Match clockOut()/startBreak() and say so.
+      alert(t('clockInFailed') + error.message)
+      setActionLoading(false)
+      return
+    }
+
+    if (data) {
       setCurrentEntry(data)
     }
     setActionLoading(false)
@@ -299,6 +336,23 @@ export default function TimeclockPage() {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="max-w-md mx-auto">
+        <div className="bg-red-50 border-2 border-red-300 rounded-2xl p-6 text-center">
+          <p className="text-lg font-semibold text-red-800 mb-2">{t('loadFailed')}</p>
+          <p className="text-sm text-red-700 mb-4 break-words">{loadError}</p>
+          <button
+            onClick={() => void init()}
+            className="w-full py-4 bg-red-600 text-white text-lg font-bold rounded-xl hover:bg-red-700 transition-colors"
+          >
+            {t('tryAgain')}
+          </button>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
TC-WORK-04 has failed every run since it started running. It only began running at all when the `E2E_WORKER_*` secrets landed — before that the whole worker `describe` was `pending` — so it has never once passed in CI.

#701 widened the wait 25s → 40s and warmed the `/worker` routes. The run on `fdacedf` still failed all three attempts:

```
AssertionError: Timed out retrying after 40000ms:
Expected to find content: '/clock (in|out)/i' within the selector: 'button' but never did.
```

TC-WORK-01 loaded the same page in 2.5s immediately before. The button is not slow — it is never mounted. Two causes produce exactly that, and no timeout fixes either.

## 1. The timeclock could wedge on the spinner forever

`setLoading(false)` lived only at the tail of `fetchCurrentEntry()`, which `init()` called only after a successful `users` lookup. No session, or a failed profile query, returned early with `loading` still `true` — and that state renders nothing but a spinner. No error, no retry, no button. A worker who hit one transient error could not clock in until they guessed to reload.

`init()` now owns the whole sequence in try/catch/**finally**, clears `loading` on every exit, and renders the failure with a Try Again that re-runs it. A failed *time-entry* lookup is treated as fatal rather than reported as "clocked out" — the wrong answer there opens a second concurrent entry.

## 2. There are three action states, not two

Clocked in **and on break** renders END BREAK *instead of* either clock button, so `/clock (in|out)/i` can never match. A reset that only knows clocked-in/clocked-out wedges permanently on an account left mid-break — and this account is shared with manual sandbox smoke-testing.

`resetToClockedOut()` now waits for any of the three real labels, then walks whichever it finds back to clocked out. Keeps #702's 40s cold-start budget on that gate.

## 3. `clockIn()` swallowed its insert error

`if (!error && data)` — the pattern CLAUDE.md warns about. The button stayed reading CLOCK IN with no entry created and nothing said: a worker-facing dead end, and a source of intermittent TC-WORK-04 failures. It now alerts like `clockOut()`/`startBreak()`, and the spec asserts no alert fired, so a DB error names itself instead of surfacing as a 20s timeout on the wrong line.

## Support

- **7 jest cases** (`src/__tests__/components/worker-timeclock.test.jsx`) covering stuck-load, retry recovery, failed entry lookup, all three button states, and the silent clock-in failure. They assert against the real `messages/en/worker.json` strings, so a label change breaks in jest before it breaks a sandbox run.
- **`e2e.yml` uploads Cypress screenshots on failure** (both jobs). They were being discarded, which is why the first two debugging rounds could only guess between these two causes — an authenticated failure cannot be reproduced from the checkout, because it tests a deployed environment.

## Verification

Run locally on the rebased branch:

- `npm run lint` — 0 errors (19 pre-existing warnings, none in changed files)
- `npm test` — 52 suites, 791 passed (was 784)
- `npm run build` — compiled successfully

The Cypress specs themselves could not be run here: the Cypress binary download is blocked in this environment (`ECONNRESET`), so install used `CYPRESS_INSTALL_BINARY=0`. The spec parses under `node --check` and its state logic is covered indirectly by the jest cases above, but the authenticated sandbox run is the real proof.

Targets `sandbox` per CLAUDE.md. Merging here updates #701 (`sandbox -> main`) in place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArpLXymhsLd4hHv9huxrb7)_