### PR TITLE
fix(worker): redirect signed-out workers instead of stranding them on an error

### DIFF
--- a/cypress/e2e/worker-flows.cy.js
+++ b/cypress/e2e/worker-flows.cy.js
@@ -24,8 +24,30 @@ function workerLogin() {
     cy.get('input[type="email"]').clear().type(worker.email);
     cy.get('input[type="password"]').clear().type(worker.password, { log: false });
     cy.get('form').find('button[type="submit"]').click();
-    // Successful worker login lands under /worker (redirects to /worker/timeclock).
-    cy.location('pathname', { timeout: 25000 }).should('include', '/worker');
+
+    // This assertion used to read `should('include', '/worker')` — which
+    // '/worker/login' ITSELF satisfies. It passed the instant it ran, whether or
+    // not the login worked, so cy.session cached a signed-out session and every
+    // spec below ran unauthenticated. The app then had no session to read and
+    // TC-WORK-04 saw no timeclock, for four CI rounds, while the login failure
+    // that caused it was never reported.
+    //
+    // So assert we actually LEFT the login page, and say why when we did not —
+    // same shape as cy.login() in cypress/support/commands.js.
+    cy.get('body', { timeout: 45000 }).should(($body) => {
+      const { pathname } = $body[0].ownerDocument.location;
+      if (!pathname.includes('/worker/login')) return;
+
+      const alert = $body.find('.bg-red-50, [role="alert"]').first().text().trim();
+      throw new Error(
+        `Worker login did not leave /worker/login (still at ${pathname}).`
+        + (alert
+          ? ` The page is showing: "${alert}".`
+          : ' The page is showing no error, so the request is still in flight or timed out.')
+        + ' Check E2E_WORKER_EMAIL / E2E_WORKER_PASSWORD, and that the account is'
+        + ' confirmed and attached to a company (database/TEST_ACCOUNT_SETUP.md).'
+      );
+    });
   });
 }
 

--- a/src/__tests__/components/worker-layout.test.jsx
+++ b/src/__tests__/components/worker-layout.test.jsx
@@ -132,6 +132,24 @@ it('still redirects to the login page when there is no session', async () => {
   expect(screen.queryByText(/couldn't load your account/i)).not.toBeInTheDocument();
 });
 
+it('redirects — does not show an error — when Supabase reports the session as missing', async () => {
+  // Supabase returns BOTH a null user and an AuthSessionMissingError when there
+  // is no session. Treating that error as a fault stranded signed-out workers on
+  // an error card reading "Auth session missing!" instead of sending them to
+  // the login page, which is exactly what the sandbox run showed.
+  mockGetUser.mockResolvedValue({
+    data: { user: null },
+    error: { name: 'AuthSessionMissingError', message: 'Auth session missing!', status: 400 },
+  });
+
+  render(<WorkerLayout><p>timeclock goes here</p></WorkerLayout>);
+
+  await screen.findByText((_, el) => el?.tagName === 'BODY');
+  expect(mockPush).toHaveBeenCalledWith('/worker/login');
+  expect(screen.queryByText(/couldn't load your account/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/auth session missing/i)).not.toBeInTheDocument();
+});
+
 it('renders the login page itself without the auth gate', async () => {
   pathname = '/worker/login/';
 

--- a/src/app/worker/layout.tsx
+++ b/src/app/worker/layout.tsx
@@ -38,14 +38,19 @@ export default function WorkerLayout({ children }: { children: React.ReactNode }
     setAuthError(null)
     try {
       const { data: { user: authUser }, error: authErr } = await supabase.auth.getUser()
-      if (authErr) throw authErr
 
+      // Check the user BEFORE the error. Having no session is not a failure —
+      // it is the logged-out case, and it has to redirect. Supabase reports it
+      // as an error ("Auth session missing!"), so throwing on `authErr` first
+      // parks a signed-out worker on an error card instead of the login page.
       if (!authUser) {
         if (pathname !== '/worker/login' && pathname !== '/worker/login/') {
           router.push('/worker/login')
         }
         return
       }
+
+      if (authErr) throw authErr
 
       // Note the join: `companies` has its own RLS, so this can fail for a
       // worker who can read their own users row perfectly well.

--- a/src/app/worker/timeclock/page.tsx
+++ b/src/app/worker/timeclock/page.tsx
@@ -76,8 +76,14 @@ export default function TimeclockPage() {
     setLoadError(null)
     try {
       const { data: { user }, error: authError } = await supabase.auth.getUser()
+
+      // No session is the logged-out case, not a fault: the layout above owns
+      // the redirect to /worker/login, so bail quietly rather than flashing an
+      // error card on the way out. Check the user before the error — Supabase
+      // reports a missing session as one.
+      if (!user) return
+
       if (authError) throw authError
-      if (!user) throw new Error('Not signed in')
 
       setUserId(user.id)
 


### PR DESCRIPTION
The screenshot-free diagnostic added in #705 did its job. TC-WORK-04's failure now reads:

```
no CLOCK IN / CLOCK OUT / END BREAK button on /worker/timeclock.
Buttons present: [Try Again].
Page text: "Couldn't load your account  Auth session missing!  Try Again"
```

Two separate bugs, one of them mine.

## 1. Signed-out workers get an error card instead of the login page

`supabase.auth.getUser()` reports "no session" as an **error** (`AuthSessionMissingError`) alongside a null user. #705 checked `if (authErr) throw authErr` *before* checking the user, so the ordinary logged-out case — which must redirect to `/worker/login` — landed on the error card instead. The redirect existed before and I broke it.

The user check now comes first in both the layout and the timeclock page, with a test pinning the `AuthSessionMissingError` shape specifically so it can't regress again.

## 2. The worker login helper could not fail — which is why this took five rounds

`workerLogin()` asserted this after submitting the form:

```js
cy.location('pathname', { timeout: 25000 }).should('include', '/worker');
```

**`/worker/login` contains `/worker`.** The assertion passed the instant it ran, on the login page, whether or not the login succeeded. So `cy.session` cached a signed-out session, and every worker spec has been running unauthenticated against an app with no session to read.

That is the actual root cause of all four earlier rounds. TC-WORK-04 kept reporting a missing button; the login failure behind it was never reported, because nothing ever checked. TC-WORK-01 and TC-WORK-02 couldn't catch it either — an empty body is still "visible", and empty text contains no 24-hour times.

It now asserts the browser actually **left** `/worker/login`, and when it hasn't, reports the on-page error text and points at the credentials and `database/TEST_ACCOUNT_SETUP.md` — the same shape as `cy.login()` in `cypress/support/commands.js`.

## What to expect next

Fixing #2 means the next failure, if there is one, names the real problem: **why that worker account cannot log in.** That may well be the `E2E_WORKER_EMAIL`/`E2E_WORKER_PASSWORD` secrets or the account itself (unconfirmed, or not attached to a company) rather than anything in the code — and this spec will now say so directly instead of failing 40 seconds later in a different place.

## Verification

- `npm run lint` — 0 errors (19 pre-existing warnings, none in changed files)
- `npm test` — 53 suites, 798 passed (was 797)
- `npm run build` — compiled successfully

Cypress itself can't run here (binary download blocked, `ECONNRESET`); the spec parses under `node --check`.

Targets `sandbox` per CLAUDE.md. Merging here updates #701 (`sandbox -> main`) in place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArpLXymhsLd4hHv9huxrb7)_