### PR TITLE
feat(growth): exclude test accounts from every funnel number

### DIFF
--- a/database/migrations/053_companies_is_test.sql
+++ b/database/migrations/053_companies_is_test.sql
@@ -1,0 +1,30 @@
+-- 053: Mark test accounts so they stop counting as customers.
+--
+-- Every funnel number the platform reports — the admin dashboard's conversion
+-- rate, and the growth_metrics_daily snapshot the growth agent planner reads —
+-- counted every row in `companies`. With no real customers yet, that meant the
+-- planner's first run reasoned over 4 trials and 3 paying accounts that were all
+-- created by hand for testing, and proposed a week of work to improve a funnel
+-- that does not exist.
+--
+-- A flag rather than deleting the rows: the test accounts are still needed for
+-- testing. A flag rather than matching on email patterns: a heuristic that
+-- silently reclassifies a real signup whose address happens to look like a test
+-- address is worse than an explicit column.
+--
+-- Default false so a real signup is counted unless someone deliberately excludes
+-- it. The failure mode of the opposite default is invisible: real customers
+-- quietly missing from every metric.
+
+ALTER TABLE companies
+  ADD COLUMN IF NOT EXISTS is_test BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN companies.is_test IS
+  'True for accounts created for testing or demos. Excluded from growth metrics, '
+  'the admin funnel, and the growth agent planner input. Never set this on a real customer.';
+
+-- Every metrics query filters on this, and all of them are "the not-test rows",
+-- so the partial index matches the actual access pattern rather than the column.
+CREATE INDEX IF NOT EXISTS idx_companies_real_accounts
+  ON companies (created_at)
+  WHERE is_test = FALSE;

--- a/src/__tests__/api/admin-stats-excludes-test-accounts.test.js
+++ b/src/__tests__/api/admin-stats-excludes-test-accounts.test.js
@@ -1,0 +1,41 @@
+/**
+ * Every companies query in the funnel-reporting routes must exclude test
+ * accounts.
+ *
+ * This is a source-level check rather than a behavioural one on purpose. The
+ * regression it guards against is someone adding a tenth `.from('companies')`
+ * query without the filter — which no behavioural test would catch, because
+ * the new query would work correctly in every respect except that it silently
+ * counts accounts nobody created for real.
+ *
+ * That failure already happened once. The growth agent planner's first run
+ * read a snapshot built from seven hand-made accounts, believed there were 4
+ * trials and 3 paying customers, and planned a week of work around a funnel
+ * that did not exist.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROUTES = [
+  'src/app/api/admin/stats/route.ts',
+  'src/app/api/growth/metrics/route.ts',
+];
+
+describe.each(ROUTES)('%s', (relativePath) => {
+  const source = fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+
+  it('filters every companies query on is_test', () => {
+    const queries = source.match(/\.from\('companies'\)/g) || [];
+    const filters = source.match(/\.eq\('is_test', false\)/g) || [];
+
+    expect(queries.length).toBeGreaterThan(0);
+    expect(filters.length).toBe(queries.length);
+  });
+
+  it('never filters to only test accounts', () => {
+    // `.eq('is_test', true)` in a reporting route would invert the meaning of
+    // every number on the page.
+    expect(source).not.toMatch(/\.eq\('is_test', true\)/);
+  });
+});

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -36,18 +36,20 @@ export async function GET(request: Request) {
       planDistributionResult,
     ] = await Promise.all([
       // Total companies
-      supabase.from('companies').select('*', { count: 'exact', head: true }),
+      supabase.from('companies').select('*', { count: 'exact', head: true }).eq('is_test', false),
 
       // Active companies (signed up in last 30 days or have stripe_customer_id)
       supabase
         .from('companies')
         .select('*', { count: 'exact', head: true })
+        .eq('is_test', false)
         .or(`stripe_customer_id.not.is.null,created_at.gte.${thirtyDaysAgo}`),
 
       // Trial companies (no stripe_customer_id, trial not expired)
       supabase
         .from('companies')
         .select('*', { count: 'exact', head: true })
+        .eq('is_test', false)
         .is('stripe_customer_id', null)
         .gte('trial_ends_at', now.toISOString()),
 
@@ -55,18 +57,21 @@ export async function GET(request: Request) {
       supabase
         .from('companies')
         .select('*', { count: 'exact', head: true })
+        .eq('is_test', false)
         .not('stripe_customer_id', 'is', null),
 
       // New signups this month
       supabase
         .from('companies')
         .select('*', { count: 'exact', head: true })
+        .eq('is_test', false)
         .gte('created_at', startOfMonth),
 
       // New signups last month
       supabase
         .from('companies')
         .select('*', { count: 'exact', head: true })
+        .eq('is_test', false)
         .gte('created_at', startOfLastMonth)
         .lte('created_at', endOfLastMonth),
 
@@ -77,6 +82,7 @@ export async function GET(request: Request) {
       supabase
         .from('companies')
         .select('id, name, email, plan, stripe_customer_id, trial_starts_at, trial_ends_at, created_at, industry')
+        .eq('is_test', false)
         .order('created_at', { ascending: false })
         .limit(10),
 
@@ -84,6 +90,7 @@ export async function GET(request: Request) {
       supabase
         .from('companies')
         .select('id, name, email, trial_ends_at, created_at')
+        .eq('is_test', false)
         .is('stripe_customer_id', null)
         .gte('trial_ends_at', now.toISOString())
         .lte('trial_ends_at', sevenDaysAgo.replace('-', '+')) // next 7 days
@@ -91,7 +98,7 @@ export async function GET(request: Request) {
         .limit(10),
 
       // Plan distribution
-      supabase.from('companies').select('plan'),
+      supabase.from('companies').select('plan').eq('is_test', false),
     ]);
 
     // Calculate plan distribution

--- a/src/app/api/growth/metrics/route.ts
+++ b/src/app/api/growth/metrics/route.ts
@@ -80,9 +80,15 @@ export async function GET(request: NextRequest) {
     // current scale this is far cheaper than eight separate count queries,
     // and it keeps the derived rates internally consistent (all computed
     // from the same read rather than from eight racing ones).
+    // Test accounts are excluded, not counted. This snapshot is the growth
+    // agent planner's entire view of the funnel — counting hand-made accounts
+    // told it there were paying customers to optimise for, and it planned a
+    // week of work accordingly. A planner reasoning over invented numbers is
+    // worse than one reasoning over honest zeroes.
     const { data: companies, error: companiesError } = await supabase
       .from('companies')
-      .select('id, plan, subscription_status, onboarding_completed, trial_starts_at, created_at');
+      .select('id, plan, subscription_status, onboarding_completed, trial_starts_at, created_at')
+      .eq('is_test', false);
 
     if (companiesError) {
       console.error('[Growth Metrics] Companies read failed:', companiesError.message);
@@ -178,9 +184,14 @@ async function linkConvertedLeads(
 
   if (recentIds.length === 0) return 0;
 
+  // Redundant today — recentIds comes from an already-filtered list — but this
+  // marks leads as 'converted', so a test account slipping through would
+  // permanently overstate lead conversion. Cheap to make the invariant local
+  // rather than dependent on what the caller happened to pass.
   const { data: recent, error } = await supabase
     .from('companies')
     .select('id, email, created_at')
+    .eq('is_test', false)
     .in('id', recentIds);
 
   if (error || !recent?.length) {


### PR DESCRIPTION
The growth agent planner's first run read a snapshot saying 4 trials and 3 paying accounts, and proposed a week of work to improve that funnel. All seven were accounts created by hand for testing. There are no customers yet.

Nothing distinguished them: every companies query counted every row. So the admin dashboard reported a conversion rate derived entirely from self-made accounts, and growth_metrics_daily fed the same fiction to the planner — which compounds, because growth_experiments becomes the history the planner reads in later weeks.

Add companies.is_test (default false) and filter on it in all eleven queries across the admin stats and growth metrics routes. Default false because the opposite default fails invisibly: a real customer silently missing from every metric is far worse than a test account needing one flag set.

A flag rather than deleting the rows, since the accounts are still needed for testing. A flag rather than matching email patterns, since a heuristic that reclassifies a real signup whose address happens to look like a test address would be both wrong and hard to notice.

The filter-coverage test is source-level by design. The regression to fear is a future companies query added without the filter, which behaves correctly in every respect except that it quietly counts fictional customers — no behavioural test would catch that.


Claude-Session: https://claude.ai/code/session_014SFnf6LWkmy56FgGHnh1g6