### PR TITLE
fix(worker): render an error instead of a blank page when the worker auth check fails

### DIFF
--- a/cypress/e2e/worker-flows.cy.js
+++ b/cypress/e2e/worker-flows.cy.js
@@ -47,12 +47,32 @@ const CLOCK_OUT = /clock out/i;
 const END_BREAK = /end break/i;
 const ANY_ACTION = /clock in|clock out|end break/i;
 
-function resetToClockedOut() {
+// `cy.contains` reports only what it could NOT find, which sent three separate
+// debugging rounds chasing the wrong cause. Assert the same thing by hand so
+// the failure prints what WAS on screen — every button label plus the page's
+// own text. The screenshot artifact says the same, but the log is readable
+// without downloading anything and outlives artifact retention.
+function waitForActionButton() {
   // 40s, not the usual 20: the /worker routes are warmed by e2e.yml but the
-  // sandbox can still be cold here, and this gate covers auth + the users row +
-  // the open time_entry lookup before any button mounts.
-  cy.contains('button', ANY_ACTION, { timeout: 40000 })
-    .should('be.visible')
+  // sandbox can still be cold here, and this gate covers the layout's auth
+  // check plus the page's own time_entry lookup before any button mounts.
+  cy.get('body', { timeout: 40000 }).should(($body) => {
+    const labels = [...$body.find('button')]
+      .map((el) => (el.innerText || '').replace(/\s+/g, ' ').trim())
+      .filter(Boolean);
+    const pageText = $body.text().replace(/\s+/g, ' ').trim().slice(0, 500);
+    expect(
+      labels.join(' | '),
+      `no CLOCK IN / CLOCK OUT / END BREAK button on /worker/timeclock. `
+        + `Buttons present: [${labels.join(' | ') || 'none'}]. Page text: "${pageText || '(empty)'}"`
+    ).to.match(ANY_ACTION);
+  });
+}
+
+function resetToClockedOut() {
+  waitForActionButton();
+
+  cy.contains('button', ANY_ACTION)
     .invoke('text')
     .then((label) => {
       if (END_BREAK.test(label)) {

--- a/messages/en/worker.json
+++ b/messages/en/worker.json
@@ -6,7 +6,9 @@
       "route": "Route",
       "hours": "Hours",
       "profile": "Profile",
-      "signOut": "Sign Out"
+      "signOut": "Sign Out",
+      "loadFailed": "Couldn't load your account",
+      "tryAgain": "Try Again"
     },
     "home": {
       "title": "Today's Jobs",

--- a/messages/es/worker.json
+++ b/messages/es/worker.json
@@ -6,7 +6,9 @@
       "route": "Ruta",
       "hours": "Horas",
       "profile": "Perfil",
-      "signOut": "Cerrar sesión"
+      "signOut": "Cerrar sesión",
+      "loadFailed": "No se pudo cargar tu cuenta",
+      "tryAgain": "Reintentar"
     },
     "home": {
       "title": "Trabajos de hoy",

--- a/src/__tests__/components/worker-layout.test.jsx
+++ b/src/__tests__/components/worker-layout.test.jsx
@@ -1,0 +1,141 @@
+/**
+ * Worker layout — the blank-page failure mode.
+ *
+ * The layout gates every /worker page. When its own auth check failed it fell
+ * through to `if (!user) return null`, rendering an empty document: no
+ * children, no error, no retry. That is invisible to a smoke test — an empty
+ * body is still "visible", and body text with nothing in it contains no
+ * 24-hour times — so TC-WORK-01 and TC-WORK-02 passed while the app was
+ * blank, and only TC-WORK-04 (which needs a real button) caught it.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('next-intl', () => {
+  const messages = require('../../../messages/en/worker.json');
+  return {
+    useTranslations: (namespace) => (key) =>
+      `${namespace}.${key}`
+        .split('.')
+        .reduce((node, part) => (node == null ? node : node[part]), messages) ?? `${namespace}.${key}`,
+  };
+});
+
+const mockPush = jest.fn();
+let pathname = '/worker/timeclock';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => pathname,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+let usersResult = {};
+const mockGetUser = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: (...args) => mockGetUser(...args),
+      signOut: jest.fn().mockResolvedValue({ error: null }),
+    },
+    from: () => {
+      const builder = {
+        select: () => builder,
+        eq: () => builder,
+        single: () => Promise.resolve(usersResult),
+      };
+      return builder;
+    },
+  },
+}));
+
+// Children of the layout, not the subject — stub them out.
+jest.mock('@/components/auth/SessionTimeoutWarning', () => () => null);
+jest.mock('@/hooks/useSessionTimeout', () => ({
+  useSessionTimeout: () => ({ showWarning: false, secondsRemaining: 0, resetTimeout: jest.fn() }),
+}));
+jest.mock('@/contexts/WorkerAuthContext', () => ({
+  WorkerAuthProvider: ({ children }) => <>{children}</>,
+}));
+jest.mock('@/components/worker/OfflineIndicator', () => ({
+  OfflineIndicator: () => null,
+  OfflineStatusDot: () => null,
+}));
+jest.mock('@/components/LanguageSwitcher', () => () => null);
+
+import WorkerLayout from '@/app/worker/layout';
+
+const WORKER = {
+  id: 'user-1',
+  full_name: 'Sam Worker',
+  email: 'sam@example.com',
+  role: 'worker',
+  company_id: 'company-1',
+  company: { name: 'Iguana Landscaping' },
+};
+
+beforeEach(() => {
+  pathname = '/worker/timeclock';
+  mockPush.mockClear();
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+  usersResult = { data: WORKER, error: null };
+});
+
+it('renders its children for a signed-in worker', async () => {
+  render(<WorkerLayout><p>timeclock goes here</p></WorkerLayout>);
+
+  expect(await screen.findByText('timeclock goes here')).toBeInTheDocument();
+});
+
+it('shows an error with a retry — not a blank page — when the profile lookup fails', async () => {
+  // The join to `companies` carries its own RLS, so this fails for a worker who
+  // can read their own users row perfectly well.
+  usersResult = { data: null, error: { code: '42501', message: 'permission denied for table companies' } };
+
+  render(<WorkerLayout><p>timeclock goes here</p></WorkerLayout>);
+
+  expect(await screen.findByText(/couldn't load your account/i)).toBeInTheDocument();
+  expect(screen.getByText(/permission denied for table companies/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+});
+
+it('shows an error rather than a blank page when the profile row is missing', async () => {
+  usersResult = { data: null, error: null };
+
+  render(<WorkerLayout><p>timeclock goes here</p></WorkerLayout>);
+
+  expect(await screen.findByText(/couldn't load your account/i)).toBeInTheDocument();
+  expect(screen.queryByText('timeclock goes here')).not.toBeInTheDocument();
+});
+
+it('recovers when the retry succeeds', async () => {
+  usersResult = { data: null, error: { code: '42501', message: 'permission denied' } };
+
+  render(<WorkerLayout><p>timeclock goes here</p></WorkerLayout>);
+  const retry = await screen.findByRole('button', { name: /try again/i });
+
+  usersResult = { data: WORKER, error: null };
+  fireEvent.click(retry);
+
+  expect(await screen.findByText('timeclock goes here')).toBeInTheDocument();
+});
+
+it('still redirects to the login page when there is no session', async () => {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+  render(<WorkerLayout><p>timeclock goes here</p></WorkerLayout>);
+
+  await screen.findByText((_, el) => el?.tagName === 'BODY');
+  expect(mockPush).toHaveBeenCalledWith('/worker/login');
+  expect(screen.queryByText(/couldn't load your account/i)).not.toBeInTheDocument();
+});
+
+it('renders the login page itself without the auth gate', async () => {
+  pathname = '/worker/login/';
+
+  render(<WorkerLayout><p>login form</p></WorkerLayout>);
+
+  expect(await screen.findByText('login form')).toBeInTheDocument();
+});

--- a/src/app/worker/layout.tsx
+++ b/src/app/worker/layout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 import Link from 'next/link'
@@ -24,35 +24,58 @@ interface WorkerUser {
 export default function WorkerLayout({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<WorkerUser | null>(null)
   const [loading, setLoading] = useState(true)
+  const [authError, setAuthError] = useState<string | null>(null)
   const pathname = usePathname()
   const router = useRouter()
   const t = useTranslations('worker.layout')
 
-  useEffect(() => {
-    const checkAuth = async () => {
-      const { data: { user: authUser } } = await supabase.auth.getUser()
+  // A failure here used to fall through to `if (!user) return null` below, which
+  // renders a BLANK PAGE: no children, no error, no way back. The worker taps
+  // the app and gets white. Every failure now lands on an error with a retry,
+  // and only the redirect-to-login path leaves `user` unset.
+  const checkAuth = useCallback(async () => {
+    setLoading(true)
+    setAuthError(null)
+    try {
+      const { data: { user: authUser }, error: authErr } = await supabase.auth.getUser()
+      if (authErr) throw authErr
 
       if (!authUser) {
         if (pathname !== '/worker/login' && pathname !== '/worker/login/') {
           router.push('/worker/login')
         }
-        setLoading(false)
         return
       }
 
-      const { data: userData } = await supabase
+      // Note the join: `companies` has its own RLS, so this can fail for a
+      // worker who can read their own users row perfectly well.
+      const { data: userData, error: userErr } = await supabase
         .from('users')
         .select('*, company:companies(name)')
         .eq('id', authUser.id)
         .single()
 
-      if (userData) {
-        setUser(userData)
-      }
+      if (userErr) throw userErr
+      if (!userData) throw new Error('No worker profile found for this account')
+
+      setUser(userData)
+    } catch (err) {
+      console.error('Worker auth check failed:', err)
+      // Supabase rejects with a plain `{ code, message }`, not an Error.
+      const message =
+        err instanceof Error
+          ? err.message
+          : typeof err === 'object' && err !== null && 'message' in err
+            ? String((err as { message: unknown }).message)
+            : String(err)
+      setAuthError(message)
+    } finally {
       setLoading(false)
     }
+  }, [pathname, router])
 
-    checkAuth()
+  useEffect(() => {
+    void checkAuth()
 
     // Register service worker for offline support
     if ('serviceWorker' in navigator) {
@@ -62,7 +85,7 @@ export default function WorkerLayout({ children }: { children: React.ReactNode }
         console.warn('[SW] Registration failed:', err)
       })
     }
-  }, [pathname, router])
+  }, [checkAuth])
 
   const handleSignOut = async () => {
     localStorage.removeItem('tooltime_worker_session')
@@ -100,6 +123,24 @@ export default function WorkerLayout({ children }: { children: React.ReactNode }
     )
   }
 
+  if (authError) {
+    return (
+      <div className="min-h-screen bg-gray-100 flex items-center justify-center p-4">
+        <div className="max-w-md w-full bg-red-50 border-2 border-red-300 rounded-2xl p-6 text-center">
+          <p className="text-lg font-semibold text-red-800 mb-2">{t('loadFailed')}</p>
+          <p className="text-sm text-red-700 mb-4 break-words">{authError}</p>
+          <button
+            onClick={() => void checkAuth()}
+            className="w-full py-4 bg-red-600 text-white text-lg font-bold rounded-xl hover:bg-red-700 transition-colors"
+          >
+            {t('tryAgain')}
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // Only reachable while the redirect to /worker/login is in flight.
   if (!user) {
     return null
   }


### PR DESCRIPTION
Follow-up to #703. TC-WORK-04 still failed on sandbox **with** that fix deployed — the deploy gate confirms the right build was serving (`deploy swapped: fdacedf0 -> bbe3fcad`) — and this time the assertion covered all three labels:

```
Expected to find content: '/clock in|clock out|end break/i'
within the selector: 'button' but never did.
```

Not CLOCK IN, not CLOCK OUT, not END BREAK. No action button of any kind. That rules out the on-break state and points *above* the page: the layout never rendered it.

## The bug

`src/app/worker/layout.tsx` gates every `/worker` route, and its auth check had the same shape as the one #703 fixed in the timeclock page — with a worse ending. When `auth.getUser()` succeeded but the `users` lookup returned null or errored, `setUser()` was never called, `loading` went false, and control reached:

```tsx
if (!user) {
  return null
}
```

A **blank page**. No children, no error, no retry. The timeclock page never mounts, so its own load-error handling can't run.

Worth noting what the layout selects: `*, company:companies(name)`. The join carries `companies`' own RLS, so this fails for a worker who can read their own `users` row perfectly well — a missing grant on the sandbox worker account produces a permanent blank screen with no diagnostic anywhere.

`checkAuth()` now runs in try/catch/finally, surfaces the underlying message with a Try Again that re-runs it, and leaves `user` unset only while the redirect to `/worker/login` is in flight.

## Why this took four runs to find

The failure is invisible to the other worker specs:

| | Why it passed on a blank page |
|---|---|
| TC-WORK-01 | `cy.get('body').should('be.visible')` — an empty body is still visible |
| TC-WORK-02 | body text with nothing in it contains no 24-hour times — vacuously true, as its own comment concedes |
| TC-WORK-04 | needs a real button, so it's the only one that caught it |

## Diagnostics

- TC-WORK-04's settle gate no longer relies on `cy.contains`, which reports only what it could **not** find. It asserts by hand and prints every button label plus the page's own text, so the log names what was actually on screen. The screenshots this suite now uploads say the same, but the log needs no download and outlives artifact retention.
- 6 jest cases for the layout: children render, both blank-page paths, retry recovery, the login redirect, and the login route's own bypass.

## Verification

- `npm run lint` — 0 errors (19 pre-existing warnings, none in changed files)
- `npm test` — 53 suites, 797 passed (was 791)
- `npm run build` — compiled successfully

Cypress itself could not be run here: the binary download is blocked in this environment (`ECONNRESET`), so install used `CYPRESS_INSTALL_BINARY=0`. The spec parses under `node --check`; the sandbox run after merge is the real proof.

**If TC-WORK-04 still fails after this**, the new assertion message will print the buttons and page text, which should name the cause outright rather than requiring a fifth round of inference.

Targets `sandbox` per CLAUDE.md. Merging here updates #701 (`sandbox -> main`) in place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArpLXymhsLd4hHv9huxrb7)_